### PR TITLE
Fix YAML frontmatter parse errors in two skills

### DIFF
--- a/skills/compose-animations/SKILL.md
+++ b/skills/compose-animations/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: compose-animations
-description: Use when writing or reviewing Jetpack Compose motion: visibility enter/exit, animating one property toward a target, color or size transitions, multiple properties from one state, switching composable content, or choosing between AnimatedVisibility, animate*AsState, rememberTransition, AnimatedContent, and Crossfade.
+description: "Use when writing or reviewing Jetpack Compose motion: visibility enter/exit, animating one property toward a target, color or size transitions, multiple properties from one state, switching composable content, or choosing between AnimatedVisibility, animate*AsState, rememberTransition, AnimatedContent, and Crossfade."
 ---
 
 # Compose: animations

--- a/skills/compose-state-hoisting/SKILL.md
+++ b/skills/compose-state-hoisting/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: compose-state-hoisting
-description: Use when deciding where Jetpack Compose UI element state or UI logic should live: local remember state, hoisted composable parameters, a plain state holder class, or a screen-level ViewModel/component.
+description: "Use when deciding where Jetpack Compose UI element state or UI logic should live: local remember state, hoisted composable parameters, a plain state holder class, or a screen-level ViewModel/component."
 ---
 
 # Compose state hoisting


### PR DESCRIPTION
## Summary

Two `SKILL.md` files have unquoted `description:` values that contain `: ` (colon + space) inside the prose. YAML parses those as nested mappings and fails:

```
Error in user YAML: (<unknown>): mapping values are not allowed in this context
```

As a result, `npx skills add chrisbanes/skills` silently skips these two skills — they never appear in the interactive picker:

- `skills/compose-animations/SKILL.md` — `"...Compose motion: visibility enter/exit..."` (line 2 col 66)
- `skills/compose-state-hoisting/SKILL.md` — `"...should live: local remember state..."` (line 3 col 94)

Wrapping the description values in double quotes fixes both without changing the rendered text.

## How to repro
```
npx skills add chrisbanes/skills
# observe "Found 14 skills" instead of 16; both skills above are absent
```

## Test plan
- [x] `YAML.safe_load` parses both frontmatters cleanly after the fix
- [x] Scanned every `skills/*/SKILL.md` — no other broken frontmatters
- [ ] `npx skills add chrisbanes/skills` shows all 16 skills