### PR TITLE
Add Compose state hoisting skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@ Instructions for AI agents (Claude Code, etc.) working in this repo.
 ## When adding, renaming, or removing a skill
 
 1. **Update `README.md`** — keep the "Skills" list in sync. Each entry links to the skill's `SKILL.md` and summarises what it covers. If you add a skill and don't update the README, the change is incomplete.
-2. **Bump `version` in `.claude-plugin/plugin.json`** — semver. Patch for fixes/wording, minor for a new skill or new triggers, major for removals or breaking renames. Installed users won't see updates otherwise.
+2. **Do not update plugin or skill versions unless explicitly asked.** If the user asks for a release/version bump, use semver in `.claude-plugin/plugin.json`: patch for fixes/wording, minor for a new skill or new triggers, major for removals or breaking renames.
 
 ## Skill layout
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Or install as a Claude Code plugin:
 
 ### Start here
 
-- Working on Compose state or effects? Start with [`compose-state-authoring`](skills/compose-state-authoring/SKILL.md), [`compose-state-holder-ui-split`](skills/compose-state-holder-ui-split/SKILL.md), or [`compose-side-effects`](skills/compose-side-effects/SKILL.md).
+- Working on Compose state or effects? Start with [`compose-state-authoring`](skills/compose-state-authoring/SKILL.md), [`compose-state-hoisting`](skills/compose-state-hoisting/SKILL.md), [`compose-state-holder-ui-split`](skills/compose-state-holder-ui-split/SKILL.md), or [`compose-side-effects`](skills/compose-side-effects/SKILL.md).
 - Investigating recomposition, stability, or jank? Start with [`compose-recomposition-performance`](skills/compose-recomposition-performance/SKILL.md).
 - Reviewing Flow or coroutine architecture? Start with [`kotlin-flow-state-event-modeling`](skills/kotlin-flow-state-event-modeling/SKILL.md) or [`kotlin-coroutines-structured-concurrency`](skills/kotlin-coroutines-structured-concurrency/SKILL.md).
 
@@ -30,6 +30,7 @@ Or install as a Claude Code plugin:
 #### State and side effects
 
 - [`compose-state-authoring`](skills/compose-state-authoring/SKILL.md) — author Compose local mutable state and read-only composable accessors correctly.
+- [`compose-state-hoisting`](skills/compose-state-hoisting/SKILL.md) — decide whether Compose UI element state belongs in local remember state, hoisted parameters, a plain state holder class, or a screen-level state holder.
 - [`compose-state-holder-ui-split`](skills/compose-state-holder-ui-split/SKILL.md) — split Compose state-holder wiring from plain-state UI for previewable and testable screens.
 - [`compose-side-effects`](skills/compose-side-effects/SKILL.md) — choose and key Compose effect APIs for event Flow collection, callbacks, cleanup, navigation, snackbar, analytics, and other side effects.
 

--- a/skills/compose-state-hoisting/SKILL.md
+++ b/skills/compose-state-hoisting/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: compose-state-hoisting
+description: Use when deciding where Jetpack Compose UI element state or UI logic should live: local remember state, hoisted composable parameters, a plain state holder class, or a screen-level ViewModel/component.
+---
+
+# Compose state hoisting
+
+## Core principle
+
+Hoist state only as far as the logic needs it. Keep simple UI element state local, move shared UI element state to the lowest common composable owner, extract a plain state holder when UI-only behavior becomes a concept, and use a screen state holder when business logic or app data is involved.
+
+## Decision guide
+
+| Situation | Owner |
+|---|---|
+| One composable reads/writes simple state | Keep local with `remember` / `rememberSaveable` |
+| Sibling or parent composables need to read/write it | Hoist state and events to their lowest common composable ancestor |
+| Related UI element state plus UI logic is making a composable hard to read, preview, or test | Extract a plain state holder class remembered in composition |
+| Repository calls, persistence, business rules, or screen UI state production are involved | Use a screen-level state holder such as a `ViewModel` or component |
+
+UI element state includes things like expansion, sheet visibility, scroll position, focus, text field editing state, selection, and animation/interaction state. Screen UI state is app data prepared for display.
+
+If UI element state is an input to business logic, it may need to live in the screen state holder too. For example, text used to query repository-backed suggestions belongs with the state holder that produces those suggestions.
+
+## Plain state holder trigger
+
+Extract a plain state holder when several of these are true:
+
+- Multiple related `remember` values are coordinated by the same callbacks.
+- Scroll, focus, text, selection, or sheet state needs named operations such as `clear`, `submit`, `jumpToTop`, or `openFilters`.
+- Derived UI flags are scattered through the composable.
+- Child composables receive mechanics they do not conceptually own.
+- Previews or tests must drive a long sequence of UI details to check one behavior.
+- Helper functions need many state parameters just to keep the composable readable.
+
+Do not extract for one boolean, one text field, or trivial show/hide logic. Ceremony is not separation of concerns.
+
+## Pattern
+
+Use a plain class for UI element state and UI logic, plus a `remember...State` function for composition-owned objects:
+
+```kotlin
+@Stable
+class ProductSearchState(
+    query: String,
+    private val listState: LazyListState,
+    private val focusRequester: FocusRequester,
+) {
+    var query by mutableStateOf(query)
+        private set
+
+    var filtersOpen by mutableStateOf(false)
+        private set
+
+    val canClear: Boolean
+        get() = query.isNotEmpty()
+
+    fun updateQuery(value: String) {
+        query = value
+    }
+
+    fun clear() {
+        query = ""
+        focusRequester.requestFocus()
+    }
+
+    suspend fun jumpToTop() {
+        listState.animateScrollToItem(0)
+    }
+}
+
+@Composable
+fun rememberProductSearchState(
+    initialQuery: String = "",
+    listState: LazyListState = rememberLazyListState(),
+    focusRequester: FocusRequester = remember { FocusRequester() },
+): ProductSearchState {
+    return remember(listState, focusRequester) {
+        ProductSearchState(initialQuery, listState, focusRequester)
+    }
+}
+```
+
+The composable renders from the state holder and calls intent-style methods. If a parent needs to coordinate the same UI behavior, accept the state holder as a parameter with a default:
+
+```kotlin
+@Composable
+fun ProductSearchPanel(
+    state: ProductSearchState = rememberProductSearchState(),
+    modifier: Modifier = Modifier,
+) {
+    val scope = rememberCoroutineScope()
+
+    SearchField(
+        query = state.query,
+        onQueryChange = state::updateQuery,
+        onClear = state::clear,
+    )
+
+    JumpToTopButton(onClick = {
+        scope.launch { state.jumpToTop() }
+    })
+}
+```
+
+## Composition ownership
+
+Plain state holders created with `remember` follow the composable lifecycle. This makes them a good home for Compose UI objects such as `LazyListState`, `FocusRequester`, `PagerState`, `DrawerState`, and `TextFieldState`.
+
+Keep suspend UI operations that require a frame clock, such as scroll or drawer animations, in a composition-scoped coroutine (`rememberCoroutineScope`, `LaunchedEffect`, or another composition-owned scope). Do not move those calls to `viewModelScope`.
+
+## Saving state
+
+Use `rememberSaveable` or a custom `Saver` only for values that should survive Activity or process recreation, such as a query string, selected filter IDs, or a current tab key.
+
+Do not try to save runtime objects like `LazyListState`, `FocusRequester`, coroutine scopes, or callbacks directly. Save the minimal serializable values needed to rebuild behavior.
+
+## Common mistakes
+
+| Mistake | Fix |
+|---|---|
+| Hoisting every local state value to a parent "just in case" | Hoist to the lowest owner that actually reads or writes it |
+| Extracting a plain state holder for one boolean | Keep simple private UI state local |
+| Putting repository calls or product rules in a Compose state holder | Move that logic to a screen state holder such as a `ViewModel` or component |
+| Keeping text or selection local when it drives repository-backed screen state | Move that input to the screen state holder with the business logic |
+| Passing a state holder deep into unrelated children | Pass plain values and callbacks unless the child truly coordinates the holder's behavior |
+| Treating the holder as a dumping ground for a whole screen | Split by cohesive UI behavior, such as search input, sheet coordination, or list controls |
+| Calling animation suspend functions from `viewModelScope` | Use a composition-scoped coroutine |
+
+## Related
+
+- [`compose-state-authoring`](../compose-state-authoring/SKILL.md) — correct local `remember` and mutable state authoring.
+- [`compose-state-holder-ui-split`](../compose-state-holder-ui-split/SKILL.md) — split screen state-holder wiring from plain state-driven UI rendering.
+- [`compose-side-effects`](../compose-side-effects/SKILL.md) — choose effect APIs and composition-scoped coroutine boundaries.
+- [`compose-focus-navigation`](../compose-focus-navigation/SKILL.md) — focus state, requesters, and keyboard/D-pad behavior.

--- a/skills/compose-state-holder-ui-split/SKILL.md
+++ b/skills/compose-state-holder-ui-split/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: compose-state-holder-ui-split
-description: Use when writing or reviewing Jetpack Compose screens that mix state holders, state collection, navigation, effects, callbacks, and UI rendering in the same composable.
+description: Use when a Jetpack Compose screen-level composable takes a ViewModel/component/controller, collects state or effects, handles navigation/snackbars, or wires callbacks while also rendering layout.
 ---
 
 # Compose: state holder/UI split
@@ -95,6 +95,8 @@ private fun ProfileContent(
 
 The "no collection in UI composables" rule is about app/business state and side-effect streams. Plain UI composables can still own UI-local framework state: `rememberScrollState`, `rememberLazyListState`, `FocusRequester`, focus state, animation state, `TextFieldState`, `MutableInteractionSource.collectIsPressedAsState()`, and similar behavior that belongs to the rendered widget.
 
+If that UI-local state grows into coordinated behavior with multiple related fields and operations, use [`compose-state-hoisting`](../compose-state-hoisting/SKILL.md) to decide whether it should become a plain state holder class remembered in composition.
+
 ## What to pass
 
 Pass the smallest useful UI contract:
@@ -150,4 +152,5 @@ If effect handling grows, extract `ProfileEffects(component, snackbarHostState)`
 ## Related
 
 - [`compose-ui-testing-patterns`](../compose-ui-testing-patterns/SKILL.md) — testing plain state-driven UI composables without the full app graph.
+- [`compose-state-hoisting`](../compose-state-hoisting/SKILL.md) — deciding where UI element state and UI logic should live, including plain state holder classes.
 - [`kotlin-multiplatform-expect-actual`](../kotlin-multiplatform-expect-actual/SKILL.md) — platform services, native views, and expect/interface boundaries when shared UI meets platform-specific leaves.


### PR DESCRIPTION
## Summary
  - Add `compose-state-hoisting` to guide decisions between local `remember`, hoisted parameters, plain state holder classes, and screen-level state holders.
  - Link the new skill from the README and sharpen `compose-state-holder-ui-split` around screen-level wiring.
  - Update agent guidance so plugin/skill versions are only changed when explicitly requested.
  
  ## Test plan
  - Validated manifests with `jq . .claude-plugin/plugin.json` and `jq . .claude-plugin/marketplace.json`.
  - Verified skill routing with pressure scenarios for complex UI-only state, simple local state, and business/repository-backed state.