### PR TITLE
Make skills more procedural

### DIFF
--- a/skills/compose-animations/SKILL.md
+++ b/skills/compose-animations/SKILL.md
@@ -5,11 +5,18 @@ description: "Use when writing or reviewing Jetpack Compose motion: visibility e
 
 # Compose: animations
 
-Official reference: [Quick guide to Animations in Compose](https://developer.android.com/develop/ui/compose/animation/quick-guide). See also [Choose an animation API](https://developer.android.com/develop/ui/compose/animation/choose-api), [Value-based animations](https://developer.android.com/develop/ui/compose/animation/value-based), [Animation modifiers and composables](https://developer.android.com/develop/ui/compose/animation/composables-modifiers).
-
 ## Core principle
 
 Pick the **smallest API that matches the problem**: built-in visibility and layout transitions first, then a single animated value, then a shared transition object when several values must move together, then gesture-level or imperative APIs when the framework cannot express the motion.
+
+## Review procedure
+
+1. Identify the visual job: show/hide, one value, coordinated values, content swap, size change, or gesture-driven motion.
+2. Choose the smallest API from the table below.
+3. Check lifecycle semantics: should hidden content leave composition, keep focus/state, or only become transparent?
+4. Check identity: for state-holder wrappers, choose `AnimatedContent.contentKey` by visual shape rather than payload churn.
+5. Check performance: keep frame-rate animation values as `State` and read them in layout/draw block modifiers when possible.
+6. Escalate to `Animatable` or lower-level APIs only when target-state animation cannot express the motion.
 
 ## Pick the smallest animation API
 
@@ -88,7 +95,7 @@ Avoid multiple independent `animate*AsState` calls that should stay visually syn
 
 ## Choosing between content-level APIs
 
-Use the official [Choose an animation API](https://developer.android.com/develop/ui/compose/animation/choose-api) tree when unsure. Compressed rules:
+Use the official [Choose an animation API](https://developer.android.com/develop/ui/compose/animation/choose-api) tree when the table is not enough. Compressed rules:
 
 | Situation | Prefer |
 |---|---|
@@ -97,7 +104,7 @@ Use the official [Choose an animation API](https://developer.android.com/develop
 | Pager-like **swipe between pages** | Horizontal pager APIs from the animation docs / Material—follow the choose-api guidance |
 | Transitions **owned by Navigation Compose** | Use navigation’s built-in transitions rather than bolting `AnimatedContent` on top of the same destination swap |
 
-**Art-based motion** (illustrations, Lottie, complex vector timelines) is outside this skill; use dedicated libraries and the “additional resources” links on [Animations](https://developer.android.com/develop/ui/compose/animation/resources).
+**Art-based motion** (illustrations, Lottie, complex vector timelines) is outside this skill; use dedicated libraries.
 
 ## Decision flow (high level)
 
@@ -158,11 +165,16 @@ Choose keys by visual shape:
 
 If recomposition counters spike during motion unrelated to bad stability, see [`compose-recomposition-performance`](../compose-recomposition-performance/SKILL.md).
 
-## Advanced pointers (read the linked docs)
+## Escalation points
 
-- **Gesture-driven or cancelable motion**: [`Animatable`](https://developer.android.com/reference/kotlin/androidx/compose/animation/core/Animatable) with `snapTo`, decay, and `pointerInput`—[Advanced animation example: Gestures](https://developer.android.com/develop/ui/compose/animation/advanced) and [Drag, swipe, and fling](https://developer.android.com/develop/ui/compose/touch-input/pointer-input/drag-swipe-fling).
-- **Infinite or repeating cycles**: [`rememberInfiniteTransition`](https://developer.android.com/reference/kotlin/androidx/compose/animation/core/rememberInfiniteTransition).
-- **Seekable / test-controlled progress**: [`SeekableTransitionState`](https://developer.android.com/reference/kotlin/androidx/compose/animation/core/SeekableTransitionState) and related APIs for predictable timelines in tests or tooling.
+Load the official docs when one of these applies:
+
+| Need | Start with |
+|---|---|
+| API tree is still ambiguous | [Choose an animation API](https://developer.android.com/develop/ui/compose/animation/choose-api) |
+| Gesture-driven, interruptible, or cancelable motion | [`Animatable`](https://developer.android.com/reference/kotlin/androidx/compose/animation/core/Animatable), pointer input, decay |
+| Infinite or repeating cycles | [`rememberInfiniteTransition`](https://developer.android.com/reference/kotlin/androidx/compose/animation/core/rememberInfiniteTransition) |
+| Seekable or test-controlled progress | [`SeekableTransitionState`](https://developer.android.com/reference/kotlin/androidx/compose/animation/core/SeekableTransitionState) and related APIs |
 
 ## Common mistakes
 

--- a/skills/compose-slot-api-pattern/SKILL.md
+++ b/skills/compose-slot-api-pattern/SKILL.md
@@ -7,21 +7,17 @@ description: Use when designing or reviewing a reusable Jetpack Compose componen
 
 ## Core principle
 
-A reusable Compose component's job is to lay things out, not to enumerate what it lays out. The moment you write `title: String, subtitle: String?, leadingIcon: ImageVector?, trailingIcon: ImageVector?, trailingText: String?, showSwitch: Boolean, switchValue: Boolean, onSwitchChange: (Boolean) -> Unit?, badge: String?, …`, the component has stopped describing a layout and started enumerating call sites — and the next call site will need a parameter the component doesn't have.
+A reusable Compose component describes layout structure. Callers provide variable visual content through slots.
 
-The fix is to **delegate content to the caller** via `@Composable` lambda parameters. The component contributes structure (where the leading bit, headline, supporting bit, trailing bit go). The caller contributes everything that goes *in* those slots.
+## API review procedure
 
-Material 3's `ListItem` is the canonical example: every visual piece is a slot (`headlineContent`, `supportingContent`, `leadingContent`, `trailingContent`, `overlineContent`), not a primitive. That's not over-engineering — it's the design that scales to every list-item shape the design system needs without ever editing `ListItem` again.
-
-## When to use this skill
-
-You're designing or reviewing a Compose component intended for reuse (more than one call site, now or planned), its visual content varies by caller, and any of these is true:
-
-- Its signature has `title: String`, `icon: ImageVector`, `actionText: String?`, etc. — primitive types describing *content*.
-- It has multiple optional-content parameters that vary by call site (`subtitle: String?`, `leadingIcon: ImageVector?`, `trailingText: String?`).
-- It has boolean flags whose only purpose is to switch between content shapes (`showChevron: Boolean`, `showSwitch: Boolean`, `mode: Mode.Text | Mode.Switch | …`).
-- It accepts a `String` parameter where one caller would want a `Text` with custom style, a second caller a `Text` with a `Badge`, a third caller a row of icons.
-- It already has *one* slot (often `trailing` or `content`) and the rest of the parameters are still primitives.
+1. Confirm the component is reusable. For a true single-use composable, do not add slot ceremony.
+2. Mark which regions vary by caller: headline, supporting text, leading visual, trailing visual, actions, body.
+3. Replace caller-controlled primitive content and shape flags with slots.
+4. Add receiver scopes only when the slot is emitted inside a layout whose scope APIs callers should use.
+5. Make absent optional regions nullable (`null`), so the component can omit their containers and spacing.
+6. Put repeated default content or tokens in `XxxDefaults`.
+7. Pair this with the `modifier` rules in `compose-modifier-and-layout-style`.
 
 ## 1. Replace primitive content with `@Composable` slots
 
@@ -40,8 +36,6 @@ fun SettingsRow(
 ) { … }
 ```
 
-This shape *seems* fine because the call sites today fit (`title` is always single-line text, `leadingIcon` is always an `ImageVector`). The problem is the *next* call site: a row with a `Badge` next to the title, a leading slot that's a circular avatar (not an `ImageVector`), a subtitle that's a row of chips. Each forces either a new parameter, a new flag, or a workaround.
-
 ```kotlin
 // ✅ GOOD — every visual region is a slot; the row describes structure, not content
 @Composable
@@ -55,7 +49,7 @@ fun SettingsRow(
 ) { … }
 ```
 
-Call sites stay short because the typical content is a one-liner:
+Call sites stay short when the typical content is a one-liner:
 
 ```kotlin
 SettingsRow(
@@ -66,7 +60,7 @@ SettingsRow(
 )
 ```
 
-And the awkward cases that *would* have required new primitive parameters now don't:
+The unusual cases no longer require new component parameters:
 
 ```kotlin
 SettingsRow(
@@ -125,9 +119,7 @@ leadingContent: @Composable () -> Unit = {}
 leadingContent: (@Composable () -> Unit)? = null
 ```
 
-Why: with a nullable slot, the *component* can branch on `leadingContent != null` and skip the slot's container, spacing, padding entirely. With an empty default, the layout still allocates the slot — sometimes you see a stray padding or spacer around content that turned out to be nothing. The nullable form makes the "absent" case structurally distinct, which is almost always what you want.
-
-The trade-off: callers who pass an explicit empty `{}` to silence a slot now have to pass `null` or omit the argument. That's the right answer either way — they shouldn't be passing `{}`.
+With a nullable slot, the component can branch on `leadingContent != null` and skip the slot's container, spacing, and padding entirely. With an empty default, the layout often still allocates space for absent content.
 
 ## 4. Defaults live in `XxxDefaults`
 

--- a/skills/compose-stability-diagnostics/SKILL.md
+++ b/skills/compose-stability-diagnostics/SKILL.md
@@ -7,18 +7,20 @@ description: Use when writing or reviewing Jetpack Compose parameter stability, 
 
 ## Core principle
 
-Compose performance problems from parameters are about **whether inputs compare cheaply and predictably across recompositions**. With Kotlin 2.0.20+ strong skipping is enabled by default, so unstable parameters no longer automatically make restartable composables non-skippable. That does not make stability irrelevant: unstable parameters are compared by instance identity (`===`), stable parameters by equality (`equals`), and churny instances can still defeat skipping.
+Compose parameter fixes start from evidence. First identify the compiler mode and the parameter comparison behavior, then change the model or call site that is actually defeating skipping.
 
-First identify the compiler mode you are on, then read reports in that context.
+With Kotlin 2.0.20+ strong skipping is enabled by default. Unstable parameters no longer automatically make restartable composables non-skippable, but unstable parameters compare by instance identity (`===`) while stable parameters compare by equality (`equals`). Churny unstable instances can still defeat skipping.
 
-## When to use this skill
+## Diagnostic procedure
 
-- A composable or screen recomposes more than expected and parameter churn is suspected.
-- A UI-state/model class is passed to composables and contains `List`, `Set`, `Map`, ranges, Java time/money types, or third-party types.
-- `composables.txt` / `classes.txt` shows unstable parameters or non-skippable composables.
-- A project uses Kotlin < 2.0.20, disables strong skipping, or has old Compose compiler report guidance.
+1. Confirm the symptom: recomposition counts, compiler report output, or a suspected churny parameter.
+2. Identify compiler mode: Kotlin/Compose compiler version and whether strong skipping is enabled.
+3. Generate or read the Compose compiler reports for the shipped variant.
+4. For each suspicious parameter, decide whether the problem is stability semantics, instance churn, or a caller-created lambda/derived value.
+5. Apply the lightest fix that makes the type/call site truthful.
+6. Re-measure the same interaction or re-read the same report before claiming the issue is fixed.
 
-## 1. Start with strong skipping
+## 1. Interpret strong skipping first
 
 On Kotlin 2.0.20+, strong skipping is enabled by default. In that mode:
 
@@ -27,7 +29,7 @@ On Kotlin 2.0.20+, strong skipping is enabled by default. In that mode:
 - Unstable parameters compare with instance equality (`===`).
 - Lambdas inside composables are automatically remembered based on captures.
 
-That means the question changes from "is this composable skippable at all?" to "will these parameters compare the way I expect, and are callers creating new unstable instances every frame?"
+Ask: "will these parameters compare the way I expect, and are callers creating new unstable instances every frame?"
 
 For older compiler setups or strong skipping disabled, the legacy rule still matters: a restartable composable with unstable parameters may be restartable but not skippable.
 
@@ -67,13 +69,13 @@ Key files:
 | `<module>-composables.csv` | Same data in sortable form |
 | `<module>-module.json` | Aggregate metrics |
 
-## 3. Fix stability where semantics need it
+## 3. Fix only the proven parameter problem
 
 Pick the lightest fix that makes the type's immutability or equality semantics true.
 
 ### Immutable collections
 
-`kotlin.collections.List` is an interface; Compose cannot know the runtime implementation is immutable. Prefer `kotlinx.collections.immutable` at UI-state boundaries:
+If reports show collection interfaces on UI state, prefer `kotlinx.collections.immutable` at UI-state boundaries:
 
 ```kotlin
 // Before: unstable collection interfaces
@@ -97,7 +99,7 @@ Do not annotate to silence a report. A false stability promise can produce stale
 
 ### Third-party immutable types
 
-For types you cannot annotate, use `stabilityConfigurationFiles`:
+For types you cannot annotate but can truthfully treat as immutable, use `stabilityConfigurationFiles`:
 
 ```kotlin
 composeCompiler {
@@ -118,7 +120,7 @@ Only list types you are willing to promise are immutable. Do not list mutable ty
 
 ## 4. Stabilize lazy item inputs
 
-Lazy list items recompose when their lambda inputs change identity, even if the visible data is unchanged.
+When lazy item recomposition comes from call-site churn, stabilize the values passed to each item instead of annotating models blindly.
 
 Hoist and remember per-item inputs that are stable for the item's lifetime:
 

--- a/skills/kotlin-multiplatform-expect-actual/SKILL.md
+++ b/skills/kotlin-multiplatform-expect-actual/SKILL.md
@@ -9,15 +9,14 @@ description: Use when designing Kotlin Multiplatform expect/actual or interface 
 
 Keep common APIs semantic and stable. Put platform mechanics behind small `expect`/`actual` declarations or interfaces, and keep Android/iOS/Desktop details out of `commonMain`.
 
-## When to use this skill
+## Boundary procedure
 
-Use this when common code needs:
-
-- Permissions, settings, intents, share sheets, deep links, haptics, biometrics, or clipboard.
-- Files, paths, clocks, locale, network reachability, sensors, crypto, media, maps, camera, native SDKs, or platform services.
-- Native platform views, controllers, or Compose Multiplatform interop.
-- Different implementation details on Android, iOS, Desktop, or Wasm while preserving one shared call site.
-- A decision between `expect/actual`, dependency injection, interfaces, or separate platform code.
+1. Name the product capability in common terms: share text, read clipboard, request haptic feedback, resolve current region.
+2. Check whether common callers need fakes, injected dependencies, lifecycle ownership, or runtime implementation choice.
+3. Pick the smallest boundary from the table below.
+4. Keep the common signature free of platform types and platform vocabulary.
+5. Put business branching in common code; keep actuals/platform bindings as translation layers.
+6. Validate by compiling every affected source set and testing common code with a fake where possible.
 
 ## Choose the boundary
 
@@ -31,7 +30,7 @@ Use this when common code needs:
 
 ## Keep common APIs semantic
 
-Common code should describe what the product needs, not how the platform does it:
+Write common APIs so callers describe intent, not platform mechanics:
 
 ```kotlin
 // GOOD: common API is semantic
@@ -43,11 +42,11 @@ expect fun currentRegion(): Region
 expect fun currentRegionFromAndroidLocale(context: Context): Region
 ```
 
-The Android actual can use `Locale` APIs. The iOS actual can use Foundation APIs. Callers should not know.
+The Android actual can use `Locale` APIs. The iOS actual can use Foundation APIs. Common callers should not know.
 
 ## Keep actuals thin
 
-Actual implementations should translate the semantic API into platform calls. If the operation needs an Activity, view controller, lifecycle owner, DI, or fakes, prefer an interface supplied by platform code instead of an `expect class`:
+Actual implementations should translate the semantic API into platform calls. If the operation needs an Activity, view controller, lifecycle owner, DI, or fakes, stop and use an interface supplied by platform code instead of an `expect class`:
 
 ```kotlin
 // commonMain
@@ -70,7 +69,7 @@ class AndroidShareSheet(
 }
 ```
 
-The Android implementation is explicitly Activity-owned. A generic `Context` may need `FLAG_ACTIVITY_NEW_TASK` and usually hides the UI lifecycle requirement. Define what `suspend` means: for many platform UI actions it means "the sheet was launched", not "the user completed sharing."
+The Android implementation is explicitly Activity-owned. A generic `Context` often hides the UI lifecycle requirement. Define what `suspend` means: for many platform UI actions it means "the sheet was launched", not "the user completed sharing."
 
 If the actual starts accumulating business rules, move those rules back to common code and leave only platform translation in the actual.
 
@@ -88,12 +87,14 @@ Platform modules bind `Clipboard` to Android/iOS implementations. Common tests u
 
 ## Compose-specific guidance
 
-- Keep platform-specific Composables at leaf nodes.
-- Pass `Modifier` through every expected Composable that emits UI.
-- Avoid platform types in `commonMain` signatures (`Context`, `Activity`, Android resource IDs, `Uri`, `Bundle`, `UIViewController`, `NSBundle`, platform permission enums, etc.).
-- If native view lifecycle matters, hide it inside the platform actual and use the right interop container (`AndroidView`, `UIKitView`, etc.).
-- Do not launch platform work directly from a Composable body. Use `remember`, `LaunchedEffect`, `DisposableEffect`, and stable keys inside actual Composables just as you would in common Compose code.
-- Make previews/tests use common plain UI composables with fake platform services where possible.
+When shared UI reaches a platform leaf:
+
+1. Keep platform-specific composables at leaf nodes.
+2. Pass `Modifier` through every expected composable that emits UI.
+3. Reject platform types in `commonMain` signatures (`Context`, `Activity`, Android resource IDs, `Uri`, `Bundle`, `UIViewController`, `NSBundle`, platform permission enums, etc.).
+4. Hide native view lifecycle inside the platform actual and use the right interop container (`AndroidView`, `UIKitView`, etc.).
+5. Do not launch platform work directly from a composable body. Use `remember`, `LaunchedEffect`, `DisposableEffect`, and stable keys inside actual composables just as you would in common Compose code.
+6. Preview/test the common plain UI composable with fake platform services where possible.
 
 ## Common mistakes
 
@@ -105,6 +106,7 @@ Platform modules bind `Clipboard` to Android/iOS implementations. Common tests u
 | One huge `Platform` expect object | Split by capability: `Clipboard`, `ShareSheet`, `Haptics` |
 | Platform UI leaks high in the tree | Push platform-specific Composable to a leaf |
 | No fakeable boundary for common tests | Use an interface instead of direct `expect` call |
+| Only one target compiles after the change | Compile all affected source sets before finishing |
 
 ## Red flags during review
 

--- a/skills/kotlin-types-value-class/SKILL.md
+++ b/skills/kotlin-types-value-class/SKILL.md
@@ -7,14 +7,15 @@ description: Use when writing or reviewing Kotlin type declarations to choose @J
 
 ## Core principle
 
-Prefer `@JvmInline value class` for single-field types that carry domain meaning. Data classes are for aggregating multiple fields. A value class gives you type safety (you can't mix up `UserId` and `String`) without the allocation overhead of a data class.
+Prefer `@JvmInline value class` for single-field types that carry domain meaning. Data classes are for aggregating multiple fields.
 
-## When to use this skill
+## Review procedure
 
-- Writing a new Kotlin type that wraps a single value
-- Reviewing a data class that has only one property
-- Seeing primitive types (`String`, `Long`, `Int`, etc.) used where a domain type would prevent misuse
-- Compose compiler reports showing unstable parameters that could be value classes
+1. Find single-property wrappers, primitive-heavy APIs, and `@Immutable` wrappers in UI state.
+2. Decide whether the single value is a real domain distinction. If not, keep the primitive or use a typealias.
+3. Check whether replacing the type changes equality, serialization, Java interop, or hot-path boxing.
+4. Convert only when the domain meaning is clear and the contract changes are acceptable.
+5. Re-run the affected compiler/tests; for Compose performance work, re-check compiler reports or recomposition evidence.
 
 ## Decision flow
 
@@ -24,7 +25,7 @@ Prefer `@JvmInline value class` for single-field types that carry domain meaning
 | Single field + no domain meaning (just grouping) | Type alias or keep the primitive |
 | Multiple fields | Data class |
 | Needs custom `equals`/`hashCode` beyond the wrapped value | Data class (value classes delegate to the underlying type) |
-| Used as a generic type argument or nullable in hot paths | Data class or primitive (autoboxing cost) |
+| Used as a generic type argument or nullable in a proven hot path | Data class or primitive |
 
 ```kotlin
 // GOOD: domain-meaningful single field
@@ -32,9 +33,8 @@ Prefer `@JvmInline value class` for single-field types that carry domain meaning
 @JvmInline value class EmailAddress(val value: String)
 @JvmInline value class Percentage(val value: Float)
 
-// BAD: data class wrapping a single field
-data class UserId(val value: String) // unnecessary allocation
-data class EmailAddress(val value: String) // type safety without the overhead is available
+// BAD: data class wrapping a single domain field
+data class UserId(val value: String)
 
 // BAD: value class with no domain meaning
 @JvmInline value class Wrapper(val value: String) // just use the String, or a type alias
@@ -45,38 +45,39 @@ data class EmailAddress(val value: String) // type safety without the overhead i
 // Use a data class if you need different equality semantics
 ```
 
-## Compose stability
+## Compose stability procedure
 
-`@JvmInline value class` is treated as `Stable` by the Compose compiler when its underlying type is stable (primitives, `String`, and other stable types). This means:
+When a Compose report points at a single-field wrapper:
 
-- Value classes passed as composable parameters avoid "unstable parameter" warnings
-- No need for `@Immutable` annotations at Compose boundaries when wrapping primitives or strings
-- Replacing single-field data classes with value classes at UI boundaries improves skippability
+1. Confirm the underlying type is stable (`String`, primitives, or another stable type).
+2. Prefer a value class over `@Immutable` on a wrapper whose only job is type distinction.
+3. Do not change public serialization/API contracts just to silence a report.
 
 ```kotlin
-// Before: data class wrapping a single field
-data class UiState(val userId: String) // works, but allocates a wrapper object
+// Before: primitive value can be mixed up with other strings
+data class UiState(val userId: String)
 
-// After: value class is stable and zero-allocation at runtime
+// After: domain type is stable at the Compose boundary
 @JvmInline value class UserId(val value: String)
 data class UiState(val userId: UserId)
 ```
 
-## Gotchas
+## Refactor checks
 
-- **Autoboxing**: Value classes are unboxed at compile time but boxed (allocated) when used as nullable (`UserId?`), generic type arguments (`List<UserId>`), or vararg parameters. In hot paths these allocations matter; in most code they don't.
-- **No backing fields**: You cannot use `init` blocks, `lateinit`, or delegated properties like `by lazy`. The class body is extremely constrained — only the single constructor parameter exists.
-- **No data-class conveniences**: No `copy()`, no `component1()` for destructuring. If you need these, use a data class. You *can* override `toString()` in a value class, but the default is `ClassName(fieldName=value)` — it does not delegate to the underlying type's `toString()`. Override it yourself if you need a different representation.
-- **No custom equals/hashCode**: These always delegate to the underlying type. Need custom equality → use a data class.
-- **when exhaustiveness**: Sealed hierarchies of value classes work differently than data class hierarchies. Test `when` branches carefully.
-- **Serialization semantics**: With kotlinx.serialization, a `@Serializable data class A(val value: String)` serializes as `{"value":"..."}`, but a `@Serializable value class A(val value: String)` serializes as the underlying value (`"..."`). Replacing a single-field data class with a value class is a breaking change for your API/JSON contract.
-- **Serialization**: Some serialization frameworks need explicit support for value classes (e.g., kotlinx.serialization's `@Serializable` works, but Jackson may need configuration).
-- **Interoperability**: From Java, value classes appear as their underlying type. Java callers bypass the type-safety wrapper.
-- **Reflection and runtime erasure**: When passed as `Any` or used in generic contexts, value classes box into a synthetic wrapper class. Java reflection sees mangled method signatures, and frameworks that rely on raw runtime types (some ORMs, DI containers, or serializers) may see the underlying type rather than the value class.
+Before replacing an existing wrapper, check the contract that callers observe:
 
-## Packing multiple values
+| Check | Action |
+|---|---|
+| JSON/API format matters | Verify serialization. `@Serializable data class A(val value: String)` encodes as an object; a value class encodes as the wrapped value. |
+| Custom equality or hashing is required | Keep a data class. Value-class equality follows the wrapped value. |
+| Callers use `copy()` or destructuring | Keep a data class or update callers deliberately. Value classes do not provide data-class conveniences. |
+| Java or reflection-heavy framework boundary | Verify interop. Java callers see the underlying type; generic/`Any` use boxes. |
+| Nullable/generic/vararg hot path | Measure before converting; those uses box. |
+| Constructor body, `lateinit`, delegated properties, backing fields | Keep a data class or redesign; value classes only store the constructor value. |
 
-A value class can only declare one field, but Compose provides `packFloats`, `packInts`, and matching `unpack*` functions in `androidx.compose.ui.util` to store multiple primitives in a single `Long`. This lets you represent composite values (e.g., a 2D point, size, or padding) as a zero-allocation value class instead of a multi-field data class.
+## Packing multiple values only after evidence
+
+Do not replace a clear multi-field data class with bit-packing unless profiling shows allocation cost on a hot path. If needed, Compose provides `packFloats`, `packInts`, and matching `unpack*` functions in `androidx.compose.ui.util`:
 
 ```kotlin
 @JvmInline value class Offset(val packedValue: Long)
@@ -86,9 +87,6 @@ val Offset.x: Float get() = unpackFloat1(packedValue)
 val Offset.y: Float get() = unpackFloat2(packedValue)
 ```
 
-- **Only use this in performance-critical paths** — manual bit-packing is error-prone. A data class is simpler and safer for most UI types.
-- **Available in `androidx.compose.ui.util`** — `packFloats`, `packInts`, `unpackFloat1`, `unpackFloat2`, `unpackInt1`, `unpackInt2`.
-
 ## Common mistakes
 
 | Mistake | Fix |
@@ -96,8 +94,8 @@ val Offset.y: Float get() = unpackFloat2(packedValue)
 | Data class wrapping a single domain field | Replace with `@JvmInline value class` |
 | Value class with no domain meaning (just a wrapper) | Use a type alias or the primitive directly |
 | Value class needing custom equality | Use a data class instead |
-| Value class as generic type argument in hot path | Accept autoboxing cost or use the primitive |
-| `@Immutable` annotation on a type that could be a value class | Replace with value class — it's Stable by default |
+| Value class as generic type argument in a hot path | Measure boxing cost; keep the primitive/data class if it matters |
+| `@Immutable` annotation on a type that could be a value class | Replace with a value class when the underlying type is stable |
 | Forgetting `@JvmInline` annotation | Always pair `value class` with `@JvmInline` for single-field classes |
 
 ## Red flags during review
@@ -113,6 +111,7 @@ val Offset.y: Float get() = unpackFloat2(packedValue)
 - The type needs custom `equals`/`hashCode` → data class
 - The type is used heavily as a nullable or generic in performance-critical code → measure autoboxing cost first
 - The project does not need the type-safety distinction → a type alias or primitive is sufficient
+- The replacement would silently change JSON, Java, reflection, or framework behavior
 
 ## Related
 


### PR DESCRIPTION
## Summary

- Reframe selected skills around explicit review and diagnostic procedures
- Turn reference-heavy value class and KMP guidance into decision/check workflows
- Keep deeper Compose animation, slot API, and stability details scoped to execution paths

## Impact

This keeps the skill content focused on what an agent should do during reviews and edits, rather than acting primarily as a knowledge store.

## Validation

- `npm run lint`
- `git diff --check HEAD~1..HEAD`