### PR TITLE
Add OpenCode plugin support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,6 +79,7 @@ jobs:
         run: |
           set -euo pipefail
 
+          jq . package.json
           jq . .claude-plugin/plugin.json
           jq . .claude-plugin/marketplace.json
           jq . .codex-plugin/plugin.json
@@ -96,12 +97,12 @@ jobs:
 
           git diff --check
 
-          if git diff --quiet -- .claude-plugin/plugin.json .codex-plugin/plugin.json; then
+          if git diff --quiet -- package.json .claude-plugin/plugin.json .codex-plugin/plugin.json; then
             echo "has_changes=false" >> "$GITHUB_OUTPUT"
             echo "No manifest version changes needed."
           else
             echo "has_changes=true" >> "$GITHUB_OUTPUT"
-            git diff -- .claude-plugin/plugin.json .codex-plugin/plugin.json
+            git diff -- package.json .claude-plugin/plugin.json .codex-plugin/plugin.json
           fi
 
       - name: Stop before publishing
@@ -122,7 +123,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          git add .claude-plugin/plugin.json .codex-plugin/plugin.json
+          git add package.json .claude-plugin/plugin.json .codex-plugin/plugin.json
           git commit -m "Bump version to $VERSION"
           git push origin HEAD:main
 

--- a/.opencode/INSTALL.md
+++ b/.opencode/INSTALL.md
@@ -1,0 +1,60 @@
+# Installing Chris Banes Skills for OpenCode
+
+## Prerequisites
+
+- [OpenCode](https://opencode.ai) installed
+
+## Installation
+
+Add `chrisbanes-skills` to the `plugin` array in your `opencode.json` file, either globally or in a project:
+
+```json
+{
+  "plugin": ["chrisbanes-skills@git+https://github.com/chrisbanes/skills.git"]
+}
+```
+
+Restart OpenCode. The plugin installs through OpenCode's plugin manager, registers the repository's skills, and adds short routing guidance for Kotlin, Android, JVM, and Jetpack Compose tasks.
+
+## Verify
+
+Use OpenCode's native `skill` tool to list skills, or ask a routing question such as:
+
+```text
+Which Chris Banes skill should I use to review this Compose state model?
+```
+
+For broad Kotlin, Android, JVM, or Jetpack Compose tasks, the agent should start with `using-chrisbanes-skills` and then load the focused skill for the task.
+
+OpenCode uses its own plugin install. If you also use Claude Code, Codex, or another harness, install this skills repo separately for each one.
+
+## Updating
+
+OpenCode installs git-backed plugin specs through its plugin manager. Some OpenCode and Bun versions pin resolved git dependencies in a lockfile or cache, so a restart may not pick up the newest commit. If updates do not appear, clear OpenCode's package cache or reinstall the plugin.
+
+To pin a specific release tag:
+
+```json
+{
+  "plugin": ["chrisbanes-skills@git+https://github.com/chrisbanes/skills.git#2026.7.6"]
+}
+```
+
+## Troubleshooting
+
+### Plugin not loading
+
+1. Check logs: `opencode run --print-logs "hello" 2>&1 | grep -i chrisbanes-skills`
+2. Verify the plugin line in your `opencode.json`
+3. Make sure you are running a recent version of OpenCode
+
+### Skills not found
+
+1. Use the native `skill` tool to list discovered skills
+2. Check that the plugin is loading
+3. Restart OpenCode after changing plugin configuration
+
+## Getting Help
+
+- Report issues: https://github.com/chrisbanes/skills/issues
+- Repository: https://github.com/chrisbanes/skills

--- a/.opencode/plugins/chrisbanes-skills.js
+++ b/.opencode/plugins/chrisbanes-skills.js
@@ -1,0 +1,65 @@
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const skillsDir = path.resolve(__dirname, "../../skills");
+const guidanceMarker = "CHRISBANES_SKILLS_OPENCODE_GUIDANCE";
+const guidance = `<${guidanceMarker}>
+Chris Banes skills are available in OpenCode. Use OpenCode's native skill tool to load focused guidance. For broad Kotlin, Android, JVM, or Jetpack Compose tasks, start by loading the using-chrisbanes-skills skill.
+</${guidanceMarker}>`;
+
+const logWarning = async (client, message) => {
+  try {
+    await client?.app?.log?.({
+      body: {
+        service: "chrisbanes-skills",
+        level: "warn",
+        message,
+      },
+    });
+  } catch {
+    // Logging must never prevent OpenCode from starting.
+  }
+};
+
+const ensureSkillPath = (config) => {
+  config.skills = config.skills || {};
+  config.skills.paths = config.skills.paths || [];
+
+  if (!config.skills.paths.includes(skillsDir)) {
+    config.skills.paths.push(skillsDir);
+  }
+};
+
+const injectGuidance = (messages) => {
+  if (!Array.isArray(messages)) return;
+
+  const firstUser = messages.find((message) => message?.info?.role === "user");
+  if (!firstUser || !Array.isArray(firstUser.parts) || firstUser.parts.length === 0) return;
+
+  const alreadyInjected = firstUser.parts.some(
+    (part) => part?.type === "text" && part.text?.includes(guidanceMarker),
+  );
+  if (alreadyInjected) return;
+
+  const referencePart = firstUser.parts[0];
+  firstUser.parts.unshift({ ...referencePart, type: "text", text: guidance });
+};
+
+export const ChrisBanesSkillsPlugin = async ({ client }) => {
+  return {
+    config: async (config) => {
+      if (!fs.existsSync(skillsDir)) {
+        await logWarning(client, `Skills directory not found: ${skillsDir}`);
+        return;
+      }
+
+      ensureSkillPath(config);
+    },
+
+    "experimental.chat.messages.transform": async (_input, output) => {
+      injectGuidance(output?.messages);
+    },
+  };
+};

--- a/README.md
+++ b/README.md
@@ -24,6 +24,16 @@ codex plugin marketplace add chrisbanes/skills --ref main
 codex plugin add chrisbanes-skills@chrisbanes-skills
 ```
 
+Or install as an OpenCode plugin:
+
+```json
+{
+  "plugin": ["chrisbanes-skills@git+https://github.com/chrisbanes/skills.git"]
+}
+```
+
+See [`.opencode/INSTALL.md`](.opencode/INSTALL.md) for details.
+
 ## Skills
 
 ### Start here

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,13 @@
 {
-  "name": "skills-lint",
+  "name": "chrisbanes-skills",
+  "version": "2026.7.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "skills-lint",
+      "name": "chrisbanes-skills",
+      "version": "2026.7.6",
+      "license": "Apache-2.0",
       "devDependencies": {
         "remark": "^15.0.1",
         "remark-cli": "^12.0.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,11 @@
 {
-  "name": "skills-lint",
-  "private": true,
+  "name": "chrisbanes-skills",
+  "version": "2026.7.6",
+  "description": "Skills for Kotlin, Android, JVM, and Jetpack Compose development by Chris Banes.",
   "type": "module",
+  "main": ".opencode/plugins/chrisbanes-skills.js",
+  "repository": "https://github.com/chrisbanes/skills",
+  "license": "Apache-2.0",
   "scripts": {
     "lint": "remark --frail skills/"
   },

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -9,6 +9,7 @@ import sys
 
 VERSION_PATTERN = re.compile(r"^[0-9]{4}\.([1-9]|1[0-2])\.([1-9]|[12][0-9]|3[01])$")
 PLUGIN_NAME = "chrisbanes-skills"
+OPENCODE_MAIN = ".opencode/plugins/chrisbanes-skills.js"
 
 
 def validate_version(version):
@@ -44,13 +45,16 @@ def validate_manifests(root, version):
 
     claude = read_json(root / ".claude-plugin" / "plugin.json")
     codex = read_json(root / ".codex-plugin" / "plugin.json")
+    package = read_json(root / "package.json")
     claude_marketplace = read_json(root / ".claude-plugin" / "marketplace.json")
     codex_marketplace = read_json(root / ".agents" / "plugins" / "marketplace.json")
 
     require(claude.get("name") == PLUGIN_NAME, "Claude plugin name must be chrisbanes-skills")
     require(codex.get("name") == PLUGIN_NAME, "Codex plugin name must be chrisbanes-skills")
+    require(package.get("name") == PLUGIN_NAME, "OpenCode package name must be chrisbanes-skills")
     require(claude.get("version") == version, f"Claude plugin version mismatch: {claude.get('version')}")
     require(codex.get("version") == version, f"Codex plugin version mismatch: {codex.get('version')}")
+    require(package.get("version") == version, f"OpenCode package version mismatch: {package.get('version')}")
     require(
         claude_marketplace.get("name") == PLUGIN_NAME,
         "Claude marketplace name must be chrisbanes-skills",
@@ -60,12 +64,14 @@ def validate_manifests(root, version):
         "Codex marketplace name must be chrisbanes-skills",
     )
     require(codex.get("skills") == "./skills/", "Codex plugin skills path must be ./skills/")
+    require(package.get("main") == OPENCODE_MAIN, f"OpenCode package main must be {OPENCODE_MAIN}")
 
 
 def plugin_manifest_paths(root):
     return [
         root / ".claude-plugin" / "plugin.json",
         root / ".codex-plugin" / "plugin.json",
+        root / "package.json",
     ]
 
 

--- a/scripts/test_release.py
+++ b/scripts/test_release.py
@@ -43,6 +43,14 @@ class ReleaseScriptTest(unittest.TestCase):
                 {"name": "chrisbanes-skills", "version": "2026.6.16", "skills": "./skills/"},
             )
             self.write_json(
+                root / "package.json",
+                {
+                    "name": "chrisbanes-skills",
+                    "version": "2026.6.16",
+                    "main": ".opencode/plugins/chrisbanes-skills.js",
+                },
+            )
+            self.write_json(
                 root / ".claude-plugin" / "marketplace.json",
                 {"name": "chrisbanes-skills"},
             )
@@ -56,8 +64,76 @@ class ReleaseScriptTest(unittest.TestCase):
 
             claude = self.read_json(root / ".claude-plugin" / "plugin.json")
             codex = self.read_json(root / ".codex-plugin" / "plugin.json")
+            package = self.read_json(root / "package.json")
             self.assertEqual(claude["version"], "2026.6.17")
             self.assertEqual(codex["version"], "2026.6.17")
+            self.assertEqual(package["version"], "2026.6.17")
+
+    def test_validate_manifests_rejects_opencode_package_name_mismatch(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            self.write_valid_manifests(root)
+            package_path = root / "package.json"
+            package = self.read_json(package_path)
+            package["name"] = "wrong-name"
+            self.write_json(package_path, package)
+
+            with self.assertRaisesRegex(ValueError, "OpenCode package name"):
+                self.release.validate_manifests(root, "2026.6.17")
+
+    def test_validate_manifests_rejects_opencode_package_version_mismatch(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            self.write_valid_manifests(root)
+            package_path = root / "package.json"
+            package = self.read_json(package_path)
+            package["version"] = "2026.6.16"
+            self.write_json(package_path, package)
+
+            with self.assertRaisesRegex(ValueError, "OpenCode package version"):
+                self.release.validate_manifests(root, "2026.6.17")
+
+    def test_validate_manifests_rejects_opencode_package_main_mismatch(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            self.write_valid_manifests(root)
+            package_path = root / "package.json"
+            package = self.read_json(package_path)
+            package["main"] = "index.js"
+            self.write_json(package_path, package)
+
+            with self.assertRaisesRegex(ValueError, "OpenCode package main"):
+                self.release.validate_manifests(root, "2026.6.17")
+
+    def write_valid_manifests(self, root, version="2026.6.17"):
+        (root / ".claude-plugin").mkdir()
+        (root / ".codex-plugin").mkdir()
+        (root / ".agents" / "plugins").mkdir(parents=True)
+
+        self.write_json(
+            root / ".claude-plugin" / "plugin.json",
+            {"name": "chrisbanes-skills", "version": version},
+        )
+        self.write_json(
+            root / ".codex-plugin" / "plugin.json",
+            {"name": "chrisbanes-skills", "version": version, "skills": "./skills/"},
+        )
+        self.write_json(
+            root / "package.json",
+            {
+                "name": "chrisbanes-skills",
+                "version": version,
+                "main": ".opencode/plugins/chrisbanes-skills.js",
+            },
+        )
+        self.write_json(
+            root / ".claude-plugin" / "marketplace.json",
+            {"name": "chrisbanes-skills"},
+        )
+        self.write_json(
+            root / ".agents" / "plugins" / "marketplace.json",
+            {"name": "chrisbanes-skills"},
+        )
 
     @staticmethod
     def write_json(path, value):


### PR DESCRIPTION
## Summary
- Add an OpenCode plugin entry point that registers this repo's skills and injects tiny routing guidance.
- Add OpenCode install docs and README instructions.
- Include root package metadata in release validation, tests, and workflow version bumps.

## Test Plan
- [x] npm run lint
- [x] jq . package.json .claude-plugin/plugin.json .codex-plugin/plugin.json .claude-plugin/marketplace.json .agents/plugins/marketplace.json >/dev/null
- [x] python3 -m unittest scripts.test_release
- [x] node -e "import('./.opencode/plugins/chrisbanes-skills.js').then((m) => { if (!m.ChrisBanesSkillsPlugin) process.exit(1); console.log('ok'); })"
- [x] python3 scripts/release.py validate-manifests 2026.7.6
- [x] git diff --check