### PR TITLE
Add MutableInteractionSource guidance to compose-ui-testing-patterns skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Or install as a Claude Code plugin:
 
 #### Testing
 
-- [`compose-ui-testing-patterns`](skills/compose-ui-testing-patterns/SKILL.md) — choose between plain UI tests, semantics assertions, key/focus tests, screenshot tests, and integration tests.
+- [`compose-ui-testing-patterns`](skills/compose-ui-testing-patterns/SKILL.md) — choose between plain UI tests, semantics assertions, key/focus tests, interaction state tests with MutableInteractionSource, screenshot tests, and integration tests.
 
 ### Kotlin
 

--- a/skills/compose-ui-testing-patterns/SKILL.md
+++ b/skills/compose-ui-testing-patterns/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: compose-ui-testing-patterns
-description: Use when writing or reviewing Jetpack Compose UI tests, screenshot tests, previews, semantics assertions, fake image loading, keyboard input, focus assertions, or tests for plain state-driven UI composables.
+description: Use when writing or reviewing Jetpack Compose UI tests, screenshot tests, previews, semantics assertions, fake image loading, keyboard input, focus assertions, interaction state (hover/pressed/focused), or tests for plain state-driven UI composables.
 ---
 
 # Compose: UI testing patterns
@@ -18,6 +18,7 @@ Test the smallest UI contract that proves the behavior. Prefer plain state-drive
 | Focus navigation or keyboard behavior | Compose test with key input |
 | Visual layout, clipping, elevation, typography, image composition | Screenshot test |
 | State holder updates UI correctly | State holder/unit test plus one wiring smoke test |
+| Hover, pressed, focused, dragged interaction state | Plain UI test with MutableInteractionSource |
 | Navigation, lifecycle, DI integration | Integration test |
 
 ## Prefer plain UI tests
@@ -74,6 +75,45 @@ assertThat(selectedId).isEqualTo("movie-1")
 
 For plain captured callback values, a direct assertion after the action is usually enough. Use `runOnIdle` when the assertion needs Compose to finish applying snapshot state, recomposition, or queued UI work before reading the result.
 
+## Interaction state with MutableInteractionSource
+
+When a composable's appearance or behavior depends on interaction state (hover, focus, press, drag), inject a `MutableInteractionSource` and emit the desired state directly. Do not try to simulate pointer/mouse events to trigger interaction states — that approach is fragile, environment-dependent, and produces flaky tests.
+
+```kotlin
+val interactionSource = MutableInteractionSource()
+
+composeTestRule.setContent {
+    OutlinedButton(
+        onClick = {},
+        interactionSource = interactionSource,
+    )
+}
+
+// Assert default (un-hovered) state
+composeTestRule.onNodeWithText("OutlinedButton").assertIsDisplayed()
+
+// Emit hover — interactionSource.emit is a suspend function,
+// so call it from a test coroutine scope.
+TestScope().launch {
+    interactionSource.emit(HoverInteraction.Enter())
+}
+
+composeTestRule.waitForIdle()
+
+// Assert the visual/semantic change that hover produces
+// (e.g., border color, elevation, or capture for screenshot test)
+composeTestRule.onNodeWithText("OutlinedButton").assertIsDisplayed()
+```
+
+The same pattern works for `PressInteraction.Press` / `Release` / `Cancel`, `FocusInteraction.Focus` / `Unfocus`, and `DragInteraction.Start` / `Stop` / `Cancel`. Emit the entry interaction, `waitForIdle`, then assert the result.
+
+Key points:
+
+- **Always inject `MutableInteractionSource`** rather than relying on the default internal source. This gives you full control over state transitions.
+- **Emit interactions from a coroutine scope** (e.g. `TestScope().launch { }`) since `emit` is a suspend function. Do not use `LaunchedEffect` — that is a production Compose effect, not a test tool.
+- **Assert the *result* of the interaction** (visual change, semantic change, enabled state), not the interaction itself. The interaction source is a test *driver*, not the assertion target.
+- **Use this for screenshot tests too** — emit the interaction state, then capture the screenshot for a deterministic hover/press/focus visual.
+
 ## Keyboard and focus
 
 For keyboard, TV, and desktop UI, drive navigation with the same input model users use (keys/D-pad), not clicks alone. Assert focused semantics, not colors or scale; reserve screenshots for visual focus treatment.
@@ -123,6 +163,8 @@ When image appearance matters, provide a deterministic local painter/bitmap inst
 | Semantics test for padding/color/focus ring | Use screenshot test |
 | Test tags everywhere | Prefer text/content description/role when stable |
 | UI test depends on real image loading/network/time | Fake or freeze the source |
+| Simulating hover/press/focus with mouse or touch events | Inject `MutableInteractionSource` and emit the interaction |
+| Relying on the default `InteractionSource` in tests | Pass `MutableInteractionSource` so you can control state |
 | TV/keyboard UI tested with `performClick` only | Use key input and focus assertions; see [compose-focus-navigation](../compose-focus-navigation/SKILL.md) |
 
 ## Red flags during review
@@ -132,3 +174,5 @@ When image appearance matters, provide a deterministic local painter/bitmap inst
 - A screenshot has random dates, clocks, remote images, or live data.
 - Assertions only check that a node exists after performing an action, not that the callback/state change happened.
 - Focus behavior is visually inspected but not asserted.
+- A test uses `performMouseInput` or touch injection to trigger hover/press states instead of `MutableInteractionSource.emit`.
+- A composable accepts `interactionSource` but tests don't inject `MutableInteractionSource`.


### PR DESCRIPTION
## Summary

- Adds a new section on using `MutableInteractionSource` for testing interaction states (hover, press, focus, drag) in Jetpack Compose UI tests
- Recommends emitting interaction states directly via `MutableInteractionSource` rather than simulating pointer/mouse events, which is fragile and environment-dependent
- Includes code example with `TestScope().launch`, key points, and full interaction type coverage
- Updates test target choice table, common mistakes, red flags, frontmatter description, and README