### PR TITLE
Add Kotlin function ownership skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,17 @@ Instructions for AI agents (Claude Code, etc.) working in this repo.
 1. **Update `README.md`** — keep the "Skills" list in sync. Each entry links to the skill's `SKILL.md` and summarises what it covers. If you add a skill and don't update the README, the change is incomplete.
 2. **Do not update plugin or skill versions unless explicitly asked.** If the user asks for a release/version bump, use the release system below.
 
+## Skill authoring checklist
+
+Before considering any skill addition or edit complete, verify:
+
+1. The frontmatter description starts with `Use when` and contains concrete trigger conditions only.
+2. The body states one core principle and gives ordered, imperative steps.
+3. Tables support rather than replace the procedure; failed checks specify the next action, and the procedure has an explicit finish gate.
+4. Examples are minimal and behavior-preserving; exceptions and non-applicable cases are explicit.
+5. RED/GREEN agent scenarios test the change, including a novel case and a counterexample against over-application.
+6. README and router integration are updated where applicable, `npm run lint` passes, and versions remain unchanged unless requested.
+
 ## Release/version system
 
 - Use SemVer-compatible CalVer: `YYYY.M.D`.

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ See [`.opencode/INSTALL.md`](.opencode/INSTALL.md) for details.
 - [`kotlin-coroutines-structured-concurrency`](skills/kotlin-coroutines-structured-concurrency/SKILL.md) — review coroutine scope ownership, init and fire-and-forget boundaries, cancellation handling, and blocking boundaries.
 - [`kotlin-control-flow`](skills/kotlin-control-flow/SKILL.md) — write and review Kotlin branching with subject `when`, guard conditions, sealed exhaustiveness, smart casts, nullable branching, and early returns.
 - [`kotlin-flow-state-event-modeling`](skills/kotlin-flow-state-event-modeling/SKILL.md) — model `StateFlow`, `SharedFlow`, `Channel`, `stateIn`, sharing policy, and one-shot events without lossy defaults.
+- [`kotlin-functions`](skills/kotlin-functions/SKILL.md) - choose the correct owner for member, top-level, extension, factory, and service functions; avoid extensions on primitive and common types by default.
 - [`kotlin-multiplatform-expect-actual`](skills/kotlin-multiplatform-expect-actual/SKILL.md) — design semantic expect/actual and interface boundaries for Kotlin Multiplatform platform interop.
 - [`kotlin-types-value-class`](skills/kotlin-types-value-class/SKILL.md) — choose `@JvmInline value class` over data class for single-field domain types, including Compose stability implications.
 

--- a/skills/kotlin-functions/SKILL.md
+++ b/skills/kotlin-functions/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: kotlin-functions
+description: Use when choosing Kotlin member, top-level, extension, factory, or service functions for String, primitive, collection, Flow, framework, or third-party receivers.
+---
+
+# Kotlin function ownership
+
+## Core principle
+
+Put a function on the smallest accurate semantic owner. Extension syntax changes call shape, not ownership.
+
+Reject primitive, common, and library-owned extensions by default: they create false ownership, domain pollution, noisy completion/imports, and collisions.
+
+## Procedure
+
+Apply in order.
+
+### 1. Name the semantic owner
+
+Name the operation and the concept that owns it. If ownership is unclear, stop before selecting syntax.
+
+### 2. Reject a misleading receiver early
+
+For `String`, primitives, collections, `Flow`, framework, or third-party receivers, require **all**:
+
+- Narrow `private`/`internal` cohesive scope.
+- Valid for every receiver value.
+- No policy, state, I/O, or dependency.
+- Materially clearer receiver syntax.
+- No better project-owned owner.
+
+Any failure forbids an extension on that receiver; choose a non-extension form in step 3. `private fun <T> MutableList<T>.swap(...)` can pass: it is list-native, policy-free, and algorithm-local.
+
+### 3. Choose the function form
+
+| Meaning | Prefer |
+|---|---|
+| Project-owned intrinsic behavior | Member |
+| Cross-type, stateless operation | Top-level function |
+| Construction or parsing | Target factory or named top-level function |
+| Retained policy, state, I/O, clock, locale, or dependencies | Injected service/collaborator |
+| Type-native operation with a clearer receiver and every step-2 gate passed | Extension |
+
+Use a service/collaborator only when behavior retains policy, state, I/O, clock/locale, or dependencies; otherwise use explicit parameters on a stateless function.
+
+### 4. Move behavior and callers
+
+Move the implementation, then update calls, imports, and function references. Preserve or deprecate public entry points unless this is an explicit breaking release; add non-public migration support only for concrete consumers.
+
+```kotlin
+// Before: String falsely owns UserId construction.
+fun String.toUserId(): UserId = UserId(this)
+
+// After: UserId owns construction and validation.
+@JvmInline
+value class UserId private constructor(val value: String) {
+    companion object {
+        fun parse(raw: String): UserId {
+            val value = raw.trim()
+            require(value.isNotEmpty() && value.all { it.isLetterOrDigit() || it == '_' })
+            return UserId(value)
+        }
+    }
+}
+
+val id = UserId.parse(raw)
+```
+
+### 5. Verify and finish
+
+For every form, check visibility, imports, collisions, and compatibility. For extensions, also check nullable receivers, generics, and future-member precedence. Compile and test; on failure, narrow the API or return to step 1.
+
+## Rationalizations
+
+| “But…” | Counter |
+|---|---|
+| Fluent syntax | Readability does not create ownership. |
+| Kotlin uses extensions | Idiom still requires accurate semantics. |
+| It is private/internal | Scope helps only when every gate passes. |
+| Utility objects are worse | Use a top-level function or target factory. |
+| Default policy is obvious | Time zone/locale defaults are policy; keep them explicit. |
+| Already in the PR | Existing code does not prove ownership. |
+
+## Red flags
+
+- Domain meaning on `String`, numbers, collections, `Flow`, or vendor types.
+- Clock, locale, I/O, policy, or dependencies hidden in an extension.
+
+## Common mistakes
+
+| Mistake | Fix |
+|---|---|
+| `Long.toDisplayDate()` | A formatter owns time-zone/locale policy. |
+| Extension hides parsing | Use `Type.parse(raw)` or a named parser. |
+| Public library-type extension | Reclassify it using steps 1-3. |
+
+## Related
+
+- [`kotlin-types-value-class`](../kotlin-types-value-class/SKILL.md)

--- a/skills/kotlin-functions/SKILL.md
+++ b/skills/kotlin-functions/SKILL.md
@@ -51,15 +51,11 @@ Move the implementation, then update calls, imports, and function references. Pr
 // Before: String falsely owns UserId construction.
 fun String.toUserId(): UserId = UserId(this)
 
-// After: UserId owns construction and validation.
+// After: UserId owns construction.
 @JvmInline
 value class UserId private constructor(val value: String) {
     companion object {
-        fun parse(raw: String): UserId {
-            val value = raw.trim()
-            require(value.isNotEmpty() && value.all { it.isLetterOrDigit() || it == '_' })
-            return UserId(value)
-        }
+        fun parse(raw: String): UserId = UserId(raw)
     }
 }
 

--- a/skills/using-chrisbanes-skills/SKILL.md
+++ b/skills/using-chrisbanes-skills/SKILL.md
@@ -30,6 +30,7 @@ If a request already clearly matches a focused skill, use that skill directly. I
 | Kotlin branching, `when` expressions, guard conditions, sealed type exhaustiveness, smart casts, nullable branching, or complex `if`/`else` chains | [`kotlin-control-flow`](../kotlin-control-flow/SKILL.md) |
 | `StateFlow`, `SharedFlow`, `Channel`, `stateIn`, `SharingStarted`, `.value`, one-shot events, sentinel initial values, or expensive `update` blocks | [`kotlin-flow-state-event-modeling`](../kotlin-flow-state-event-modeling/SKILL.md) |
 | Kotlin Multiplatform platform APIs, source set boundaries, `expect`/`actual`, interfaces for platform services, permissions, files, sensors, native SDKs, or Compose Multiplatform interop | [`kotlin-multiplatform-expect-actual`](../kotlin-multiplatform-expect-actual/SKILL.md) |
+| Kotlin function placement, member vs top-level function, extension functions, factories, primitive receivers, or extensions on String, collections, Flow, framework, or third-party types | [`kotlin-functions`](../kotlin-functions/SKILL.md) |
 | Single-field domain types, primitive obsession, or choosing `@JvmInline value class` vs `data class` | [`kotlin-types-value-class`](../kotlin-types-value-class/SKILL.md) |
 | Polling or shepherding PRs/MRs, triaging review comments, fixing CI failures, or keeping reviews moving | [`shepherd`](../shepherd/SKILL.md) |
 


### PR DESCRIPTION
## Summary
- add procedural guidance for choosing member, top-level, factory, collaborator, and extension functions
- treat extensions on primitive and common types as an anti-pattern by default, with a narrow local exception
- add repository-level acceptance checks for procedural, behavior-tested skills

## Test plan
- [x] `npm run lint`
- [x] `git diff --check origin/main...HEAD`