### PR TITLE
Add Codex plugin release workflow

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,21 @@
+{
+  "name": "chrisbanes-skills",
+  "interface": {
+    "displayName": "Chris Banes Skills"
+  },
+  "plugins": [
+    {
+      "name": "chrisbanes-skills",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/chrisbanes/skills",
+        "ref": "main"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Developer Tools"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "chrisbanes-skills",
   "description": "Skills for Kotlin, Android, JVM, and Jetpack Compose development by Chris Banes.",
-  "version": "2026.05.21",
+  "version": "2026.6.16",
   "author": {
     "name": "Chris Banes",
     "url": "https://github.com/chrisbanes"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,34 @@
+{
+  "name": "chrisbanes-skills",
+  "version": "2026.6.16",
+  "description": "Skills for Kotlin, Android, JVM, and Jetpack Compose development by Chris Banes.",
+  "author": {
+    "name": "Chris Banes",
+    "url": "https://github.com/chrisbanes"
+  },
+  "repository": "https://github.com/chrisbanes/skills",
+  "license": "Apache-2.0",
+  "keywords": [
+    "kotlin",
+    "android",
+    "jetpack-compose",
+    "skills"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Chris Banes Skills",
+    "shortDescription": "Kotlin, Android, and Jetpack Compose development skills.",
+    "longDescription": "A set of Codex skills for Kotlin, Android, JVM, and Jetpack Compose development.",
+    "developerName": "Chris Banes",
+    "category": "Developer Tools",
+    "capabilities": [
+      "Skills"
+    ],
+    "websiteURL": "https://github.com/chrisbanes/skills",
+    "defaultPrompt": [
+      "Review this Compose state model.",
+      "Check this Flow event design.",
+      "Diagnose Compose recomposition issues."
+    ]
+  }
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,153 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version as YYYY.M.D. Leave empty to use today's UTC date."
+        required: false
+        type: string
+      dry_run:
+        description: "Validate and show changes without pushing or creating a release."
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Resolve version
+        id: version
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+
+          VERSION="$(python3 scripts/release.py resolve-version "$INPUT_VERSION")"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Resolved release version: $VERSION"
+
+      - name: Check existing tag and release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          git fetch --tags origin
+
+          if git rev-parse -q --verify "refs/tags/$VERSION" >/dev/null; then
+            echo "Tag already exists: $VERSION" >&2
+            exit 1
+          fi
+
+          if gh release view "$VERSION" >/dev/null 2>&1; then
+            echo "GitHub release already exists: $VERSION" >&2
+            exit 1
+          fi
+
+      - name: Update manifests
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          python3 scripts/release.py update-manifests "$VERSION"
+
+      - name: Validate manifests
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          jq . .claude-plugin/plugin.json
+          jq . .claude-plugin/marketplace.json
+          jq . .codex-plugin/plugin.json
+          jq . .agents/plugins/marketplace.json
+
+          python3 scripts/release.py validate-manifests "$VERSION"
+
+      - name: Lint skills
+        run: npm run lint
+
+      - name: Check release diff
+        id: diff
+        run: |
+          set -euo pipefail
+
+          git diff --check
+
+          if git diff --quiet -- .claude-plugin/plugin.json .codex-plugin/plugin.json; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            echo "No manifest version changes needed."
+          else
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+            git diff -- .claude-plugin/plugin.json .codex-plugin/plugin.json
+          fi
+
+      - name: Stop before publishing
+        if: ${{ inputs.dry_run }}
+        run: |
+          echo "Dry run requested. Release validation completed; no commit, tag, or GitHub release was created."
+
+      - name: Configure Git author
+        if: ${{ !inputs.dry_run && steps.diff.outputs.has_changes == 'true' }}
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR_ID+$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Commit and push version bump
+        if: ${{ !inputs.dry_run && steps.diff.outputs.has_changes == 'true' }}
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          git add .claude-plugin/plugin.json .codex-plugin/plugin.json
+          git commit -m "Bump version to $VERSION"
+          git push origin HEAD:main
+
+      - name: Resolve release target
+        if: ${{ !inputs.dry_run }}
+        id: release_target
+        run: |
+          set -euo pipefail
+
+          LATEST_TAG="$(git describe --tags --abbrev=0 2>/dev/null || true)"
+          if [ -n "$LATEST_TAG" ]; then
+            COMMITS_SINCE_TAG="$(git rev-list --count "$LATEST_TAG"..HEAD)"
+            if [ "$COMMITS_SINCE_TAG" = "0" ]; then
+              echo "No commits since latest tag: $LATEST_TAG" >&2
+              exit 1
+            fi
+          fi
+
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub release
+        if: ${{ !inputs.dry_run }}
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ steps.version.outputs.version }}
+          target_commitish: ${{ steps.release_target.outputs.sha }}
+          name: ${{ steps.version.outputs.version }}
+          generate_release_notes: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 
 .DS_Store
 node_modules/
+__pycache__/
+*.py[cod]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,17 @@ Instructions for AI agents (Claude Code, etc.) working in this repo.
 ## When adding, renaming, or removing a skill
 
 1. **Update `README.md`** — keep the "Skills" list in sync. Each entry links to the skill's `SKILL.md` and summarises what it covers. If you add a skill and don't update the README, the change is incomplete.
-2. **Do not update plugin or skill versions unless explicitly asked.** If the user asks for a release/version bump, use semver in `.claude-plugin/plugin.json`: patch for fixes/wording, minor for a new skill or new triggers, major for removals or breaking renames.
+2. **Do not update plugin or skill versions unless explicitly asked.** If the user asks for a release/version bump, use the release system below.
+
+## Release/version system
+
+- Use SemVer-compatible CalVer: `YYYY.M.D`.
+- Do not zero-pad month or day values. Use `2026.6.17`, not `2026.06.17`.
+- Keep `.claude-plugin/plugin.json` and `.codex-plugin/plugin.json` on the same version.
+- New Git release tags should match the manifest version exactly.
+- Existing zero-padded tags from before this policy map to the non-padded manifest version. For example, origin tag `2026.06.16` maps to manifest version `2026.6.16`.
+- Only cut a release when publishing installable changes. Skill wording/fixes, new skills/triggers, removals, and renames all use the publication date as the version.
+- Call out removals and renames clearly in release notes because they break existing user references.
 
 ## Skill layout
 
@@ -15,7 +25,7 @@ Instructions for AI agents (Claude Code, etc.) working in this repo.
 
 ## Manifests
 
-- `.claude-plugin/marketplace.json` and `.claude-plugin/plugin.json` are both JSON (not JSONC). Validate with `jq . <file>` before committing.
+- `.claude-plugin/marketplace.json`, `.claude-plugin/plugin.json`, `.agents/plugins/marketplace.json`, and `.codex-plugin/plugin.json` are all JSON (not JSONC). Validate with `jq . <file>` before committing.
 - The plugin `name` field in both manifests must stay `chrisbanes-skills`.
 
 ## Commits and PRs

--- a/README.md
+++ b/README.md
@@ -17,6 +17,13 @@ Or install as a Claude Code plugin:
 /plugin install chrisbanes-skills@chrisbanes-skills
 ```
 
+Or install as a Codex plugin:
+
+```
+codex plugin marketplace add chrisbanes/skills --ref main
+codex plugin add chrisbanes-skills@chrisbanes-skills
+```
+
 ## Skills
 
 ### Start here
@@ -71,6 +78,14 @@ Or install as a Claude Code plugin:
 Skills live at `skills/<skill-name>/SKILL.md`, flat (no language nesting). The `name:` in the SKILL.md frontmatter must match the directory name.
 
 Frontmatter is validated against [`skills.schema.json`](skills.schema.json) — `name` and `description` are required, `name` must be kebab-case.
+
+### Releases
+
+Release versions use SemVer-compatible CalVer: `YYYY.M.D` without zero-padded month or day values, for example `2026.6.17`.
+
+Keep `.claude-plugin/plugin.json`, `.codex-plugin/plugin.json`, and new Git release tags on the same version. Existing zero-padded tags from before this policy map to the non-padded manifest version, so `2026.06.16` maps to `2026.6.16`. Only bump versions when publishing an installable release.
+
+To publish a release, run the **Release** workflow from GitHub Actions. Leave the version input empty to use today's UTC `YYYY.M.D` version, or provide a specific non-zero-padded CalVer value. Use the dry-run option to validate without creating a commit, tag, or GitHub release.
 
 Before pushing, lint skills (frontmatter schema + markdown):
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+import argparse
+import datetime as dt
+import json
+import pathlib
+import re
+import sys
+
+
+VERSION_PATTERN = re.compile(r"^[0-9]{4}\.([1-9]|1[0-2])\.([1-9]|[12][0-9]|3[01])$")
+PLUGIN_NAME = "chrisbanes-skills"
+
+
+def validate_version(version):
+    if not VERSION_PATTERN.fullmatch(version):
+        raise ValueError(
+            "Version must use SemVer-compatible CalVer YYYY.M.D without "
+            f"zero-padded month/day: {version}"
+        )
+    return version
+
+
+def default_version():
+    today = dt.datetime.now(dt.timezone.utc).date()
+    return f"{today.year}.{today.month}.{today.day}"
+
+
+def resolve_version(input_version):
+    if input_version:
+        return validate_version(input_version)
+    return default_version()
+
+
+def update_manifests(root, version):
+    validate_version(version)
+    for path in plugin_manifest_paths(root):
+        data = read_json(path)
+        data["version"] = version
+        write_json(path, data)
+
+
+def validate_manifests(root, version):
+    validate_version(version)
+
+    claude = read_json(root / ".claude-plugin" / "plugin.json")
+    codex = read_json(root / ".codex-plugin" / "plugin.json")
+    claude_marketplace = read_json(root / ".claude-plugin" / "marketplace.json")
+    codex_marketplace = read_json(root / ".agents" / "plugins" / "marketplace.json")
+
+    require(claude.get("name") == PLUGIN_NAME, "Claude plugin name must be chrisbanes-skills")
+    require(codex.get("name") == PLUGIN_NAME, "Codex plugin name must be chrisbanes-skills")
+    require(claude.get("version") == version, f"Claude plugin version mismatch: {claude.get('version')}")
+    require(codex.get("version") == version, f"Codex plugin version mismatch: {codex.get('version')}")
+    require(
+        claude_marketplace.get("name") == PLUGIN_NAME,
+        "Claude marketplace name must be chrisbanes-skills",
+    )
+    require(
+        codex_marketplace.get("name") == PLUGIN_NAME,
+        "Codex marketplace name must be chrisbanes-skills",
+    )
+    require(codex.get("skills") == "./skills/", "Codex plugin skills path must be ./skills/")
+
+
+def plugin_manifest_paths(root):
+    return [
+        root / ".claude-plugin" / "plugin.json",
+        root / ".codex-plugin" / "plugin.json",
+    ]
+
+
+def read_json(path):
+    with path.open(encoding="utf-8") as file:
+        return json.load(file)
+
+
+def write_json(path, data):
+    with path.open("w", encoding="utf-8") as file:
+        json.dump(data, file, indent=2)
+        file.write("\n")
+
+
+def require(condition, message):
+    if not condition:
+        raise ValueError(message)
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Release helpers for chrisbanes-skills.")
+    parser.add_argument(
+        "--root",
+        default=".",
+        type=pathlib.Path,
+        help="Repository root. Defaults to the current directory.",
+    )
+
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    resolve_parser = subparsers.add_parser("resolve-version")
+    resolve_parser.add_argument("input_version", nargs="?", default="")
+
+    update_parser = subparsers.add_parser("update-manifests")
+    update_parser.add_argument("version")
+
+    validate_parser = subparsers.add_parser("validate-manifests")
+    validate_parser.add_argument("version")
+
+    args = parser.parse_args(argv)
+    root = args.root.resolve()
+
+    try:
+        if args.command == "resolve-version":
+            print(resolve_version(args.input_version))
+        elif args.command == "update-manifests":
+            update_manifests(root, args.version)
+        elif args.command == "validate-manifests":
+            validate_manifests(root, args.version)
+        else:
+            parser.error(f"Unknown command: {args.command}")
+    except ValueError as error:
+        print(error, file=sys.stderr)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_release.py
+++ b/scripts/test_release.py
@@ -1,0 +1,72 @@
+import importlib.util
+import json
+import pathlib
+import tempfile
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+RELEASE_SCRIPT = ROOT / "scripts" / "release.py"
+
+
+def load_release_module():
+    spec = importlib.util.spec_from_file_location("release", RELEASE_SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class ReleaseScriptTest(unittest.TestCase):
+    def setUp(self):
+        self.release = load_release_module()
+
+    def test_validate_version_accepts_non_zero_padded_calver(self):
+        self.assertEqual(self.release.validate_version("2026.6.17"), "2026.6.17")
+
+    def test_validate_version_rejects_zero_padded_calver(self):
+        with self.assertRaises(ValueError):
+            self.release.validate_version("2026.06.17")
+
+    def test_update_and_validate_manifests(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            (root / ".claude-plugin").mkdir()
+            (root / ".codex-plugin").mkdir()
+            (root / ".agents" / "plugins").mkdir(parents=True)
+
+            self.write_json(
+                root / ".claude-plugin" / "plugin.json",
+                {"name": "chrisbanes-skills", "version": "2026.6.16"},
+            )
+            self.write_json(
+                root / ".codex-plugin" / "plugin.json",
+                {"name": "chrisbanes-skills", "version": "2026.6.16", "skills": "./skills/"},
+            )
+            self.write_json(
+                root / ".claude-plugin" / "marketplace.json",
+                {"name": "chrisbanes-skills"},
+            )
+            self.write_json(
+                root / ".agents" / "plugins" / "marketplace.json",
+                {"name": "chrisbanes-skills"},
+            )
+
+            self.release.update_manifests(root, "2026.6.17")
+            self.release.validate_manifests(root, "2026.6.17")
+
+            claude = self.read_json(root / ".claude-plugin" / "plugin.json")
+            codex = self.read_json(root / ".codex-plugin" / "plugin.json")
+            self.assertEqual(claude["version"], "2026.6.17")
+            self.assertEqual(codex["version"], "2026.6.17")
+
+    @staticmethod
+    def write_json(path, value):
+        path.write_text(json.dumps(value, indent=2) + "\n", encoding="utf-8")
+
+    @staticmethod
+    def read_json(path):
+        return json.loads(path.read_text(encoding="utf-8"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add Codex plugin marketplace metadata and manifest
- define SemVer-compatible CalVer release policy
- add manual GitHub Actions release workflow with Python helper/tests

## Validation

- python3 -m unittest scripts/test_release.py
- python3 scripts/release.py resolve-version 2026.6.17
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "release workflow YAML parses"'
- git diff --check
- python3 scripts/release.py validate-manifests 2026.6.16
- python3 /Users/chris/.codex/skills/.system/plugin-creator/scripts/validate_plugin.py .
- npm run lint