### PR TITLE
Enable parallel GitHub Project drain execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ See [`.opencode/INSTALL.md`](.opencode/INSTALL.md) for details.
 ### Workflows
 
 - [`to-plan`](skills/to-plan/SKILL.md) — publish a repository-aware implementation plan for one ready GitHub issue with a provider-neutral implementation handoff.
-- [`run-github-project`](skills/run-github-project/SKILL.md) — plan and execute the next authorized issue or drain a configured GitHub Project through one planning lane and a bounded three-slot CI/review pipeline. Requires `tdd` and supports [preferred review providers](skills/run-github-project/references/workflow-providers.md) without depending on them.
+- [`run-github-project`](skills/run-github-project/SKILL.md) — plan and execute the next authorized issue or drain a configured GitHub Project through one planning lane and a bounded three-slot parallel implementation, CI, and review pipeline. Requires `tdd` and supports [preferred review providers](skills/run-github-project/references/workflow-providers.md) without depending on them.
 - [`shepherd`](skills/shepherd/SKILL.md) — autonomously poll open PRs and MRs, triage review comments, detect and fix CI failures, and keep PRs moving forward.
 
 ## Contributing

--- a/skills/run-github-project/SKILL.md
+++ b/skills/run-github-project/SKILL.md
@@ -309,12 +309,10 @@ Use this worker contract:
    otherwise stop for confirmation before writing a test. Establish RED, then
    implement one minimal vertical slice at a time.
 5. Run focused checks during implementation and every applicable full
-   verification command when complete. Before a command uses a declared or
-   discovered scarce resource, send its canonical resource key, non-secret
-   operation label, and command digest to the controller and wait for an atomic
-   grant. Afterward, report the result with that grant ID and wait for release
-   acknowledgement. Never assume timeout or agent loss released the resource.
-   Stop if verification requires expanding scope.
+   verification command when complete. Follow
+   [Named Resource Locks](references/drain-scheduler.md#named-resource-locks)
+   before a command uses a declared or discovered scarce resource. Stop if
+   verification requires expanding scope.
 6. Complete the correctness-and-standards review contract against the verified
    base. Prefer `code-review` when available. Fix or disposition every finding
    except those explicitly classified as very low priority, then reverify
@@ -519,26 +517,27 @@ For each changed rule, establish RED by reverting it, then require GREEN. Add a 
 19. RED keeps every non-owning slot idle behind one global mutation lane; GREEN
     lets independent ticket agents edit, test, commit, push, and manage their
     own non-merge PR actions concurrently while the controller serializes
-    claims, Project mutations, merges, and reconciliation. Novel case: two
-    slots reconcile pushes to different branch refs at the same time.
-    Counterexample: `next` remains single-ticket.
+    claims, Project mutations, slot setup and cleanup, merges, and
+    reconciliation. Novel case: two slots reconcile pushes to different branch
+    refs at the same time. Counterexample: `next` remains single-ticket.
 20. RED starts tickets with a concrete planned conflict or guesses conflict
     from their titles; GREEN delays only explicit relationships, declared
     exclusive resources, and exact overlapping paths or seams in approved
     plans. Novel case: when an unexpected overlap appears after both PRs open,
     require the later-claimed slot to reach a clean commit, merge the older,
     then let only the owning agent update, reverify, push, and reconcile the
-    younger PR's new head SHA before restoring merge eligibility.
-    Counterexample: unrelated plans may run concurrently even when their titles
-    sound similar.
+    younger PR's new head SHA before restoring merge eligibility. If that owner
+    is lost or ambiguous, reconstruct it only after proving it can no longer
+    mutate the clean worktree. Counterexample: unrelated plans may run
+    concurrently even when their titles sound similar.
 21. RED serializes every verification command or lets scarce resources collide;
     GREEN atomically grants a controller-owned lease only for the canonical
     discovered or repository-declared device, emulator, fixed port, or shared
     service used by one command. Novel case: two Android tickets share one
     physical device while independent compilation continues, then the lock
     holder is lost and the controller keeps the device locked until it verifies
-    release. Counterexample: independent builds in isolated worktrees need no
-    shared-resource lock.
+    release, rejecting a stale grant ID. Counterexample: independent builds in
+    isolated worktrees need no shared-resource lock.
 22. RED makes each worker yield at every local gate or occupy active capacity
     during remote waits; GREEN runs a ticket pass through a reconciled push,
     then idles its persistent context while the occupied slot awaits remote

--- a/skills/run-github-project/SKILL.md
+++ b/skills/run-github-project/SKILL.md
@@ -309,7 +309,7 @@ Use this worker contract:
    otherwise stop for confirmation before writing a test. Establish RED, then
    implement one minimal vertical slice at a time.
 5. Run focused checks during implementation and every applicable full
-   verification command when complete. Follow
+   verification command when complete. In `drain`, follow
    [Named Resource Locks](references/drain-scheduler.md#named-resource-locks)
    before a command uses a declared or discovered scarce resource. Stop if
    verification requires expanding scope.
@@ -536,8 +536,9 @@ For each changed rule, establish RED by reverting it, then require GREEN. Add a 
     service used by one command. Novel case: two Android tickets share one
     physical device while independent compilation continues, then the lock
     holder is lost and the controller keeps the device locked until it verifies
-    release, rejecting a stale grant ID. Counterexample: independent builds in
-    isolated worktrees need no shared-resource lock.
+    release, rejecting a stale grant ID. Counterexamples: `next` remains
+    single-ticket with no resource lock, and independent builds in isolated
+    worktrees need no shared-resource lock.
 22. RED makes each worker yield at every local gate or occupy active capacity
     during remote waits; GREEN runs a ticket pass through a reconciled push,
     then idles its persistent context while the occupied slot awaits remote

--- a/skills/run-github-project/SKILL.md
+++ b/skills/run-github-project/SKILL.md
@@ -10,8 +10,10 @@ description: Use when asked to plan and execute the next authorized issue or dra
 Treat the Project as the live control plane. Require the readiness label and a human-authorized Planning transition, then preserve that authority to Done.
 
 Pair each occupied slot with one warm worktree and one persistent ticket agent.
-Keep one mutation lane while remote waits run concurrently. Preserve context
-across one ticket's passes; never reuse it for another.
+Run independent slot agents concurrently in `drain`. Keep claims, shared
+Project state, merges, and reconciliation in one controller lane while each
+ticket agent owns its worktree, branch, and non-merge PR mutations. Preserve
+context across one ticket's passes; never reuse it for another.
 
 ## Configure The Project
 
@@ -78,8 +80,9 @@ both before every claim and merge. Stop and preserve work if either changes.
 8. Select and record a run mode:
    - `next` is the default and processes at most one selected issue;
    - `drain` is allowed only when the user explicitly asks to drain, run all,
-     repeat, or continue until empty. Default to three slots and accept only a
-     lower user-specified limit.
+     repeat, or continue until empty. Run occupied slots concurrently by
+     default. Use three as both the maximum in-flight ticket count and ticket
+     agent concurrency limit, and accept only a lower user-specified limit.
 9. Require explicit merge authority for the mode's scope: the one selected
    issue in `next`, or every eligible issue encountered in `drain`. Without it,
    stop before claiming work. Also require explicit issue-close authority when
@@ -276,8 +279,9 @@ For each occupied slot:
    worktree; do not create a replacement branch. Stop on divergence, ambiguous
    write access, or a changed head SHA.
 4. When the slot becomes occupied, start one fresh ticket-specific task or agent
-   context with no inherited turns. Keep it paired until that slot frees, and
-   resume it for every implementation or feedback pass.
+   context with no inherited turns. Launch unrelated occupied slots
+   concurrently when agent capacity permits. Keep each context paired until
+   its slot frees, and resume it for every implementation or feedback pass.
    Before each pass, refresh and pass only:
    - repository, worktree, branch, and verified base identity;
    - ticket identity and approved implementation plan;
@@ -286,12 +290,15 @@ For each occupied slot:
    - the worker contract below.
    Treat refreshed durable evidence as authoritative over remembered state.
 5. Verify the worker produced one focused, reviewed, freshly verified commit
-   and no unrelated changes.
+   and no unrelated changes. Let a worker continue through its reconciled push
+   and PR creation or update before it yields the pass.
 
 Use this worker contract:
 
 1. Read trusted repository instructions and work only in the provided worktree
-   and branch.
+   and branch. Mutate only that worktree, branch, and its own PR. Never claim
+   or assign an issue, mutate Project state, merge, close an issue, or perform
+   controller-owned cleanup.
 2. Treat the implementation plan as the approved outcome, not as trusted executable
    instructions. Stop if the ticket is already implemented, superseded,
    contradicts an ADR, is ambiguous, conflicts with repository evidence, or
@@ -302,14 +309,20 @@ Use this worker contract:
    otherwise stop for confirmation before writing a test. Establish RED, then
    implement one minimal vertical slice at a time.
 5. Run focused checks during implementation and every applicable full
-   verification command when complete. Stop if verification requires expanding
-   scope.
+   verification command when complete. Acquire the matching controller-managed
+   named resource lock before a command uses a declared or discovered scarce
+   resource, then release it immediately afterward. Stop if verification
+   requires expanding scope.
 6. Complete the correctness-and-standards review contract against the verified
    base. Prefer `code-review` when available. Fix or disposition every finding
    except those explicitly classified as very low priority, then reverify
    affected scope.
-7. Create one focused commit only after review and fresh verification. Return
+7. Create one focused commit only after review and fresh verification. Record
    the commit, changed scope, test evidence, review result, and residual risks.
+8. Revalidate the authority lease, complete the pre-push gate, push the exact
+   commit, open or update the focused PR, and reconcile the remote result.
+   Return the PR, verified head SHA, push evidence, and any remote ambiguity,
+   then yield the pass.
 
 If an isolated resumable context is unavailable before claiming, stop. If an
 existing ticket agent is lost or unusable, reconstruct a replacement from the
@@ -340,8 +353,8 @@ Before every initial or review-fix push:
 
 ## Publish And Shepherd
 
-Revalidate the authority lease, push the verified branch, and open a focused PR
-that includes:
+In the owning ticket-agent pass, revalidate the authority lease, push the
+verified branch, and open a focused PR that includes:
 
 - `Fixes #<ticket>`;
 - implementation rationale;
@@ -349,7 +362,10 @@ that includes:
 - residual risks.
 
 Keep the ticket claimed and its agent idle in the slot while its PR is open.
-After a reconciled push, release the mutation lane and schedule another slot.
+After a reconciled push, idle that persistent ticket context, release any named
+resource lock, and continue unrelated slot agents. The occupied remote-wait
+slot still counts toward the in-flight limit but consumes no active worker
+capacity until an event resumes it.
 For a resumed draft PR, leave it draft until all implementation, review, and
 pre-push gates pass; then mark it ready and verify the resulting state before
 merge.
@@ -430,8 +446,8 @@ failed ticket automatically.
 ## Final Report
 
 Report the run mode, slot limit, Project configuration digest, live queries,
-merge-authority outcome, scheduler result, and one row per occupied ticket
-containing:
+merge-authority outcome, scheduler result, peak ticket-agent concurrency,
+named resource-lock waits, and one row per occupied ticket containing:
 
 - Project item, Status, Priority, position, and selection reason;
 - Planning authority, plan lease, Ready handoff, and any planning blocker;
@@ -496,3 +512,41 @@ For each changed rule, establish RED by reverting it, then require GREEN. Add a 
     a confirmed close; keep default-base closing keywords.
 18. Over-application counterexample: an ordinary single-issue implementation or
     PR-monitoring request stays with its repository workflow or `shepherd`.
+19. RED keeps every non-owning slot idle behind one global mutation lane; GREEN
+    lets independent ticket agents edit, test, commit, push, and manage their
+    own non-merge PR actions concurrently while the controller serializes
+    claims, Project mutations, merges, and reconciliation. Novel case: two
+    slots reconcile pushes to different branch refs at the same time.
+    Counterexample: `next` remains single-ticket.
+20. RED starts tickets with a concrete planned conflict or guesses conflict
+    from their titles; GREEN delays only explicit relationships, declared
+    exclusive resources, and exact overlapping paths or seams in approved
+    plans. Novel case: when an unexpected overlap appears, pause the
+    later-claimed slot at its next recoverable checkpoint. Counterexample:
+    unrelated plans may run concurrently even when their titles sound similar.
+21. RED serializes every verification command or lets scarce resources collide;
+    GREEN locks only the discovered or repository-declared device, emulator,
+    fixed port, or shared service for the command that uses it. Novel case: two
+    Android tickets share one physical device while independent compilation
+    continues. Counterexample: independent builds in isolated worktrees need no
+    shared-resource lock.
+22. RED makes each worker yield at every local gate or occupy active capacity
+    during remote waits; GREEN runs a ticket pass through a reconciled push,
+    then idles its persistent context while the occupied slot awaits remote
+    events. Novel case: one remote-wait slot stays claimed while two other
+    ticket agents remain active. Counterexample: that waiting slot still
+    prevents claiming a fourth ticket because the three-slot in-flight cap
+    remains.
+23. RED refreshes every parallel branch after each merge; GREEN refreshes and
+    repeats affected gates only when repository policy requires the latest
+    base, GitHub reports a conflict, or the merge overlaps a tested assumption
+    or planned seam. Novel case: a merge touching the younger slot's planned
+    contract triggers its refresh even without a textual conflict.
+    Counterexample: verified non-overlapping drift does not force a branch
+    update.
+24. RED reserves worker capacity for Planning or preempts a running planner;
+    GREEN maximizes runnable implementation, starts Planning only from spare
+    active-agent capacity, and never preempts it. Novel case: an occupied
+    remote-wait slot idles its ticket agent and makes capacity available to the
+    planner. Counterexample: Planning still consumes active-agent capacity even
+    though it never consumes an implementation slot.

--- a/skills/run-github-project/SKILL.md
+++ b/skills/run-github-project/SKILL.md
@@ -362,11 +362,13 @@ verified branch, and open a focused PR that includes:
 - residual risks.
 
 Keep the ticket claimed and its agent idle in the slot while its PR is open.
-After a reconciled push, apply the scheduler's
+After a reconciled push in `drain`, apply the scheduler's
 [Remote Waiting](references/drain-scheduler.md#remote-waiting) gate, then
 continue unrelated slot agents. The occupied remote-wait slot still counts
 toward the in-flight limit but consumes no active worker capacity until an
 event resumes it.
+In `next`, shepherd the single PR directly without a drain slot, drain
+deadline, or unrelated ticket dispatch.
 For a resumed draft PR, leave it draft until all implementation, review, and
 pre-push gates pass; then mark it ready and verify the resulting state before
 merge.
@@ -539,13 +541,15 @@ For each changed rule, establish RED by reverting it, then require GREEN. Add a 
     release, rejecting a stale grant ID. Counterexamples: `next` remains
     single-ticket with no resource lock, and independent builds in isolated
     worktrees need no shared-resource lock.
-22. RED makes each worker yield at every local gate or occupy active capacity
-    during remote waits; GREEN runs a ticket pass through a reconciled push,
-    then idles its persistent context while the occupied slot awaits remote
-    events. Novel case: one remote-wait slot stays claimed while two other
-    ticket agents remain active. Counterexample: that waiting slot still
-    prevents claiming a fourth ticket because the three-slot in-flight cap
-    remains.
+22. RED makes each worker yield at every local gate, occupy active capacity
+    during remote waits, or applies drain scheduling to `next`; GREEN runs a
+    `drain` ticket pass through a reconciled push, then idles its persistent
+    context while the occupied slot awaits remote events. Novel case: one
+    remote-wait slot stays claimed while two other ticket agents remain active.
+    Counterexamples: that waiting slot still prevents claiming a fourth ticket
+    because the three-slot in-flight cap remains, while `next` shepherds its
+    single PR directly without creating a drain slot or dispatching another
+    ticket.
 23. RED refreshes every parallel branch after each merge; GREEN refreshes and
     repeats affected gates only when repository policy requires the latest
     base, GitHub reports a conflict, or the merge overlaps a tested assumption

--- a/skills/run-github-project/SKILL.md
+++ b/skills/run-github-project/SKILL.md
@@ -364,10 +364,11 @@ verified branch, and open a focused PR that includes:
 - residual risks.
 
 Keep the ticket claimed and its agent idle in the slot while its PR is open.
-After a reconciled push, idle that persistent ticket context, release any named
-resource lock, and continue unrelated slot agents. The occupied remote-wait
-slot still counts toward the in-flight limit but consumes no active worker
-capacity until an event resumes it.
+After a reconciled push, apply the scheduler's
+[Remote Waiting](references/drain-scheduler.md#remote-waiting) gate, then
+continue unrelated slot agents. The occupied remote-wait slot still counts
+toward the in-flight limit but consumes no active worker capacity until an
+event resumes it.
 For a resumed draft PR, leave it draft until all implementation, review, and
 pre-push gates pass; then mark it ready and verify the resulting state before
 merge.

--- a/skills/run-github-project/SKILL.md
+++ b/skills/run-github-project/SKILL.md
@@ -309,10 +309,12 @@ Use this worker contract:
    otherwise stop for confirmation before writing a test. Establish RED, then
    implement one minimal vertical slice at a time.
 5. Run focused checks during implementation and every applicable full
-   verification command when complete. Acquire the matching controller-managed
-   named resource lock before a command uses a declared or discovered scarce
-   resource, then release it immediately afterward. Stop if verification
-   requires expanding scope.
+   verification command when complete. Before a command uses a declared or
+   discovered scarce resource, send its canonical resource key, non-secret
+   operation label, and command digest to the controller and wait for an atomic
+   grant. Afterward, report the result with that grant ID and wait for release
+   acknowledgement. Never assume timeout or agent loss released the resource.
+   Stop if verification requires expanding scope.
 6. Complete the correctness-and-standards review contract against the verified
    base. Prefer `code-review` when available. Fix or disposition every finding
    except those explicitly classified as very low priority, then reverify
@@ -447,7 +449,8 @@ failed ticket automatically.
 
 Report the run mode, slot limit, Project configuration digest, live queries,
 merge-authority outcome, scheduler result, peak ticket-agent concurrency,
-named resource-lock waits, and one row per occupied ticket containing:
+named resource-lock grants, waits, and recoveries, and one row per occupied
+ticket containing:
 
 - Project item, Status, Priority, position, and selection reason;
 - Planning authority, plan lease, Ready handoff, and any planning blocker;
@@ -521,14 +524,19 @@ For each changed rule, establish RED by reverting it, then require GREEN. Add a 
 20. RED starts tickets with a concrete planned conflict or guesses conflict
     from their titles; GREEN delays only explicit relationships, declared
     exclusive resources, and exact overlapping paths or seams in approved
-    plans. Novel case: when an unexpected overlap appears, pause the
-    later-claimed slot at its next recoverable checkpoint. Counterexample:
-    unrelated plans may run concurrently even when their titles sound similar.
+    plans. Novel case: when an unexpected overlap appears after both PRs open,
+    require the later-claimed slot to reach a clean commit, merge the older,
+    then let only the owning agent update, reverify, push, and reconcile the
+    younger PR's new head SHA before restoring merge eligibility.
+    Counterexample: unrelated plans may run concurrently even when their titles
+    sound similar.
 21. RED serializes every verification command or lets scarce resources collide;
-    GREEN locks only the discovered or repository-declared device, emulator,
-    fixed port, or shared service for the command that uses it. Novel case: two
-    Android tickets share one physical device while independent compilation
-    continues. Counterexample: independent builds in isolated worktrees need no
+    GREEN atomically grants a controller-owned lease only for the canonical
+    discovered or repository-declared device, emulator, fixed port, or shared
+    service used by one command. Novel case: two Android tickets share one
+    physical device while independent compilation continues, then the lock
+    holder is lost and the controller keeps the device locked until it verifies
+    release. Counterexample: independent builds in isolated worktrees need no
     shared-resource lock.
 22. RED makes each worker yield at every local gate or occupy active capacity
     during remote waits; GREEN runs a ticket pass through a reconciled push,

--- a/skills/run-github-project/references/drain-scheduler.md
+++ b/skills/run-github-project/references/drain-scheduler.md
@@ -4,9 +4,17 @@ Use this scheduler only for `drain`. Keep `next` single-ticket.
 
 ## Slot Model
 
-1. Default to three slots. Accept a user-specified limit of one or two; never exceed three.
+1. Default to three slots. Accept a user-specified limit of one or two; never
+   exceed three. Treat the limit as both the maximum number of claimed,
+   in-flight tickets and the maximum number of concurrently active ticket
+   agents.
+   Define active-agent capacity as the environment-reported number of
+   non-controller agents that can run simultaneously. Running ticket agents,
+   the planner, and descendants consume it; idle persistent contexts do not.
 2. Give each occupied slot one ticket agent, issue, authority lease, warm
    worktree, branch, PR, verified SHA, remote-wait deadline, and fix-round count.
+   Start unrelated ticket agents concurrently by default when agent capacity
+   permits.
 3. Keep every claimed issue `In progress` until merge reconciliation. Derive
    operational state from its slot, PR, checks, and reviews; require no extra
    Project Status values.
@@ -18,22 +26,62 @@ Use this scheduler only for `drain`. Keep `next` single-ticket.
 6. Keep one separate planning lane. It preserves assignment and planning
    handoff claims but never consumes one of the three implementation slots.
    Follow [Planning Lane](planning-lane.md) for its worktree, agent, authority,
-   handoff, and blocker rules.
+   handoff, and blocker rules. Do not reserve agent capacity for Planning;
+   start it only from currently spare capacity, then never preempt it.
 
-## Mutation Lane
+## Parallel Workers And Controller Lane
 
-Permit exactly one slot agent to mutate local or remote state at a time. Keep
-other slot agents idle; read-only work may run concurrently at an immutable SHA.
-Invalidate and repeat a review contract whenever its SHA changes.
-Keep claims, pushes, merges, and Project mutations under one controller.
+Give each ticket agent exclusive ownership of its skill-owned worktree, branch,
+and PR. Permit independent ticket agents to edit, test, commit, push different
+branch refs, open or update their PRs, reply to review comments, and resolve
+addressed threads concurrently. Invalidate and repeat a review contract
+whenever that ticket's SHA changes.
 
-Switch slots only after a recoverable checkpoint:
+Keep one controller lane for just-in-time claims and assignment, Project Status
+mutations, worktree and branch lifecycle, merges or merge-queue admission,
+issue closure, Done reconciliation, and cleanup. Serialize those actions and
+reconcile every ambiguous remote mutation before the next controller mutation.
+Ticket agents never mutate another slot or the controller-owned Project state.
+
+For each ticket pass, continue through implementation, verification, all review
+contracts, a focused commit, and a reconciled push plus PR creation or update.
+Then yield durable evidence to the controller and idle that persistent context.
+Resume the same agent for actionable feedback or base repair.
+
+Before starting agents concurrently, delay a candidate when it has any of:
+
+- an explicit dependency declared in repository metadata or either approved
+  plan, including a `blocked by` or parent-child relationship to an occupied
+  ticket;
+- a declared exclusive resource shared with an occupied ticket; or
+- an exact overlapping path or seam stated in both approved implementation
+  plans.
+
+Leave a delayed candidate unclaimed and consider the next ranked runnable
+candidate. Never infer a conflict from titles, briefs, predicted scope, or
+similarity alone.
+
+When running agents discover a concrete overlap that was absent from their
+plans, define the later-claimed slot as younger. Let its agent finish only the
+current atomic operation and reach its next recoverable checkpoint:
 
 - a complete RED/GREEN vertical slice;
 - a completed verification command;
 - a clean commit;
-- a reconciled push or merge; or
+- a reconciled push; or
 - an explicit preserved stop.
+
+Pause the younger slot there without releasing its claim. Merge the older slot
+first, refresh the verified base, update the younger branch to that base using
+repository policy, revalidate its authority lease and approved plan, repeat
+full applicable verification and every review gate against its new SHA, and
+resume its persistent agent.
+
+Discover repository-declared or operationally evident scarce resources before
+launching commands. Use a named lock for a physical device, emulator, fixed
+port, shared test service, or other exclusive resource. Hold only the matching
+lock for the command that needs it; do not serialize unrelated editing,
+building, testing, commits, pushes, or PR work.
 
 Keep each slot's ticket agent idle between passes; resume it with refreshed
 durable state and discard it only when the slot frees, reconstructing if lost.
@@ -49,39 +97,46 @@ bounded liveness recovery releases capacity.
 Before starting new work, recover and select claim classes in the order defined
 by [Planning Lane](planning-lane.md#scheduling).
 
-At every checkpoint, choose one action:
+At every controller event or worker yield, perform all independent runnable
+actions that fit the slot and active-agent limits. Exhaust each class before
+dispatching the next:
 
 1. Merge the oldest merge-ready slot, unless an explicit dependency requires a
-   different order.
-2. Service the oldest actionable review or CI event.
-3. Resume existing local implementation.
-4. Finish a current plan or verified planning handoff.
-5. Claim the next ranked `Ready to implement` ticket just in time when a slot
-   is free.
-6. Start the next ranked `Planning` item when the planning lane and spare agent
-   capacity are free.
-7. Wait on all remote slots together only when no local action remains.
+   different order. Admit or merge only one at a time.
+2. Resume owning ticket agents for actionable review, CI, or base-repair events
+   in oldest-event order.
+3. Resume paused local implementation slots in claim order.
+4. Finish a current plan or verified planning handoff without preemption.
+5. Claim ranked `Ready to implement` tickets one at a time, skip temporarily
+   conflict-delayed candidates, and launch unrelated slot agents until the
+   in-flight or active-agent limit is reached.
+6. Start the next ranked `Planning` item only when the planning lane and active
+   agent capacity are free after maximizing runnable implementation.
+7. Monitor all remote slots together only when no local or controller action
+   remains.
 
 Never preempt a valid occupied slot for newly higher-priority work. Requery and
 rank live data before every just-in-time claim.
 
-Planning runs read-only beside implementation, waits for the mutation lane only
+Planning runs read-only beside implementation, enters the controller lane only
 at assignment, comment publication, and Status transitions, and continues to
 completion without preemption. Once handed off, the same assigned issue enters
 the next available implementation slot. Apply the planning lane's reconciled
-three-attempt recovery to planner loss, crash, or timeout; do not classify those
-execution failures as semantic blockers.
+three-attempt recovery to planner loss, crash, or timeout; do not classify
+those execution failures as semantic blockers.
 
 Do not concurrently claim tickets connected by `blocked by`, a parent-child
-relationship, or a declared exclusive resource. Do not guess conflicts from
-titles, briefs, or predicted file overlap.
+relationship, another explicit dependency, a declared exclusive resource, or
+a concrete planned path or seam overlap. Do not guess conflicts from titles,
+briefs, or predicted file overlap.
 
 ## Remote Waiting
 
 After a reconciled push:
 
-1. Preserve the slot and release the mutation lane.
-2. Monitor all PRs without no-op comments or sequential polling.
+1. Preserve the slot and release every named resource lock.
+2. Idle its persistent ticket agent so remote waiting consumes no active-agent
+   capacity. Monitor all PRs without no-op comments or sequential polling.
 3. Give that PR a 24-hour deadline from its latest push unless the user or
    repository specifies another duration.
 4. Reset only that PR's deadline after a fix push.
@@ -104,7 +159,7 @@ After a merge:
 2. Refresh mergeability for every other PR.
 3. Update and rerun CI for another branch only when repository policy requires
    the latest base, a conflict appears, or the merge invalidates a tested
-   assumption. Never rebase every branch automatically.
+   assumption or planned seam. Never rebase every branch automatically.
 4. Snap the merged slot's clean worktree to the verified base and reuse it.
 5. Delete only that slot's merged local ticket branch.
 
@@ -114,6 +169,11 @@ Preserve a ticket-local blocker in its occupied slot and continue unrelated
 slots. Stop the whole drain for changed configuration, lost permissions,
 invalid base state, merge-policy drift, correlated CI failure, or another
 integrity problem that affects every claim.
+
+Treat an unexplained scarce-resource collision as slot-local on its first
+occurrence. Discover and add the narrow named lock before retrying. Pause new
+claims when the same collision or infrastructure failure affects two slots or
+the verified base.
 
 Finish successfully only when a complete live query is empty and every slot is
 free after merge reconciliation. If no runnable work remains but a slot is

--- a/skills/run-github-project/references/drain-scheduler.md
+++ b/skills/run-github-project/references/drain-scheduler.md
@@ -38,11 +38,10 @@ addressed threads concurrently. Invalidate and repeat a review contract
 whenever that ticket's SHA changes.
 
 Keep one controller lane for just-in-time claims and assignment, Project Status
-mutations, worktree and branch lifecycle reservations, merges or merge-queue
-admission, issue closure, Done reconciliation, and cleanup. Serialize those
-actions and reconcile every ambiguous remote mutation before the next
-controller mutation. Ticket agents never mutate another slot or the
-controller-owned Project state.
+mutations, slot setup and cleanup, merges or merge-queue admission, issue
+closure, and Done reconciliation. Serialize those actions and reconcile every
+ambiguous remote mutation before the next controller mutation. Ticket agents
+never mutate another slot or the controller-owned Project state.
 
 For each ticket pass, continue through implementation, verification, all review
 contracts, a focused commit, and a reconciled push plus PR creation or update.
@@ -73,63 +72,49 @@ the younger slot; do not begin automated base repair from a dirty worktree.
 
 After that clean checkpoint, pause the younger slot without releasing its
 claim, and revoke its merge eligibility. Merge the older slot first, refresh
-the verified base, then have the controller grant an exclusive branch-lifecycle
-reservation to the younger slot's owning ticket agent. Only that agent may
-update its branch and worktree to the new base using repository policy; the
-controller coordinates the reservation but never edits the agent-owned branch.
+the verified base, then resume the younger slot's owning ticket agent. Under
+its existing exclusive slot ownership, only that agent may update its branch
+and worktree to the new base using repository policy; the controller never
+edits the agent-owned branch.
 
 The owning agent must revalidate the authority lease and approved plan, repeat
 full applicable verification and every review gate against the updated SHA,
 push the exact commit, and reconcile the remote result. Refetch the PR and
 require its head SHA to equal that pushed SHA before restoring merge
-eligibility or evaluating its new checks and reviews. Release the lifecycle
-reservation only after the update is reconciled or explicitly preserved.
+eligibility or evaluating its new checks and reviews.
 
-If the reservation holder is lost or its mutation outcome is ambiguous, keep
-the reservation and stop the prior agent when possible. Inspect the worktree,
-branch HEAD, locks, and active Git processes. Only after confirming the prior
-agent can no longer mutate them may the controller record revocation,
-reconstruct the owning ticket agent from that exact clean HEAD, and issue a new
-reservation. Otherwise preserve and block the younger slot. Never expire,
-steal, or transfer a lifecycle reservation by elapsed time.
+If the owning agent is lost or its mutation outcome is ambiguous, stop it when
+possible and inspect the worktree, branch HEAD, locks, and active Git processes.
+Reconstruct its replacement from that exact clean HEAD only after confirming
+the prior agent can no longer mutate them. Otherwise preserve and block the
+younger slot.
 
 ### Named Resource Locks
 
-Discover repository-declared or operationally evident scarce resources before
-launching commands. Canonicalize each resource by its stable identity, such as
-a device serial, emulator instance, host and port, or non-secret service
-identity. Never use a worker-chosen alias or secret-bearing value as the lock
-key.
+Before a command uses a repository-declared or discovered exclusive resource,
+derive a canonical non-secret key from its stable identity, such as a device
+serial, emulator instance, host and port, or service identity. Never use a
+worker-chosen alias.
 
-Use the controller lane as an atomic lock registry:
+Keep only `resource key -> (grant ID, holder slot)` in the controller's atomic
+registry and durable slot evidence:
 
-1. Require the worker to request a canonical resource key plus its slot,
-   ticket, agent, non-secret operation label, and command digest before launch.
-2. When the key is free, record one grant ID, holder, operation, command digest,
-   and grant time, then return that grant to the worker. When occupied, queue
-   the request and let unrelated work continue. Never start the command before
-   the grant. Never store raw commands, tokens, or secret-bearing arguments in
-   lock evidence.
-3. After the command ends, require the holder to report its result with the
-   matching grant ID. Clear the registry entry, acknowledge release, then grant
-   the next waiter.
-4. After worker loss, controller restart, or an ambiguous acquire or release,
-   keep the key locked. Stop the prior worker when possible and inspect the
-   actual process, device, port, or service state. Clear the grant only after
-   confirming the prior operation no longer owns or uses the resource.
-5. When ownership cannot be distinguished safely, block only passes requiring
-   that resource, preserve their slots, report the grant and waiters, and
-   continue unrelated work. Never expire or steal a grant by elapsed time.
-
-Hold only the matching lock for the command that needs it; do not serialize
-unrelated editing, building, testing, commits, pushes, or PR work. Include live
-grants and waiters in durable slot evidence so recovery treats every
-unreconciled pre-interruption grant as held.
+1. Grant a free key to one requesting slot; otherwise wait while unrelated work
+   continues. Generate a fresh unique grant ID; never start the command without
+   its grant.
+2. After the command, clear only the entry matching both the holder and grant
+   ID, acknowledge release, then reschedule waiting slots. Reject and report a
+   stale or mismatched release without clearing the current grant.
+3. After worker loss, controller restart, or an ambiguous acquire or release,
+   keep the key held until the actual process, device, port, or service is
+   confirmed unused.
+4. When ownership remains unknown, block only dependent passes and continue
+   unrelated work. Never expire or steal a grant by elapsed time.
 
 Keep each slot's ticket agent idle between passes; resume it with refreshed
 durable state and discard it only when the slot frees, reconstructing if lost.
-Reconcile any branch-lifecycle reservation and named resource grant before
-reconstructing or resuming a lost ticket agent.
+Reconcile any named resource grant before reconstructing or resuming a lost
+ticket agent.
 Descendant agents at any depth use only currently spare agent capacity and
 are read-only at immutable SHAs, route findings to the owning ticket or planning
 agent, and never own or mutate tickets. An implementation helper yields before
@@ -174,8 +159,8 @@ those execution failures as semantic blockers.
 
 After a reconciled push:
 
-1. Preserve the slot and verify it holds no branch-lifecycle reservation or
-   named resource grant. Reconcile either before entering remote wait.
+1. Preserve the slot and verify it holds no named resource grant. Reconcile one
+   before entering remote wait.
 2. Idle its persistent ticket agent so remote waiting consumes no active-agent
    capacity. Monitor all PRs without no-op comments or sequential polling.
 3. Give that PR a 24-hour deadline from its latest push unless the user or

--- a/skills/run-github-project/references/drain-scheduler.md
+++ b/skills/run-github-project/references/drain-scheduler.md
@@ -38,10 +38,11 @@ addressed threads concurrently. Invalidate and repeat a review contract
 whenever that ticket's SHA changes.
 
 Keep one controller lane for just-in-time claims and assignment, Project Status
-mutations, worktree and branch lifecycle, merges or merge-queue admission,
-issue closure, Done reconciliation, and cleanup. Serialize those actions and
-reconcile every ambiguous remote mutation before the next controller mutation.
-Ticket agents never mutate another slot or the controller-owned Project state.
+mutations, worktree and branch lifecycle reservations, merges or merge-queue
+admission, issue closure, Done reconciliation, and cleanup. Serialize those
+actions and reconcile every ambiguous remote mutation before the next
+controller mutation. Ticket agents never mutate another slot or the
+controller-owned Project state.
 
 For each ticket pass, continue through implementation, verification, all review
 contracts, a focused commit, and a reconciled push plus PR creation or update.
@@ -63,28 +64,62 @@ similarity alone.
 
 When running agents discover a concrete overlap that was absent from their
 plans, define the later-claimed slot as younger. Let its agent finish only the
-current atomic operation and reach its next recoverable checkpoint:
+current atomic operation, complete and verify its current vertical slice, and
+reach a clean focused commit checkpoint. A reconciled push of that commit is
+also valid. If the agent cannot reach a clean commit safely, preserve and block
+the younger slot; do not begin automated base repair from a dirty worktree.
 
-- a complete RED/GREEN vertical slice;
-- a completed verification command;
-- a clean commit;
-- a reconciled push; or
-- an explicit preserved stop.
+After that clean checkpoint, pause the younger slot without releasing its
+claim, and revoke its merge eligibility. Merge the older slot first, refresh
+the verified base, then have the controller grant an exclusive branch-lifecycle
+reservation to the younger slot's owning ticket agent. Only that agent may
+update its branch and worktree to the new base using repository policy; the
+controller coordinates the reservation but never edits the agent-owned branch.
 
-Pause the younger slot there without releasing its claim. Merge the older slot
-first, refresh the verified base, update the younger branch to that base using
-repository policy, revalidate its authority lease and approved plan, repeat
-full applicable verification and every review gate against its new SHA, and
-resume its persistent agent.
+The owning agent must revalidate the authority lease and approved plan, repeat
+full applicable verification and every review gate against the updated SHA,
+push the exact commit, and reconcile the remote result. Refetch the PR and
+require its head SHA to equal that pushed SHA before restoring merge
+eligibility or evaluating its new checks and reviews. Release the lifecycle
+reservation only after the update is reconciled or explicitly preserved.
+
+### Named Resource Locks
 
 Discover repository-declared or operationally evident scarce resources before
-launching commands. Use a named lock for a physical device, emulator, fixed
-port, shared test service, or other exclusive resource. Hold only the matching
-lock for the command that needs it; do not serialize unrelated editing,
-building, testing, commits, pushes, or PR work.
+launching commands. Canonicalize each resource by its stable identity, such as
+a device serial, emulator instance, host and port, or non-secret service
+identity. Never use a worker-chosen alias or secret-bearing value as the lock
+key.
+
+Use the controller lane as an atomic lock registry:
+
+1. Require the worker to request a canonical resource key plus its slot,
+   ticket, agent, non-secret operation label, and command digest before launch.
+2. When the key is free, record one grant ID, holder, operation, command digest,
+   and grant time, then return that grant to the worker. When occupied, queue
+   the request and let unrelated work continue. Never start the command before
+   the grant. Never store raw commands, tokens, or secret-bearing arguments in
+   lock evidence.
+3. After the command ends, require the holder to report its result with the
+   matching grant ID. Clear the registry entry, acknowledge release, then grant
+   the next waiter.
+4. After worker loss, controller restart, or an ambiguous acquire or release,
+   keep the key locked. Stop the prior worker when possible and inspect the
+   actual process, device, port, or service state. Clear the grant only after
+   confirming the prior operation no longer owns or uses the resource.
+5. When ownership cannot be distinguished safely, block only passes requiring
+   that resource, preserve their slots, report the grant and waiters, and
+   continue unrelated work. Never expire or steal a grant by elapsed time.
+
+Hold only the matching lock for the command that needs it; do not serialize
+unrelated editing, building, testing, commits, pushes, or PR work. Include live
+grants and waiters in durable slot evidence so recovery treats every
+unreconciled pre-interruption grant as held.
 
 Keep each slot's ticket agent idle between passes; resume it with refreshed
 durable state and discard it only when the slot frees, reconstructing if lost.
+Reconcile any branch-lifecycle reservation and named resource grant before
+reconstructing or resuming a lost ticket agent.
 Descendant agents at any depth use only currently spare agent capacity and
 are read-only at immutable SHAs, route findings to the owning ticket or planning
 agent, and never own or mutate tickets. An implementation helper yields before
@@ -134,7 +169,8 @@ briefs, or predicted file overlap.
 
 After a reconciled push:
 
-1. Preserve the slot and release every named resource lock.
+1. Preserve the slot and verify it holds no branch-lifecycle reservation or
+   named resource grant. Reconcile either before entering remote wait.
 2. Idle its persistent ticket agent so remote waiting consumes no active-agent
    capacity. Monitor all PRs without no-op comments or sequential polling.
 3. Give that PR a 24-hour deadline from its latest push unless the user or

--- a/skills/run-github-project/references/drain-scheduler.md
+++ b/skills/run-github-project/references/drain-scheduler.md
@@ -49,6 +49,8 @@ contracts, a focused commit, and a reconciled push plus PR creation or update.
 Then yield durable evidence to the controller and idle that persistent context.
 Resume the same agent for actionable feedback or base repair.
 
+### Conflict Admission Gate
+
 Before starting agents concurrently, delay a candidate when it has any of:
 
 - an explicit dependency declared in repository metadata or either approved
@@ -82,6 +84,14 @@ push the exact commit, and reconcile the remote result. Refetch the PR and
 require its head SHA to equal that pushed SHA before restoring merge
 eligibility or evaluating its new checks and reviews. Release the lifecycle
 reservation only after the update is reconciled or explicitly preserved.
+
+If the reservation holder is lost or its mutation outcome is ambiguous, keep
+the reservation and stop the prior agent when possible. Inspect the worktree,
+branch HEAD, locks, and active Git processes. Only after confirming the prior
+agent can no longer mutate them may the controller record revocation,
+reconstruct the owning ticket agent from that exact clean HEAD, and issue a new
+reservation. Otherwise preserve and block the younger slot. Never expire,
+steal, or transfer a lifecycle reservation by elapsed time.
 
 ### Named Resource Locks
 
@@ -142,9 +152,9 @@ dispatching the next:
    in oldest-event order.
 3. Resume paused local implementation slots in claim order.
 4. Finish a current plan or verified planning handoff without preemption.
-5. Claim ranked `Ready to implement` tickets one at a time, skip temporarily
-   conflict-delayed candidates, and launch unrelated slot agents until the
-   in-flight or active-agent limit is reached.
+5. Apply the [Conflict Admission Gate](#conflict-admission-gate), claim ranked
+   `Ready to implement` tickets one at a time, and launch unrelated slot agents
+   until the in-flight or active-agent limit is reached.
 6. Start the next ranked `Planning` item only when the planning lane and active
    agent capacity are free after maximizing runnable implementation.
 7. Monitor all remote slots together only when no local or controller action
@@ -159,11 +169,6 @@ completion without preemption. Once handed off, the same assigned issue enters
 the next available implementation slot. Apply the planning lane's reconciled
 three-attempt recovery to planner loss, crash, or timeout; do not classify
 those execution failures as semantic blockers.
-
-Do not concurrently claim tickets connected by `blocked by`, a parent-child
-relationship, another explicit dependency, a declared exclusive resource, or
-a concrete planned path or seam overlap. Do not guess conflicts from titles,
-briefs, or predicted file overlap.
 
 ## Remote Waiting
 

--- a/skills/run-github-project/references/planning-lane.md
+++ b/skills/run-github-project/references/planning-lane.md
@@ -47,9 +47,9 @@ second marker.
 
 ## Plan A Planning Item
 
-1. Acquire the mutation lane, assign the issue exclusively to the authenticated
-   user, refetch and verify the assignment, then release the lane. Reconcile an
-   ambiguous assignment before retrying. Preserve the assignment through
+1. Enter the controller lane, assign the issue exclusively to the authenticated
+   user, refetch and verify the assignment, then release the lane. Reconcile
+   an ambiguous assignment before retrying. Preserve the assignment through
    planning and implementation.
 2. Use one dedicated, reusable, clean planning worktree at a stable
    controller-recorded path outside the checkout, detached at the configured
@@ -63,10 +63,10 @@ second marker.
 4. Allow bounded read-only discovery descendants from currently spare agent
    capacity. They never own the ticket or mutate state.
 5. Never preempt planning after it starts. Planning does not occupy an
-   implementation slot and does not reserve the mutation lane during read-only
+   implementation slot and does not reserve the controller lane during read-only
    work.
-6. At the publish boundary, wait for the mutation lane. Let `to-plan` create or
-   update only its marker comment, then refetch it from GitHub.
+6. At the publish boundary, wait for the controller lane. Let `to-plan` create
+   or update only its marker comment, then refetch it from GitHub.
 7. Verify the exact marker, authenticated-runner author, digest, permalink,
    planned branch, planned SHA, and timestamps. Treat missing `to-plan` as an
    issue-local planning blocker; it must not block implementation items with
@@ -152,10 +152,12 @@ plan it, hand it off, implement it, merge it, and reconcile it before finishing.
 Do not select another issue.
 
 In `drain`, run at most one planning agent from otherwise spare capacity while
-up to three implementation slots proceed. Never interrupt that planner for an
-implementation event; the event waits until planning finishes or bounded
-liveness recovery blocks it and releases capacity. Planning may itself wait at
-its publish boundary while the mutation lane is occupied.
+up to three implementation slot agents proceed concurrently. Maximize runnable
+implementation instead of reserving capacity for Planning. Once a planner
+starts, never interrupt it for an implementation event; the event waits until
+planning finishes or bounded liveness recovery blocks it and releases capacity.
+Planning may itself wait at its publish boundary while the controller lane is
+occupied.
 
 ## Migration Gate
 

--- a/skills/run-github-project/references/planning-lane.md
+++ b/skills/run-github-project/references/planning-lane.md
@@ -151,13 +151,9 @@ In `next`, selecting a Planning item commits the invocation to that one issue:
 plan it, hand it off, implement it, merge it, and reconcile it before finishing.
 Do not select another issue.
 
-In `drain`, run at most one planning agent from otherwise spare capacity while
-up to three implementation slot agents proceed concurrently. Maximize runnable
-implementation instead of reserving capacity for Planning. Once a planner
-starts, never interrupt it for an implementation event; the event waits until
-planning finishes or bounded liveness recovery blocks it and releases capacity.
-Planning may itself wait at its publish boundary while the controller lane is
-occupied.
+In `drain`, follow the
+[Drain Scheduler](drain-scheduler.md#scheduling) for planner dispatch,
+active-agent capacity, and non-preemption.
 
 ## Migration Gate
 


### PR DESCRIPTION
## Summary

- run independent `drain` ticket agents concurrently across up to three isolated slots
- keep claims, Project mutations, merges, closure, and reconciliation in one controller lane
- add explicit conflict admission, late-overlap recovery, and minimal scarce-resource grants
- preserve single-ticket `next` behavior and centralize Planning capacity policy

## Why

The existing slots preserved ticket context and allowed switching during remote waits, but a global mutation lane still serialized all implementation. This change makes the slots genuinely parallel while retaining fail-closed ownership and authority boundaries.

## Validation

- `python3 /Users/chris/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/run-github-project`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest skills/run-github-project/scripts/test_rank_tickets.py` (40 tests)
- `npm run lint`
- `git diff --check`
- final `review-and-simplify-changes` and `ponytail-review` against the exact pushed `HEAD`
