### PR TITLE
Add cross-phase back-writing guidance to Compose performance skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ Or install as a Claude Code plugin:
 
 #### Performance
 
-- [`compose-recomposition-performance`](skills/compose-recomposition-performance/SKILL.md) — choose between the two recomposition investigation paths: stability/equality or deferred state reads.
+- [`compose-recomposition-performance`](skills/compose-recomposition-performance/SKILL.md) — route stability, deferred reads, and cross-phase back-writing.
 - [`compose-stability-diagnostics`](skills/compose-stability-diagnostics/SKILL.md) — diagnose Compose compiler reports, strong skipping behavior, unstable parameters, and stability fixes.
-- [`compose-state-deferred-reads`](skills/compose-state-deferred-reads/SKILL.md) — move frame-rate scroll, animation, and gesture reads out of composition into layout or draw.
+- [`compose-state-deferred-reads`](skills/compose-state-deferred-reads/SKILL.md) — move frame-rate reads out of composition; avoid back-writing snapshot state across phases and cross-row measurement reads in composition.
 
 #### UI API design and layout
 

--- a/skills/compose-modifier-and-layout-style/SKILL.md
+++ b/skills/compose-modifier-and-layout-style/SKILL.md
@@ -281,6 +281,46 @@ The benefit isn't a performance win — the runtime handles both fine — it's t
   }
   ```
 
+## 7. Measure-phase constraint decoration
+
+When composable A captures a size and composable B must match it, **do not read the captured size in B's composable body** (`Modifier.height(state.dp)`). That ties B to composition whenever the measurement state changes.
+
+Capture in a layout callback on A; apply on B inside `Modifier.layout` so only layout invalidates:
+
+```kotlin
+fun Modifier.decorateMeasureConstraints(
+    decorate: (Constraints) -> Constraints,
+): Modifier = layout { measurable, incoming ->
+    val constraints = decorate(incoming).constrain(incoming)
+    val placeable = measurable.measure(constraints)
+    layout(placeable.width, placeable.height) {
+        placeable.placeRelative(0, 0)
+    }
+}
+```
+
+```kotlin
+// Hoisted at the common parent of both rows:
+//   var anchorHeightPx by remember { mutableIntStateOf(0) }
+
+// Measured row — write state only from onSizeChanged
+RowAnchor(Modifier.onSizeChanged { size -> if (size.height != anchorHeightPx) anchorHeightPx = size.height })
+
+// Sibling rows — read anchorHeightPx only inside layout
+RowSibling(
+    Modifier.decorateMeasureConstraints { incoming ->
+        if (anchorHeightPx > 0) {
+            // Clamp to incoming bounds so the constraint never exceeds the parent's max.
+            incoming.copy(minHeight = anchorHeightPx, maxHeight = anchorHeightPx)
+        } else {
+            incoming
+        }
+    },
+)
+```
+
+Use a composition-time fallback (fixed height) only while `anchorHeightPx` is `0`. See [`compose-state-deferred-reads`](../compose-state-deferred-reads/SKILL.md) for the full cross-row pattern.
+
 ## Quick reference
 
 | Symptom | Diagnosis | Fix |
@@ -299,6 +339,7 @@ The benefit isn't a performance win — the runtime handles both fine — it's t
 | `Layout { if (cond) X() }` with no other content and no layout-tuning args | Hoist (§6) | Move the `if` outside the layout |
 | `Box(modifier = …) { if (cond) X() }` | Layout carries semantics — leave (§6 carve-out) | Keep as-is |
 | `Box { if (cond) X() else Y() }` | Both branches contribute — leave (§6 carve-out) | Keep as-is |
+| Sibling lazy row reads `height(state)` from another row's measurement | Composition-time size coupling (§7) | Capture on measured row; apply via `decorateMeasureConstraints` on siblings |
 
 ## When NOT to apply
 
@@ -331,3 +372,4 @@ The declaration-side rules (§1–§3) should not be skipped merely because "thi
 ## Related
 
 - [`compose-slot-api-pattern`](../compose-slot-api-pattern/SKILL.md) — the other half of declaring a reusable composable's public API: take `@Composable () -> Unit` slots for variable content. A reusable component takes both a `modifier` parameter *and* slots — caller owns placement *and* what to place.
+- [`compose-state-deferred-reads`](../compose-state-deferred-reads/SKILL.md) — back-writing across phases and deferred measurement reads.

--- a/skills/compose-recomposition-performance/SKILL.md
+++ b/skills/compose-recomposition-performance/SKILL.md
@@ -1,18 +1,19 @@
 ---
 name: compose-recomposition-performance
-description: Use when investigating Jetpack Compose recomposition performance, skippable/restartable composables, composables.txt or compiler reports, Layout Inspector recomposition counts, or frame-rate State reads in composition vs layout/draw, and it is not yet clear whether the cause is parameter stability or deferred reads.
+description: Use when investigating Jetpack Compose recomposition performance, skippable/restartable composables, composables.txt or compiler reports, Layout Inspector recomposition counts, back-writing snapshot state across phases, or frame-rate State reads in composition vs layout/draw, and it is not yet clear whether the cause is parameter stability, deferred reads, or cross-phase back-writing.
 ---
 
 # Compose recomposition performance
 
-Router only — deep fixes live in [`compose-stability-diagnostics`](../compose-stability-diagnostics/SKILL.md) and [`compose-state-deferred-reads`](../compose-state-deferred-reads/SKILL.md).
+Router only — deep fixes live in focused skills below.
 
-## Two axes
+## Three axes
 
 1. **Parameter stability / skipping** — can Compose skip this restartable composable; are arguments stable and comparable?
 2. **Where `State` is read** — is frame-rate `State` read during composition vs layout/draw?
+3. **Back-writing across phases** — does a later phase write snapshot state that invalidates an earlier phase? Examples: map/list mutation during composition that re-invalidates the same composition; `onSizeChanged` (layout phase) writing state read by a sibling in composition.
 
-Either axis can dominate; they combine independently.
+Axes 2 and 3 often overlap (a sibling reading measured size in composition is both a deferred-read violation and a layout → composition back-write). Axis 1 is independent.
 
 ## Route here → focused skill
 
@@ -20,15 +21,35 @@ Either axis can dominate; they combine independently.
 |---|---|
 | Skipping, unstable params, compiler/`composables.txt` churn | [`compose-stability-diagnostics`](../compose-stability-diagnostics/SKILL.md) |
 | Frame-rate `State` read phase (composition vs layout/draw) | [`compose-state-deferred-reads`](../compose-state-deferred-reads/SKILL.md) |
-| Evidence for both | Apply both skills in parallel |
+| `putAll` / map rebuild / cross-row `height(state)` during composition | [`compose-state-deferred-reads`](../compose-state-deferred-reads/SKILL.md) — § back-writing |
+| Focus-driven side work in composable body | [`compose-side-effects`](../compose-side-effects/SKILL.md) — `snapshotFlow` |
+| Evidence for multiple axes | Apply matching skills in parallel |
 
 ## Review order
 
-1. Decide which axis fits the evidence; open the matching skill.
-2. If unclear, sample both — stability churn vs composition-phase reads of fast `State`.
-3. Re-measure after changes.
+1. Reproduce one transition (focus move, insertion, scroll) and note which composables recompose.
+2. If counts spike on unchanged lazy items, check back-writing (composition mutations and cross-row measurement) before blaming stability.
+3. If counts climb every frame during scroll/animation, check deferred reads.
+4. If skipping fails despite stable data, check parameter stability and compiler reports.
+5. Re-measure after each fix.
+
+## False leads
+
+These changes often **do not** reduce recomposition count:
+
+| Attempt | Why it fails |
+|---|---|
+| `remember(index) { isFirstRow(index) }` instead of inline `when (index)` | Same inputs; no skipping benefit |
+| Identity cache for read-only derived maps | Can serve stale overlays; `remember(keys)` is enough |
+| `mutableIntStateOf` + layout modifier on **both** measured and sibling rows | Sibling still reads size in composition unless measure-only |
+| Forcing `Exactly(1)` on both rows in focus-move tests | One row often correctly recomposes 0 times |
+| Hoisting without stabilizing lambda captures | New lambda instance each frame still defeats skipping |
 
 ## When NOT to apply
 
 - Recomposition tracks real data changes, or the bug is correctness not cost.
 - No profiler / compiler signal suggests a problem.
+
+## Related
+
+- [`compose-state-authoring`](../compose-state-authoring/SKILL.md) — authoring `mutableState*` safely.

--- a/skills/compose-side-effects/SKILL.md
+++ b/skills/compose-side-effects/SKILL.md
@@ -163,6 +163,37 @@ Every registration path should have a matching `onDispose` cleanup path.
 | `LaunchedEffect(...) { nonSuspendSetter() }` | Usually `SideEffect`; keep `LaunchedEffect` only for keyed one-shot/deferred work |
 | Listener added in `LaunchedEffect` with no cleanup | Use `DisposableEffect` |
 | Launching from click by setting `shouldShowSnackbar = true` | Use `rememberCoroutineScope()` in the click callback |
+| `if (isFocused) { … }` or focus read in composable body for side work | Side work during composition | `LaunchedEffect(focused) { … }` or `snapshotFlow` |
+| `onSizeChanged { heightState = it.height }` on measured composable | OK in isolation — but layout → composition back-write if a sibling reads `heightState` in composition | Siblings must consume height in measure phase, not `Modifier.height(state.dp)` in composition |
+
+## Focus and measurement
+
+**Focus:** Reading focus in the composable body to drive **side work** (preloading, analytics, toasts) runs that work during composition. Observe focus in an effect instead:
+
+```kotlin
+// ❌ BAD — side work runs during composition every time `focused` is true,
+// including transient focus passes; `SideEffect` re-runs after every successful recomposition
+@Composable
+fun Preloader(interactionSource: MutableInteractionSource) {
+    val focused by interactionSource.collectIsFocusedAsState()
+    if (focused) {
+        preloadImages()
+    }
+}
+
+// ✅ GOOD — side work in a keyed effect
+@Composable
+fun Preloader(interactionSource: MutableInteractionSource) {
+    val focused by interactionSource.collectIsFocusedAsState()
+    LaunchedEffect(focused) {
+        if (focused) preloadImages()
+    }
+}
+```
+
+Use `snapshotFlow { … }` inside `LaunchedEffect` when you need to sample multiple snapshot reads or debounce rapid changes without keying the effect on every derived value. For TV/D-pad focus navigation semantics, see [`compose-focus-navigation`](../compose-focus-navigation/SKILL.md).
+
+**Measurement:** `onSizeChanged` / `onGloballyPositioned` are valid **callbacks**, but they fire during the layout phase. Writing snapshot state there is only safe if no earlier phase reads it. If a sibling reads that state in composition, layout is back-writing into composition and the sibling will recompose every measure pass. Apply captured dimensions in `Modifier.layout` (see [`compose-modifier-and-layout-style`](../compose-modifier-and-layout-style/SKILL.md) §7 and [`compose-state-deferred-reads`](../compose-state-deferred-reads/SKILL.md)).
 
 ## Red flags during review
 

--- a/skills/compose-stability-diagnostics/SKILL.md
+++ b/skills/compose-stability-diagnostics/SKILL.md
@@ -116,6 +116,33 @@ kotlinx.datetime.*
 
 Only list types you are willing to promise are immutable. Do not list mutable types such as `java.util.Date`.
 
+## 4. Stabilize lazy item inputs
+
+Lazy list items recompose when their lambda inputs change identity, even if the visible data is unchanged.
+
+Hoist and remember per-item inputs that are stable for the item's lifetime:
+
+```kotlin
+// ❌ BAD — new lambda instances when parent recomposes
+items(list, key = { it.id }) { item ->
+    RowCard(
+        onClick = { onItemClick(item.id) },
+        isHighlighted = { item.id == selectedId },
+    )
+}
+
+// ✅ GOOD — stable captures for this item instance
+items(list, key = { it.id }) { item ->
+    val onClick = remember(item.id) { { onItemClick(item.id) } }
+    val isHighlighted = remember(item.id, selectedId) { item.id == selectedId }
+    RowCard(onClick = onClick, isHighlighted = isHighlighted)
+}
+```
+
+Also hoist row position metadata (`isFirst`, `isLast`, corner radii) with `remember(index) { … }` when the value depends only on index — but do not expect this alone to fix back-writing or cross-row measurement bugs.
+
+Verify focus moves and insertions with recomposition-count assertions after hoisting.
+
 ## Quick reference
 
 | Symptom | Diagnosis | Fix |
@@ -125,11 +152,13 @@ Only list types you are willing to promise are immutable. Do not list mutable ty
 | `unstable val price: BigDecimal` | External immutable type | Add to stability config |
 | `@Immutable` on a type with mutable internals | False promise | Fix the model or remove the annotation |
 | Composable skips poorly despite strong skipping | New unstable instance each recomposition | Remember, hoist, or make the type stable/equality-based |
+| Lazy items recompose on parent recompose despite unchanged data | New lambda or derived-value instance per parent recompose (§4) | Hoist per-item with `remember(item.id) { … }` |
 | Reports not generated | Compose compiler plugin missing or flag not set | Apply `org.jetbrains.kotlin.plugin.compose` and enable destinations |
 
 ## When NOT to apply
 
-- The issue is a fast-changing `State` read in composition, such as scroll or animation. Use `compose-state-deferred-reads`.
+- The issue is back-writing across phases or cross-row measurement reads. Use [`compose-state-deferred-reads`](../compose-state-deferred-reads/SKILL.md).
+- The issue is a fast-changing `State` read in composition, such as scroll or animation. Use [`compose-state-deferred-reads`](../compose-state-deferred-reads/SKILL.md).
 - The recomposition count matches real data changes.
 - The bug is wrong data or stale state, not excess work.
 - The code is test-only and readability is more important than report cleanliness.

--- a/skills/compose-state-authoring/SKILL.md
+++ b/skills/compose-state-authoring/SKILL.md
@@ -67,6 +67,25 @@ Two pieces and both matter:
 
 For collections, prefer `mutableStateListOf` / `mutableStateMapOf` (also `remember`-ed). They emit Snapshot reads on every read and Snapshot writes on every mutation. A `remember { mutableStateOf(mutableListOf<X>()) }` followed by `list.add(x)` will *not* recompose, because `MutableList.add` doesn't go through the State setter — you'd have to replace the value (`state = state + x`).
 
+### Back-writing snapshot state during composition
+
+**Back-writing** means writing observable state in a phase that triggers invalidation of an earlier (or the current) phase. Mutating `mutableState*` from the composable body back-writes into the same composition pass and schedules another. Do not rebuild derived data this way:
+
+```kotlin
+// ❌ BAD — clear + putAll on every composition
+val merged = remember { mutableStateMapOf<Key, ViewState>() }
+merged.clear()
+merged.putAll(parent)
+merged.putAll(overlay)
+
+// ✅ GOOD — immutable snapshot remembered from inputs
+val merged = remember(parent, overlay) {
+    if (overlay.isEmpty()) parent else parent + overlay
+}
+```
+
+If the result is read-only for the current inputs, `remember(keys) { … }` is enough. See [`compose-state-deferred-reads`](../compose-state-deferred-reads/SKILL.md) for cross-row measurement and measure-phase fixes.
+
 ### When this rule does NOT apply
 
 - **Inside `remember { … }`'s producer block.** That runs once per key change, not on every recompose. A local `var` there is fine: `val builder = remember { mutableListOf<X>().apply { var n = 0; … } }`.
@@ -141,6 +160,7 @@ This skill is about authoring Compose state correctly. `rememberUpdatedState` is
 | `var x = …` inside `@Composable fun` body | Not recomposition-safe (§1) | `var x by remember { mutableStateOf(…) }` |
 | `var x = …` inside `Column { … }` / `Row { … }` content lambda | Same — content lambdas are `@Composable` (§1) | Same fix |
 | `remember { mutableStateOf(list) }` then `.add(x)` not recomposing | Mutation bypasses State setter | Use `mutableStateListOf`, or replace the value: `state = state + x` |
+| `stateMap.clear(); stateMap.putAll(...)` in composable body | Back-writing composition → composition | `remember(keys) { derivedSnapshot }` |
 | `@Composable fun` with no `Text`/`Box`/`remember`/effect calls | Could be `@ReadOnlyComposable` (§2) | Add `@ReadOnlyComposable` above `@Composable` |
 | `@ReadOnlyComposable` function that calls `Box {}` / `Column {}` / a normal composable | Contract violation (§2) | Remove `@ReadOnlyComposable` |
 

--- a/skills/compose-state-deferred-reads/SKILL.md
+++ b/skills/compose-state-deferred-reads/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: compose-state-deferred-reads
-description: Use when Jetpack Compose code reads scroll, animation, gesture, or other frame-rate State in composition, passes changing values across composable boundaries, or uses value-form layout/draw modifiers.
+description: Use when Jetpack Compose code reads scroll, animation, gesture, or other frame-rate State in composition, passes changing values across composable boundaries, uses value-form layout/draw modifiers, or back-writes observable state from a later phase into one that's already run.
 ---
 
 # Compose state deferred reads
@@ -9,7 +9,9 @@ description: Use when Jetpack Compose code reads scroll, animation, gesture, or 
 
 State reads invalidate the phase that reads them. If a `State<T>` is read in a composable body, changes invalidate composition. If it is read in layout or draw, changes can invalidate only layout or draw. Frame-rate state such as scroll offsets, animations, and drag positions usually belongs in layout/draw, not composition.
 
-The fix is structural: keep the `State<T>` or a provider lambda, and read the value inside a layout/draw callback.
+**Back-writing** is the symmetric failure mode: writing observable state from a phase that triggers invalidation of an earlier phase. Compose phases run composition → layout → draw. Writing snapshot-backed state from layout or draw to state read in composition invalidates composition; writing during composition to state read earlier in the same composition does the same. Both schedule extra work — often cascading into sibling lazy items.
+
+The fix is structural: keep the `State<T>` or a provider lambda and read the value inside a layout/draw callback; capture measurements in callbacks and apply them in the measure phase, not by reading measurement state in sibling composable bodies.
 
 ## When to use this skill
 
@@ -17,6 +19,66 @@ The fix is structural: keep the `State<T>` or a provider lambda, and read the va
 - `LazyListState.firstVisibleItemScrollOffset`, `ScrollState.value`, `Animatable.value`, or gesture state is read in a composable body.
 - A composable takes `scrollOffset: Int`, `progress: Float`, `dragOffset: Offset`, or similar frame-rate values.
 - Recomposition counters climb during scroll, animation, or gestures even when data is stable.
+- A composable body calls `stateMap[key] = …`, `list.addAll(…)`, or similar on every recomposition (back-writing composition → composition).
+- One lazy item captures size with `onSizeChanged` / `onGloballyPositioned` and a sibling reads that height in composition (`Modifier.height(state.dp)`) — back-writing layout → composition.
+
+## 0. Back-writing
+
+**Back-writing** = writing observable state in one phase that triggers invalidation of an earlier (or the current) phase. Compose runs composition → layout → draw, so:
+
+- Writing snapshot state during composition that's read in the same composition.
+- Writing snapshot state during layout (e.g. from `Modifier.layout`, `onSizeChanged`, `onGloballyPositioned`) that's read during composition.
+- Writing snapshot state during draw that's read during composition or layout.
+
+In all cases the writer schedules extra invalidation passes — often cascading into sibling lazy items.
+
+Do not write to `mutableStateOf`, `mutableStateListOf`, `mutableStateMapOf`, or other snapshot-backed state from the composable body on every pass:
+
+```kotlin
+// ❌ BAD — mutates observable map during composition; siblings recompose repeatedly
+@Composable
+fun MergeOverlay(parent: Map<Key, ViewState>, overlay: Map<Key, ViewState>): Map<Key, ViewState> {
+    val merged = remember { mutableStateMapOf<Key, ViewState>() }
+    merged.clear()
+    merged.putAll(parent)
+    merged.putAll(overlay)   // back-writing composition → composition
+    return merged
+}
+
+// ✅ GOOD — read-only merge; no composition-time writes
+@Composable
+fun MergeOverlay(parent: Map<Key, ViewState>, overlay: Map<Key, ViewState>): Map<Key, ViewState> =
+    remember(parent, overlay) {
+        if (overlay.isEmpty()) parent else parent + overlay
+    }
+```
+
+Prefer `remember(keys) { … }` for derived read-only snapshots. Reserve `mutableState*` writes for event callbacks (`onClick`) or effects — not for rebuilding derived data on every composition.
+
+Callbacks like `onSizeChanged` write *during layout*. That is only safe if no earlier phase reads the resulting state — see cross-row measurement below.
+
+### Cross-row measurement (layout → composition back-write)
+
+When row A measures and row B must match A's height, do not read A's captured size in B's composable body. `onSizeChanged` writes during layout; if B reads it in composition, layout has just back-written into composition:
+
+```kotlin
+var anchorHeightPx by remember { mutableIntStateOf(0) }
+
+// ❌ BAD — B reads measurement state in composition; insertion/focus can double-recompose B
+RowA(Modifier.onSizeChanged { anchorHeightPx = it.height })
+RowB(Modifier.height(with(LocalDensity.current) { anchorHeightPx.toDp() }))  // composition read
+
+// ✅ GOOD — capture on A; apply on B in measure phase only
+RowA(Modifier.onSizeChanged { if (it.height != anchorHeightPx) anchorHeightPx = it.height })
+RowB(
+    Modifier.decorateMeasureConstraints { incoming ->
+        if (anchorHeightPx > 0) incoming.copy(minHeight = anchorHeightPx, maxHeight = anchorHeightPx)
+        else incoming
+    },
+)
+```
+
+`decorateMeasureConstraints` is a small layout helper (see [`compose-modifier-and-layout-style`](../compose-modifier-and-layout-style/SKILL.md)). While height is unknown, siblings use a fixed fallback in composition; once known, only layout invalidates — not an extra composition cascade.
 
 ## 1. Prefer block-form modifiers
 
@@ -126,6 +188,9 @@ Use these when the state changes where something is placed or painted. If the st
 | `Child(scrollOffset = listState.firstVisibleItemScrollOffset)` | Fast-changing value crosses boundary | `Child(scrollOffsetProvider = { ... })` |
 | Draw block still recomposes every frame | Value was read before draw block | Move the `State.value` read inside the draw block |
 | State chooses between different UI branches | Composition decision | Keep the read in composition |
+| `mergedMap.putAll(overlay)` in composable body | Back-writing composition → composition | `remember(parent, overlay) { parent + overlay }` |
+| Sibling `Modifier.height(measuredPx.toDp())` | Back-writing layout → composition | Measure-phase constraint decoration |
+| Identity cache for read-only merge | Stale overlay risk | `remember(keys)` on immutable result |
 
 ## When NOT to apply
 
@@ -136,6 +201,7 @@ Use these when the state changes where something is placed or painted. If the st
 
 ## Related
 
-- [`compose-state-holder-ui-split`](../compose-state-holder-ui-split/SKILL.md) - where state-holder vs plain UI split applies when passing providers/lambdas across boundaries.
-- [`compose-stability-diagnostics`](../compose-stability-diagnostics/SKILL.md) - parameter stability and compiler reports.
-- [`compose-modifier-and-layout-style`](../compose-modifier-and-layout-style/SKILL.md) - child composables need a normal `modifier` parameter before callers can move visual reads into modifiers.
+- [`compose-state-authoring`](../compose-state-authoring/SKILL.md) — when `mutableState*` belongs in composition vs callbacks.
+- [`compose-state-holder-ui-split`](../compose-state-holder-ui-split/SKILL.md) — where state-holder vs plain UI split applies when passing providers/lambdas across boundaries.
+- [`compose-stability-diagnostics`](../compose-stability-diagnostics/SKILL.md) — parameter stability and compiler reports.
+- [`compose-modifier-and-layout-style`](../compose-modifier-and-layout-style/SKILL.md) — measure-phase constraint decoration helper.


### PR DESCRIPTION
  ## Summary
  - Extends `compose-recomposition-performance` router with a third axis: back-writing across phases (composition→composition, layout→composition).
  - Adds focused coverage in `compose-state-deferred-reads` (§0 back-writing, cross-row measurement) and `compose-state-authoring` (back-writing snapshot state during composition).
  - Adds `decorateMeasureConstraints` helper and §7 measure-phase constraint decoration to `compose-modifier-and-layout-style`.
  - Adds §4 lazy-item lambda input stabilization to `compose-stability-diagnostics`.
  - Clarifies the focus-driven side-work anti-pattern in `compose-side-effects`.