### PR TITLE
Add Backlog triage to project runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ See [`.opencode/INSTALL.md`](.opencode/INSTALL.md) for details.
 ### Workflows
 
 - [`to-plan`](skills/to-plan/SKILL.md) — publish a repository-aware implementation plan for one ready GitHub issue with a provider-neutral implementation handoff.
-- [`run-github-project`](skills/run-github-project/SKILL.md) — plan and execute the next authorized issue or drain a configured GitHub Project through one planning lane and a bounded three-slot parallel implementation, CI, and review pipeline. Requires `tdd` and supports [preferred review providers](skills/run-github-project/references/workflow-providers.md) without depending on them.
+- [`run-github-project`](skills/run-github-project/SKILL.md) — triage unblocked Backlog work after the execution queue clears, or plan and execute authorized GitHub Project issues through one planning lane and a bounded three-slot parallel implementation, CI, and review pipeline. Requires `tdd` for implementation and preserves the `triage` provider's approval gate.
 - [`shepherd`](skills/shepherd/SKILL.md) — autonomously poll open PRs and MRs, triage review comments, detect and fix CI failures, and keep PRs moving forward.
 
 ## Contributing

--- a/skills/run-github-project/SKILL.md
+++ b/skills/run-github-project/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: run-github-project
-description: Use when asked to plan and execute the next authorized issue or drain authorized issues from a configured GitHub Project through implementation, review, merge, and reconciliation.
+description: Use when asked to triage Backlog work, plan and execute the next authorized issue, or drain authorized issues from a configured GitHub Project through implementation, review, merge, and reconciliation.
 ---
 
 # Run GitHub Project
@@ -10,6 +10,10 @@ description: Use when asked to plan and execute the next authorized issue or dra
 Treat the Project as the live control plane. Require the readiness label and a
 human-authorized Planning transition, preserve that authority through
 contract-preserving re-plans, and return true human work to Backlog.
+
+Park dependency-blocked Backlog items. After authorized execution is empty,
+route unblocked `needs-triage` items through the unchanged `triage` approval
+gate without manufacturing Planning authority.
 
 Pair each occupied slot with one warm worktree and one persistent ticket agent.
 Run independent slot agents concurrently in `drain`. Keep claims, shared
@@ -29,6 +33,7 @@ Require:
 - Project owner, number, URL, and node ID;
 - Status field name and ID plus Backlog, Planning, Ready to implement, In
   progress, and Done option names and IDs;
+- the exact repository label mapped to the `needs-triage` role;
 - Priority field name and ID plus option names and IDs in descending order;
 - execution-approver GitHub logins allowed to authorize Planning;
 - an optional trusted Project filter expression;
@@ -62,34 +67,40 @@ both before every claim and merge. Stop and preserve work if either changes.
 
 1. Read the closest trusted repository instructions.
 2. Configure and validate the repository's Project binding.
-3. Require `tdd`. Follow
+3. Require `tdd` before implementation work. Follow
    [references/workflow-providers.md](references/workflow-providers.md); stop
-   with its exact source and install command if `tdd` is unavailable. Never
-   install it implicitly or approximate it.
+   the execution lane with its exact source and install command if `tdd` is
+   unavailable. Permit a triage-only tail run to continue. Never install it
+   implicitly or approximate it.
 4. Read [references/planning-lane.md](references/planning-lane.md). Verify
    `to-plan` before planning work; if missing, block only the planning lane.
-5. Read [references/review-contracts.md](references/review-contracts.md).
+5. Read [references/triage-lane.md](references/triage-lane.md). Verify
+   `triage` before Backlog work; if missing, block only the triage lane.
+6. Read [references/review-contracts.md](references/review-contracts.md).
    Prefer the named review providers in
    [references/workflow-providers.md](references/workflow-providers.md), but
    permit equivalent installed skills or direct execution of the bundled
    contracts. Record the provider for each contract. Do not stop solely because
    a preferred provider is unavailable.
-6. Confirm the authenticated GitHub identity, Project read/write access,
+7. Confirm the authenticated GitHub identity, Project read/write access,
    GitHub CLI `project` scope, current default, verified base, and clean state.
-7. Inspect repository automation that can change Project Status or archive Done
+8. Inspect repository automation that can change Project Status or archive Done
    items. Stop if it conflicts with the configured Backlog, Planning, Ready to
    implement, In progress, and Done lifecycle.
-8. Select and record a run mode:
+9. Select and record a run mode:
    - `next` is the default and processes at most one selected issue;
    - `drain` is allowed only when the user explicitly asks to drain, run all,
      repeat, or continue until empty. Run occupied slots concurrently by
      default. Use three as both the maximum in-flight ticket count and ticket
      agent concurrency limit, and accept only a lower user-specified limit.
-9. Require explicit merge authority for the mode's scope: the one selected
-   issue in `next`, or every eligible issue encountered in `drain`. Without it,
-   stop before claiming work. Also require explicit issue-close authority when
-   `close-after-merge` is configured.
-10. For `drain`, read and follow
+10. Before any execution claim, require explicit merge authority for the
+   mode's scope: the one selected issue in `next`, or every eligible issue
+   encountered in `drain`. Without it, stop before claiming execution; never
+   bypass an executable ticket by entering triage. A triage-only selection
+   requires no merge authority, and triage approval never supplies it. Also
+   require explicit issue-close authority when `close-after-merge` is
+   configured.
+11. For `drain`, read and follow
    [references/drain-scheduler.md](references/drain-scheduler.md).
 
 Do not support publish-only mode or impose a ticket cap in `drain`. Standing
@@ -120,10 +131,10 @@ review, check, comment, PR, or merge is absent.
      then refetch;
    - stop and preserve resumable state when the outcome cannot be distinguished
      safely.
-5. Reconcile assignments, Status changes, PR creation, comments, replies,
-   thread resolution, and merges against their resulting state. Never emit a
-   duplicate comment or perform a second merge because the original response
-   was lost.
+5. Reconcile assignments, labels, issue closure, Status changes, PR creation,
+   comments, replies, thread resolution, and merges against their resulting
+   state. Never emit a duplicate comment, repeat a close, or perform a second
+   merge because the original response was lost.
 6. After an ambiguous merge response, do not advance or clean up that slot
    until the PR's merged state, closed ticket, and refreshed base tip are
    verified.
@@ -136,8 +147,9 @@ review, check, comment, PR, or merge is absent.
 Query the live Project at startup and after every confirmed merge. In `next`,
 use the post-merge query only for reconciliation and reporting; do not claim a
 second ticket. In `drain`, include newly added, Planning, and Ready-to-implement
-items until the first complete successful empty query. Leave tickets added
-after that query for the next invocation.
+items plus Backlog `needs-triage` items until the first complete successful
+empty executable-and-triage query. Leave tickets added after that query for the
+next invocation.
 
 1. Run `gh project field-list <number> --owner <owner> --format json` and verify
    configured field and option IDs against their expected names. Use ProjectV2
@@ -147,29 +159,37 @@ after that query for the next invocation.
    lightweight fields required by
    [references/normalized-ticket.md](references/normalized-ticket.md), including
    Project position, exact labels and assignees, and linked implementation PR
-   identity, closure relationship, head SHA, and base target.
+   identity and closure relationship.
 3. Apply the optional trusted Project filter, then always intersect it with:
    - membership in the configured repository;
    - an open, non-draft GitHub issue;
    - Planning, Ready to implement, or In progress Status; or
    - Backlog Status while assigned to the authenticated runner, solely to
-     recover interrupted human-work cleanup.
+     recover interrupted human-work cleanup; or
+   - Backlog Status plus the exact configured `needs-triage` label for the
+     triage inventory.
 4. Record draft, pull-request, redacted, cross-repository, closed, malformed,
    or filter-excluded items as ineligible. Never convert draft items into
    tickets or use a named Project view implicitly.
-5. Build contender classes in the exact order defined by
-   [Planning Lane](references/planning-lane.md#scheduling). Within each class
-   use Priority, visible position, then issue number. Do not preempt a claim.
+5. Build execution contender classes in the exact order defined by
+   [Planning Lane](references/planning-lane.md#scheduling). Build the separate
+   triage inventory through
+   [Backlog Triage Lane](references/triage-lane.md). Within each class use
+   Priority, visible position, then issue number. Do not preempt a claim.
 6. Phase two: hydrate contenders in order with fresh batched GraphQL reads.
    Gather:
    - native open `blocked by` relationships;
    - all open descendants in the issue's sub-issue tree;
-   - the latest status events entering Backlog, Planning, and Ready to implement,
+   - for execution and assigned-Backlog cleanup contenders, the latest status
+     events entering Backlog, Planning, and Ready to implement,
      including event ID, actor login, `createdAt`, resulting Status, and
      `wasAutomated`;
-   - every v1 or v2 marker-owned implementation plan, minimized state, active
-     replan report, author login, and lease field defined by the normalized
-     schema.
+   - for execution and assigned-Backlog cleanup contenders, every v1 or v2
+     marker-owned implementation plan, minimized state, active replan report,
+     author login, and lease field defined by the normalized schema; and
+   - for execution and assigned-Backlog cleanup contenders, complete linked
+     implementation PR metadata, including author, draft state, head repository,
+     ref, SHA, and base target.
    Preserve an invalid claimed contender as a blocked slot. Report and advance
    when an unclaimed contender is invalid. Hydrate all contenders together
    only when one bounded batch is cheaper and remains within GitHub rate and
@@ -196,6 +216,7 @@ python3 <skill-dir>/scripts/rank_tickets.py \
   --planning-status <planning-name> \
   --ready-status <ready-to-implement-name> \
   --in-progress-status <in-progress-name> \
+  --needs-triage-label <needs-triage-label> \
   --priority <highest-name> [--priority <next-name> ...] \
   --max-claims <mode-slot-limit> \
   < normalized-tickets.json
@@ -208,7 +229,8 @@ Project positions.
 
 Pass configured Status and Priority display names, never option IDs; use IDs
 only for Project mutations. Pass Priority names in descending order, rank unset
-Priority last, and require the exact `ready-for-agent` label.
+Priority last, and require the exact configured `needs-triage` label for the
+triage inventory plus the exact `ready-for-agent` label for execution.
 
 Hydrate every current-user claim before unclaimed contenders.
 Preserve returned `blockedClaims` in occupied implementation slots and
@@ -217,8 +239,8 @@ fill free capacity from returned `candidates`. Planning and
 `resume-backlog-cleanup` claims do not count toward `max-claims`. Finish
 Backlog cleanup before new claims. Leave an In progress item assigned to
 someone else alone. Report an unassigned In progress item as stale and
-ineligible; ignore an unassigned Backlog item until a human moves it to
-Planning.
+ineligible; ignore an unassigned Backlog item without the exact configured
+`needs-triage` label until a human moves it to Planning.
 
 When no claim exists, hydrate current-user PR contenders before new work.
 Otherwise preserve the phase-one Priority, visible-position, and issue-number
@@ -228,6 +250,12 @@ Report and skip an unclaimed malformed, blocked, unsupported, or unauthorized
 item without stopping valid work. Preserve a claimed planning blocker without
 an implementation slot; block only the affected implementation slot when
 claimed implementation becomes ineligible.
+
+Preserve returned `parkedBlocked` items without invoking `triage`. Keep returned
+`triageCandidates` outside the execution scheduler until the authoritative
+execution-clear predicate in
+[Backlog Triage Lane](references/triage-lane.md#dispatch) is satisfied. Then
+follow that lane one issue at a time.
 
 Resume a linked PR only when exactly one open PR clearly closes the issue, its
 author is the authenticated user, it targets the configured repository and
@@ -457,8 +485,10 @@ isolation rules from the drain scheduler.
    and perform a complete live Project query. Do not update every branch
    automatically; follow the scheduler's base-drift rules.
 
-Finish `next` after one selected issue reaches a confirmed terminal outcome and
-the post-merge live query succeeds. For `drain`, treat
+Finish `next` after one selected execution issue reaches a confirmed terminal
+outcome and the post-merge live query succeeds, or after one tail-lane triage
+issue reaches a reconciled outcome when no executable issue exists. For
+`drain`, treat
 [Failure Isolation And Finish Gate](references/drain-scheduler.md#failure-isolation-and-finish-gate)
 as the authoritative success, partial-drain, preservation, and cleanup
 procedure. In `next`, preserve the worktree, branch, PR, assignment, and In
@@ -469,8 +499,9 @@ failed ticket automatically.
 
 Report the run mode, slot limit, Project configuration digest, live queries,
 merge-authority outcome, scheduler result, peak ticket-agent concurrency,
-named resource-lock grants, waits, and recoveries, and one row per occupied
-ticket containing:
+named resource-lock grants, waits, recoveries, triage provider result,
+`parkedBlocked` inventory, triage recommendations and reconciled outcomes, and
+one row per occupied ticket containing:
 
 - Project item, Status, Priority, position, and selection reason;
 - Planning authority, plan lease, Ready handoff, and any planning blocker;
@@ -607,3 +638,24 @@ For each changed rule, establish RED by reverting it, then require GREEN. Add a 
     create is reconciled by revision and payload digest. Counterexample:
     failure of both presentation mechanisms is reported but does not invalidate
     the new plan.
+28. RED hides Backlog `needs-triage` items or repeatedly triages them while
+    blocked; GREEN ranks unblocked items separately and returns blockers or
+    open descendants as `parkedBlocked`. Novel case: the final blocker closes
+    after a merge and the dependant enters `triageCandidates` on refresh.
+    Counterexample: a body-only `Blocked by` claim without configured fallback
+    evidence never supplies the live gate.
+29. RED treats automatic triage dispatch as permission to change labels,
+    comment, or close; GREEN invokes the exact `triage` provider through its
+    recommendation boundary and waits for the maintainer's decision. Novel
+    case: an approved `ready-for-agent` outcome leaves the item in Backlog
+    awaiting a human Planning transition. Counterexample: standing merge or
+    issue-close authority never approves triage mutations.
+30. RED pauses occupied execution or assigned Backlog cleanup for triage, lets
+    a blocked Planning claim slip past the tail gate, or lets parked work
+    prevent a successful drain; GREEN starts the one-item triage tail lane only
+    after all valid and blocked execution and Planning claims, assigned Backlog
+    cleanup, Planning work, and slots are clear, and records a deferred
+    recommendation once without looping. Novel case: `blockedPlanningClaims`
+    prevents triage even though it consumes no implementation slot.
+    Counterexample: an unassigned Backlog item without `needs-triage` never
+    enters the triage lane.

--- a/skills/run-github-project/agents/openai.yaml
+++ b/skills/run-github-project/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: "Run GitHub Project"
-  short_description: "Plan and execute authorized Project work"
-  default_prompt: "Use $run-github-project in next mode to plan if needed and execute one authorized issue from this repository's configured GitHub Project after confirming merge authority."
+  short_description: "Triage and execute authorized Project work"
+  default_prompt: "Use $run-github-project in next mode to execute one authorized issue, or triage one unblocked Backlog issue when no executable work remains, after confirming the required authority."
 
 policy:
   allow_implicit_invocation: false

--- a/skills/run-github-project/references/drain-scheduler.md
+++ b/skills/run-github-project/references/drain-scheduler.md
@@ -33,6 +33,10 @@ Use this scheduler only for `drain`. Keep `next` single-ticket.
    and idle ticket context on the planning claim. Restore that same ownership
    when the handoff reacquires a slot. A Backlog handoff instead removes all
    skill-owned artifacts and retains no claim.
+8. Keep Backlog triage as a tail lane. Follow
+   the authoritative execution-clear predicate in
+   [Backlog Triage Lane](triage-lane.md#dispatch). It consumes no implementation
+   slot and processes one issue at a time.
 
 ## Parallel Workers And Controller Lane
 
@@ -152,6 +156,9 @@ dispatching the next:
    agent capacity are free after maximizing runnable implementation.
 8. Monitor all remote slots together only when no local or controller action
    remains.
+9. After the authoritative execution-clear predicate in
+   [Backlog Triage Lane](triage-lane.md#dispatch) is satisfied, process the next
+   unblocked Backlog `needs-triage` item through the triage tail lane.
 
 Never preempt a valid occupied slot for newly higher-priority work. Requery and
 rank live data before every just-in-time claim.
@@ -219,11 +226,15 @@ scheduler capacity, report the exact unreconciled artifact, and never delete it
 by guess. Keep the runner assigned as the durable cleanup lease until the
 idempotent finish state proves that its PR, processes, resource grants,
 worktree, and branches are gone; unassign last. A later run may finish only an
-assigned Backlog cleanup with verified runner provenance; an unassigned Backlog
-item remains human-owned.
+assigned Backlog cleanup with verified runner provenance. An unassigned Backlog
+item without the configured `needs-triage` label remains human-owned; an
+eligible labeled item belongs only to the triage tail lane.
 
-Finish successfully only when a complete live query is empty and every slot is
-free after merge reconciliation. If no runnable work remains but a slot is
-blocked or timed out, stop with a partial-drain report, preserve every affected
-worktree, branch, PR, assignment, and `In progress` Status, and never report
-success.
+Finish successfully only when the authoritative execution-clear predicate in
+[Backlog Triage Lane](triage-lane.md#dispatch) is satisfied and a complete live
+query has no non-deferred triage candidate after merge reconciliation.
+Dependency-parked Backlog items do not prevent success; report their live
+blockers. If no runnable work remains but a claim or slot is blocked or timed
+out, or the triage provider cannot complete an eligible item, stop with a
+partial-drain report, preserve every affected worktree, branch, PR, assignment,
+and `In progress` Status, and never report success.

--- a/skills/run-github-project/references/normalized-ticket.md
+++ b/skills/run-github-project/references/normalized-ticket.md
@@ -1,7 +1,7 @@
 # Normalized Ticket Schema
 
 Provide every field below to `scripts/rank_tickets.py` from fresh, completely
-paginated GitHub and Project reads:
+paginated GitHub and Project reads. Use this shape for execution contenders:
 
 ```json
 {
@@ -68,6 +68,34 @@ paginated GitHub and Project reads:
 }
 ```
 
+Use the same canonical shape for Backlog triage contenders, with transition and
+replan fields set to `null` and `implementationPlans` empty when absent. Backlog
+`openPullRequests` entries need only `number`, `url`, and `closesIssue`; omit
+execution-only author, draft, head, and base fields:
+
+```json
+{
+  "number": 43,
+  "title": "Unblocked issue awaiting triage",
+  "url": "https://github.com/owner/repository/issues/43",
+  "state": "OPEN",
+  "projectItemId": "PVTI_backlog",
+  "projectStatus": "Backlog",
+  "projectPriority": "High",
+  "projectPosition": 18,
+  "labels": ["needs-triage"],
+  "assignees": [],
+  "blockedBy": [],
+  "openDescendants": [],
+  "backlogTransition": null,
+  "planningTransition": null,
+  "readyTransition": null,
+  "replanRequest": null,
+  "implementationPlans": [],
+  "openPullRequests": []
+}
+```
+
 Use GitHub logins, never display names, for assignees, PR authors, and
 transition actors. Normalize `labels` to exact label names. Normalize
 `blockedBy` and `openDescendants` entries to integer issue numbers for the
@@ -87,8 +115,9 @@ latest transition into Backlog. An assigned Backlog item also requires a
 runner-authored `replanRequest` with `disposition: "human-required"` so cleanup
 can resume after interruption. Keep that assignment as the durable cleanup
 lease until the controller verifies that every exact runner-owned artifact is
-absent and unassigns last. An unassigned Backlog item is human-owned and
-ineligible.
+absent and unassigns last. An unassigned Backlog item without the configured
+`needs-triage` label is human-owned and ineligible for runner execution; an
+eligible labeled item belongs only to the triage inventory.
 
 Normalize every runner-owned v1 or v2 plan marker, including minimized
 comments, into `implementationPlans`. A v1 comment is a revision-one root. A v2
@@ -127,6 +156,12 @@ Retained head and PR fields may be null but must identify exact durable state
 when present. The report must precede the resulting Status transition and
 identify the plan that authorized the prior Ready handoff.
 
+For Backlog triage contenders, the ranker ignores historical Planning, Ready,
+and plan fields. Require the configured `needs-triage` label, no assignee, and
+no open implementation pull request. Return an otherwise valid item with open
+native blockers or descendants as `parkedBlocked`; return an unblocked item as
+`triageCandidates`. Never feed either collection into an implementation slot.
+
 The ranker returns valid current-user claims and ordered unclaimed candidates:
 
 ```json
@@ -148,6 +183,15 @@ The ranker returns valid current-user claims and ordered unclaimed candidates:
     {"ticket": {"number": 45}, "action": "claim"},
     {"ticket": {"number": 46}, "action": "plan"}
   ],
+  "triageCandidates": [
+    {"ticket": {"number": 47}, "action": "triage"}
+  ],
+  "parkedBlocked": [
+    {
+      "ticket": {"number": 48},
+      "reasons": ["blocked by ['owner/repository#41']"]
+    }
+  ],
   "excluded": []
 }
 ```
@@ -157,7 +201,11 @@ controller owns scheduling; the ranker only validates claims and orders
 candidates. Each `blockedClaims` entry occupies a slot and preserves a claimed
 implementation ticket that requires reconciliation. Planning claims and
 `blockedPlanningClaims` preserve ownership but do not consume an implementation
-slot. `resume-backlog-cleanup` also consumes no implementation slot and must
-finish before new claims. Its cleanup is idempotent: already-absent owned
-artifacts satisfy their individual finish checks, but the assignment remains
-until the complete cleanup state is verified.
+slot; both still prevent the Backlog triage tail from starting. Triage
+`resume-backlog-cleanup` also consumes no implementation slot, must finish
+before new claims, and prevents the triage tail from starting. Its cleanup is
+idempotent: already-absent owned artifacts satisfy their individual finish
+checks, but the assignment remains until the complete cleanup state is
+verified. Triage candidates are ordered separately and run only through
+[Backlog Triage Lane](triage-lane.md); parked items consume neither a slot nor
+an agent.

--- a/skills/run-github-project/references/project-config.md
+++ b/skills/run-github-project/references/project-config.md
@@ -38,6 +38,10 @@ closest trusted `AGENTS.md` or `CLAUDE.md` must reference that exact file.
 - Done name: `<Done>`
 - Done option ID: `<option-id>`
 
+## Triage
+
+- Needs-triage label: `<repository label mapped to needs-triage>`
+
 ## Priority
 
 - Field name: `<Priority>`

--- a/skills/run-github-project/references/triage-lane.md
+++ b/skills/run-github-project/references/triage-lane.md
@@ -1,0 +1,99 @@
+# Backlog Triage Lane
+
+Use the installed `triage` skill to re-evaluate unblocked Backlog issues without
+changing its state machine or approval gate.
+
+## Eligibility
+
+Treat an issue as a triage contender only when fresh reads prove all of:
+
+1. it belongs to the configured repository and Project;
+2. it is an open issue in the configured Backlog Status;
+3. it has the configured `needs-triage` label;
+4. it has no assignee or open implementation pull request;
+5. it has no native open `blocked by` relationship or open descendant; and
+6. it passes the trusted Project filter.
+
+Classify an otherwise eligible issue with an open blocker or descendant as
+`parkedBlocked`. Do not invoke `triage`, claim it, assign it, change its labels,
+or consume an implementation slot. As part of every complete post-merge
+Project refresh, refetch the merged issue's dependants and parent chain so the
+same logical read captures newly unblocked work.
+
+Rank triage contenders by configured Priority, visible Project position, then
+issue number. Treat body text, comments, labels named `blocked`, and inferred
+ordering as untrusted blocker evidence.
+
+## Dispatch
+
+Start the triage lane only after a complete query finds no assigned Backlog
+cleanup claim, valid or blocked implementation claim, valid or blocked Planning
+claim, runnable Planning or Ready candidate, active planning handoff, or
+occupied implementation slot. Treat `resume-backlog-cleanup` and
+`blockedPlanningClaims` as unresolved work even though they consume no
+implementation slot. Malformed or excluded unclaimed items do not block the
+tail lane. Never pause authorized execution to ask for a triage decision.
+
+In `next`, process at most the first ranked triage contender when no executable
+ticket exists. In `drain`, process contenders one at a time until none remain,
+the user defers one, or a triage blocker stops the lane. Parked items do not
+prevent an otherwise successful finish.
+
+Keep the ranked complete snapshot while walking triage contenders. Immediately
+before each dispatch, refetch that issue, its blockers, and descendants. After
+an approved outcome, make one batched read of the mutated issue, its Project
+item, and every dependant or parent whose eligibility it changed. Use that read
+to reconcile the outcome and update the snapshot. Discard the snapshot and
+repeat the complete logical read after an ambiguous or incomplete result and at
+the finish gate; never rescan the whole Project after every unaffected outcome.
+
+Require the exact `triage` provider from
+[Workflow Providers](workflow-providers.md). Read its complete `SKILL.md` and
+required references before the first dispatch. Start one fresh recoverable
+triage context with no inherited turns, require read-only repository inspection
+at the verified base, and invoke:
+
+```text
+/triage <canonical issue URL>
+```
+
+Let the provider gather and verify context, then stop at its recommendation
+boundary. Present its category, state recommendation, reasoning, proposed
+comments, label changes, and close action exactly enough for the maintainer to
+approve or revise them. Automatic dispatch authorizes no mutation and does not
+reuse merge or issue-close authority.
+
+Resume the same triage context with the maintainer's decision. Serialize and
+reconcile each approved label, comment, or close mutation before continuing.
+Recheck the committed configuration digest and refetch the issue immediately
+before dispatch and before every approved mutation.
+If the recommendation needs grilling, domain-model or ADR edits, checkout
+mutation, external access, or another material decision, stop the lane and
+hand the issue back to the maintainer without changing it.
+
+## Reconcile The Outcome
+
+Use the batched post-mutation read to reconcile the approved outcome:
+
+- For `ready-for-agent`, require the provider's durable agent brief and exact
+  label transition. Leave the item in Backlog and report that it awaits a
+  human Planning transition; never manufacture execution authority.
+- For `ready-for-human`, `needs-info`, or `wontfix`, require the provider's
+  approved comment, label, and closure result as applicable.
+- For `needs-triage`, a rejected recommendation, or a deferred decision, leave
+  the item unchanged and mark it deferred for this invocation so it cannot
+  loop.
+
+Discard the triage context after its issue reaches a reconciled outcome or is
+deferred. Never reuse it for another issue.
+
+## Finish Gate
+
+Finish the triage lane only after a complete refreshed query finds no
+non-deferred unblocked triage contender. Report:
+
+- every triaged issue and reconciled outcome;
+- every issue awaiting human Planning authorization;
+- every deferred or blocked triage attempt;
+- every `parkedBlocked` issue and its live blockers; and
+- provider or GitHub failures that left the lane incomplete.

--- a/skills/run-github-project/references/workflow-providers.md
+++ b/skills/run-github-project/references/workflow-providers.md
@@ -7,12 +7,23 @@ Never install a provider implicitly.
 | Skill | Source | Install |
 | --- | --- | --- |
 | `tdd` | `mattpocock/skills` | `npx skills add mattpocock/skills --skill tdd` |
+| `triage` | `mattpocock/skills` | `npx skills add mattpocock/skills --skill triage` |
 
-If `tdd` is unavailable, stop and report its source and exact install command.
+If `tdd` is unavailable, stop the execution lane and report its source and
+exact install command. Permit a triage-only tail run to continue.
 
 `to-plan` is required only while processing `Planning`. If it is unavailable,
 block those planning items locally and continue implementation items whose
 marker-owned plans and handoffs are current.
+
+`triage` is required only while processing an unblocked Backlog
+`needs-triage` item. If it is unavailable, block only the triage lane, continue
+authorized execution, and report its source and exact install command from the
+table.
+
+The explicit `run-github-project` procedure may dispatch `triage` to its
+recommendation boundary. Its disabled implicit invocation and maintainer
+approval gate still prohibit automatic label, comment, or close mutations.
 
 ## Preferred Review Providers
 

--- a/skills/run-github-project/scripts/rank_tickets.py
+++ b/skills/run-github-project/scripts/rank_tickets.py
@@ -52,14 +52,14 @@ def parse_args() -> argparse.Namespace:
         help="GitHub login allowed to authorize Planning transitions. Repeat as needed.",
     )
     parser.add_argument(
+        "--backlog-status",
+        default="Backlog",
+        help="Configured Project status display name for untriaged or human work.",
+    )
+    parser.add_argument(
         "--planning-status",
         default="Planning",
         help="Configured GitHub Project status display name that queues planning.",
-    )
-    parser.add_argument(
-        "--backlog-status",
-        default="Backlog",
-        help="Configured Project status display name that requires human work.",
     )
     parser.add_argument(
         "--ready-status",
@@ -70,6 +70,11 @@ def parse_args() -> argparse.Namespace:
         "--in-progress-status",
         default="In progress",
         help="Configured GitHub Project status display name that marks an item active.",
+    )
+    parser.add_argument(
+        "--needs-triage-label",
+        default="needs-triage",
+        help="Configured issue label that queues an unblocked Backlog item for triage.",
     )
     parser.add_argument(
         "--priority",
@@ -140,7 +145,12 @@ def timestamp(value: Any, field: str, number: Any) -> datetime:
     return result
 
 
-def pull_request_values(values: Any, number: Any) -> list[dict[str, Any]]:
+def pull_request_values(
+    values: Any,
+    number: Any,
+    *,
+    require_execution_fields: bool,
+) -> list[dict[str, Any]]:
     if not isinstance(values, list):
         raise InputError(f"ticket {number}: openPullRequests must be an array")
     result: list[dict[str, Any]] = []
@@ -158,8 +168,15 @@ def pull_request_values(values: Any, number: Any) -> list[dict[str, Any]]:
             raise InputError(
                 f"ticket {number}: pull request number must be a positive integer",
             )
+        nonempty_string(value.get("url"), "pull request url", number)
+        if not isinstance(value.get("closesIssue"), bool):
+            raise InputError(
+                f"ticket {number}: pull request closesIssue must be a boolean",
+            )
+        if not require_execution_fields:
+            result.append(value)
+            continue
         for field in (
-            "url",
             "author",
             "headRepository",
             "headRefName",
@@ -168,10 +185,6 @@ def pull_request_values(values: Any, number: Any) -> list[dict[str, Any]]:
             "baseRefName",
         ):
             nonempty_string(value.get(field), f"pull request {field}", number)
-        if not isinstance(value.get("closesIssue"), bool):
-            raise InputError(
-                f"ticket {number}: pull request closesIssue must be a boolean",
-            )
         if not isinstance(value.get("isDraft"), bool):
             raise InputError(
                 f"ticket {number}: pull request isDraft must be a boolean",
@@ -188,6 +201,19 @@ def parse_project_position(value: Any, number: Any) -> float:
     if value < 0:
         raise InputError(f"ticket {number}: projectPosition must be a non-negative number")
     return float(value)
+
+
+def project_priority_rank(
+    project_priority: str | None,
+    priorities: tuple[str, ...],
+) -> tuple[int, str | None]:
+    if project_priority is not None and project_priority not in priorities:
+        return len(priorities), f"unknown project priority {project_priority!r}"
+    return (
+        priorities.index(project_priority)
+        if project_priority is not None
+        else len(priorities)
+    ), None
 
 
 def require_ticket_shape(ticket: Any) -> dict[str, Any]:
@@ -448,6 +474,41 @@ def parse_implementation_plan_chain(
     return plans, active
 
 
+def analyze_common_ticket(
+    ticket: dict[str, Any],
+    priorities: tuple[str, ...],
+    *,
+    require_execution_pr_fields: bool,
+) -> dict[str, Any]:
+    number = ticket["number"]
+    priority_rank, priority_error = project_priority_rank(
+        ticket["projectPriority"],
+        priorities,
+    )
+    return {
+        "assignees": assignee_values(ticket["assignees"], number),
+        "labels": string_values(ticket["labels"], "labels", number),
+        "blockers": string_values(ticket["blockedBy"], "blockedBy", number),
+        "openDescendants": string_values(
+            ticket["openDescendants"],
+            "openDescendants",
+            number,
+        ),
+        "pullRequests": pull_request_values(
+            ticket["openPullRequests"],
+            number,
+            require_execution_fields=require_execution_pr_fields,
+        ),
+        "projectPosition": parse_project_position(
+            ticket["projectPosition"],
+            number,
+        ),
+        "priorityRank": priority_rank,
+        "errors": [priority_error] if priority_error is not None else [],
+        "exclusions": [],
+    }
+
+
 def analyze_ticket(
     ticket: dict[str, Any],
     *,
@@ -462,24 +523,26 @@ def analyze_ticket(
     execution_approvers: tuple[str, ...],
 ) -> dict[str, Any]:
     number = ticket["number"]
-    assignees = assignee_values(ticket["assignees"], number)
-    labels = string_values(ticket["labels"], "labels", number)
-    blockers = string_values(ticket["blockedBy"], "blockedBy", number)
-    open_descendants = string_values(
-        ticket["openDescendants"],
-        "openDescendants",
-        number,
+    common = analyze_common_ticket(
+        ticket,
+        priorities,
+        require_execution_pr_fields=True,
     )
-    pull_requests = pull_request_values(ticket["openPullRequests"], number)
-    project_position = parse_project_position(ticket["projectPosition"], number)
+    assignees = common["assignees"]
+    labels = common["labels"]
+    blockers = common["blockers"]
+    open_descendants = common["openDescendants"]
+    pull_requests = common["pullRequests"]
+    project_position = common["projectPosition"]
+    priority_rank = common["priorityRank"]
     project_status = ticket["projectStatus"]
     assigned_to_current_user = current_user in assignees
     recovering_backlog_cleanup = (
         project_status == backlog_status and assigned_to_current_user
     )
 
-    errors: list[str] = []
-    exclusions: list[str] = []
+    errors = common["errors"]
+    exclusions = common["exclusions"]
     if "ready-for-agent" not in labels and not recovering_backlog_cleanup:
         exclusions.append("missing ready-for-agent label")
 
@@ -765,15 +828,6 @@ def analyze_ticket(
             f"found {project_status!r}",
         )
 
-    project_priority = ticket["projectPriority"]
-    if project_priority is not None and project_priority not in priorities:
-        errors.append(f"unknown project priority {project_priority!r}")
-    priority_rank = (
-        priorities.index(project_priority)
-        if project_priority is not None and project_priority in priorities
-        else len(priorities)
-    )
-
     if blockers and not recovering_backlog_cleanup:
         exclusions.append(f"blocked by {blockers}")
     if open_descendants and not recovering_backlog_cleanup:
@@ -910,6 +964,55 @@ def analyze_ticket(
     }
 
 
+def analyze_backlog_ticket(
+    ticket: dict[str, Any],
+    *,
+    needs_triage_label: str,
+    priorities: tuple[str, ...],
+) -> dict[str, Any]:
+    common = analyze_common_ticket(
+        ticket,
+        priorities,
+        require_execution_pr_fields=False,
+    )
+    assignees = common["assignees"]
+    labels = common["labels"]
+    blockers = common["blockers"]
+    open_descendants = common["openDescendants"]
+    pull_requests = common["pullRequests"]
+    project_position = common["projectPosition"]
+    priority_rank = common["priorityRank"]
+
+    errors = common["errors"]
+    exclusions = common["exclusions"]
+    blocker_reasons: list[str] = []
+    if str(ticket["state"]).upper() != "OPEN":
+        exclusions.append("not open")
+    if needs_triage_label not in labels:
+        exclusions.append("human work required in Backlog")
+
+    if assignees:
+        exclusions.append(f"assigned to {assignees}")
+    if pull_requests:
+        exclusions.append(
+            "has open implementation PRs "
+            f"{[pull_request['url'] for pull_request in pull_requests]}",
+        )
+    if blockers:
+        blocker_reasons.append(f"blocked by {blockers}")
+    if open_descendants:
+        blocker_reasons.append(f"open descendants {open_descendants}")
+
+    return {
+        "ticket": ticket,
+        "priorityRank": priority_rank,
+        "projectPosition": project_position,
+        "blockerReasons": blocker_reasons,
+        "errors": errors,
+        "exclusions": exclusions,
+    }
+
+
 def ticket_rank(item: dict[str, Any]) -> tuple[int, float, int]:
     return (
         item["priorityRank"],
@@ -931,11 +1034,22 @@ def main() -> int:
         execution_approvers = tuple(args.execution_approvers)
         if len(set(execution_approvers)) != len(execution_approvers):
             raise InputError("execution approvers must be unique")
+        statuses = (
+            args.backlog_status,
+            args.planning_status,
+            args.ready_status,
+            args.in_progress_status,
+        )
+        if len(set(statuses)) != len(statuses):
+            raise InputError("project statuses must be unique")
+        if not args.needs_triage_label:
+            raise InputError("needs-triage label must be non-empty")
         if not 1 <= args.max_claims <= 3:
             raise InputError("max claims must be between 1 and 3")
 
         seen_numbers: set[int] = set()
-        analyses: list[dict[str, Any]] = []
+        execution_analyses: list[dict[str, Any]] = []
+        triage_analyses: list[dict[str, Any]] = []
         invalid_unclaimed: list[dict[str, Any]] = []
         invalid_claimed: list[dict[str, Any]] = []
         invalid_planning_claimed: list[dict[str, Any]] = []
@@ -945,20 +1059,35 @@ def main() -> int:
                 if ticket["number"] in seen_numbers:
                     raise InputError(f"duplicate ticket number {ticket['number']}")
                 seen_numbers.add(ticket["number"])
-                analyses.append(
-                    analyze_ticket(
+                if (
+                    ticket["projectStatus"] == args.backlog_status
+                    and not has_current_user_assignment(
                         ticket,
-                        current_user=args.current_user,
-                        backlog_status=args.backlog_status,
-                        planning_status=args.planning_status,
-                        ready_status=args.ready_status,
-                        in_progress_status=args.in_progress_status,
-                        priorities=priorities,
-                        repository=args.repository,
-                        base_branch=args.base_branch,
-                        execution_approvers=execution_approvers,
-                    ),
-                )
+                        args.current_user,
+                    )
+                ):
+                    triage_analyses.append(
+                        analyze_backlog_ticket(
+                            ticket,
+                            needs_triage_label=args.needs_triage_label,
+                            priorities=priorities,
+                        ),
+                    )
+                else:
+                    execution_analyses.append(
+                        analyze_ticket(
+                            ticket,
+                            current_user=args.current_user,
+                            backlog_status=args.backlog_status,
+                            planning_status=args.planning_status,
+                            ready_status=args.ready_status,
+                            in_progress_status=args.in_progress_status,
+                            priorities=priorities,
+                            repository=args.repository,
+                            base_branch=args.base_branch,
+                            execution_approvers=execution_approvers,
+                        ),
+                    )
             except InputError as error:
                 number = raw_ticket.get("number", "?") if isinstance(raw_ticket, dict) else "?"
                 invalid = {
@@ -978,6 +1107,11 @@ def main() -> int:
                         invalid_planning_claimed.append(invalid)
                     else:
                         invalid_claimed.append(invalid)
+                elif (
+                    isinstance(raw_ticket, dict)
+                    and raw_ticket.get("projectStatus") == args.backlog_status
+                ):
+                    invalid_unclaimed.append(invalid)
                 else:
                     invalid_unclaimed.append(invalid)
 
@@ -986,7 +1120,7 @@ def main() -> int:
                 "number": item["ticket"]["number"],
                 "reasons": item["errors"] + item["exclusions"],
             }
-            for item in analyses
+            for item in execution_analyses
             if (
                 item["assignedToCurrentUser"]
                 and item["ticket"]["projectStatus"] == args.in_progress_status
@@ -998,7 +1132,7 @@ def main() -> int:
                 "number": item["ticket"]["number"],
                 "reasons": item["errors"] + item["exclusions"],
             }
-            for item in analyses
+            for item in execution_analyses
             if (
                 item["assignedToCurrentUser"]
                 and item["ticket"]["projectStatus"]
@@ -1012,7 +1146,9 @@ def main() -> int:
         ]
 
         eligible = [
-            item for item in analyses if not item["errors"] and not item["exclusions"]
+            item
+            for item in execution_analyses
+            if not item["errors"] and not item["exclusions"]
         ]
         claimed = [item for item in eligible if item["assignedToCurrentUser"]]
         claimed.sort(
@@ -1062,12 +1198,32 @@ def main() -> int:
                 "number": item["ticket"]["number"],
                 "reasons": item["errors"] + item["exclusions"],
             }
-            for item in analyses
+            for item in execution_analyses
             if (
                 not item["assignedToCurrentUser"]
                 and (item["errors"] or item["exclusions"])
             )
+        ] + [
+            {
+                "number": item["ticket"]["number"],
+                "reasons": item["errors"] + item["exclusions"],
+            }
+            for item in triage_analyses
+            if item["errors"] or item["exclusions"]
         ]
+        eligible_triage = [
+            item
+            for item in triage_analyses
+            if not item["errors"] and not item["exclusions"]
+        ]
+        triage_candidates = sorted(
+            (item for item in eligible_triage if not item["blockerReasons"]),
+            key=ticket_rank,
+        )
+        parked_blocked = sorted(
+            (item for item in eligible_triage if item["blockerReasons"]),
+            key=ticket_rank,
+        )
         output = {
             "claimLimit": args.max_claims,
             "blockedClaims": blocked_claims,
@@ -1088,6 +1244,20 @@ def main() -> int:
                     ),
                 }
                 for item in candidates
+            ],
+            "triageCandidates": [
+                {
+                    "ticket": item["ticket"],
+                    "action": "triage",
+                }
+                for item in triage_candidates
+            ],
+            "parkedBlocked": [
+                {
+                    "ticket": item["ticket"],
+                    "reasons": item["blockerReasons"],
+                }
+                for item in parked_blocked
             ],
             "excluded": excluded,
         }

--- a/skills/run-github-project/scripts/test_rank_tickets.py
+++ b/skills/run-github-project/scripts/test_rank_tickets.py
@@ -34,6 +34,8 @@ DEFAULT_STATUS_ARGUMENTS = (
     "Ready",
     "--in-progress-status",
     "In progress",
+    "--needs-triage-label",
+    "needs-triage",
 )
 
 
@@ -113,6 +115,19 @@ def ticket(number: int, **overrides: object) -> dict:
     }
     if "implementationPlan" in overrides:
         result.pop("implementationPlans")
+    result.update(overrides)
+    return result
+
+
+def backlog_ticket(number: int, **overrides: object) -> dict:
+    result = ticket(
+        number,
+        projectStatus="Backlog",
+        labels=["needs-triage"],
+        planningTransition=None,
+        readyTransition=None,
+        implementationPlan=None,
+    )
     result.update(overrides)
     return result
 
@@ -315,6 +330,37 @@ class RankTicketsTest(unittest.TestCase):
         self.assertEqual(
             ["resume-backlog-cleanup", "resume-implementation"],
             [entry["action"] for entry in output["claims"]],
+        )
+
+    def test_keeps_assigned_cleanup_separate_from_unassigned_triage(self) -> None:
+        cleanup = ticket(
+            205,
+            projectStatus="Backlog",
+            assignees=["chris"],
+            replanRequest=replan_request(205, disposition="human-required"),
+            backlogTransition={
+                "id": "PVTE_205_backlog",
+                "actor": "chris",
+                "createdAt": "2026-07-28T12:00:00Z",
+                "status": "Backlog",
+                "wasAutomated": False,
+            },
+        )
+        triage = backlog_ticket(206)
+
+        returncode, output = run_ranker([triage, cleanup])
+
+        self.assertEqual(0, returncode)
+        self.assertEqual(
+            ["resume-backlog-cleanup"],
+            [entry["action"] for entry in output["claims"]],
+        )
+        self.assertEqual(
+            [206],
+            [
+                entry["ticket"]["number"]
+                for entry in output["triageCandidates"]
+            ],
         )
 
     def test_backlog_cleanup_ignores_implementation_readiness_changes(self) -> None:
@@ -586,6 +632,126 @@ class RankTicketsTest(unittest.TestCase):
             output["excluded"],
         )
 
+    def test_ranks_unblocked_backlog_triage_candidates_separately(self) -> None:
+        later = backlog_ticket(12, projectPosition=20)
+        earlier = backlog_ticket(13, projectPosition=2)
+        critical = backlog_ticket(
+            14,
+            projectPriority="Critical",
+            projectPosition=200,
+        )
+        implementation = ticket(15, projectPriority="Low")
+
+        returncode, output = run_ranker(
+            [later, earlier, critical, implementation],
+        )
+
+        self.assertEqual(0, returncode)
+        self.assertEqual(
+            [14, 13, 12],
+            [
+                entry["ticket"]["number"]
+                for entry in output["triageCandidates"]
+            ],
+        )
+        self.assertEqual(
+            ["triage", "triage", "triage"],
+            [entry["action"] for entry in output["triageCandidates"]],
+        )
+        self.assertEqual(
+            [15],
+            [entry["ticket"]["number"] for entry in output["candidates"]],
+        )
+
+    def test_parks_backlog_item_with_open_native_blocker(self) -> None:
+        blocked = backlog_ticket(16, blockedBy=[17])
+
+        returncode, output = run_ranker([blocked])
+
+        self.assertEqual(0, returncode)
+        self.assertEqual([], output["triageCandidates"])
+        self.assertEqual(
+            [
+                {
+                    "ticket": blocked,
+                    "reasons": ["blocked by ['17']"],
+                },
+            ],
+            output["parkedBlocked"],
+        )
+        self.assertEqual([], output["excluded"])
+
+    def test_parks_backlog_parent_with_open_descendant(self) -> None:
+        parent = backlog_ticket(18, openDescendants=[19])
+
+        returncode, output = run_ranker([parent])
+
+        self.assertEqual(0, returncode)
+        self.assertEqual([], output["triageCandidates"])
+        self.assertEqual(
+            [
+                {
+                    "ticket": parent,
+                    "reasons": ["open descendants ['19']"],
+                },
+            ],
+            output["parkedBlocked"],
+        )
+
+    def test_does_not_triage_backlog_item_without_needs_triage_label(self) -> None:
+        ready = backlog_ticket(22, labels=["ready-for-agent"])
+
+        returncode, output = run_ranker([ready])
+
+        self.assertEqual(0, returncode)
+        self.assertEqual([], output["triageCandidates"])
+        self.assertEqual([], output["parkedBlocked"])
+        self.assertEqual(
+            [{"number": 22, "reasons": ["human work required in Backlog"]}],
+            output["excluded"],
+        )
+
+    def test_does_not_automatically_triage_assigned_backlog_item(self) -> None:
+        assigned = backlog_ticket(23, assignees=["maintainer"])
+
+        returncode, output = run_ranker([assigned])
+
+        self.assertEqual(0, returncode)
+        self.assertEqual([], output["triageCandidates"])
+        self.assertEqual(
+            [{"number": 23, "reasons": ["assigned to ['maintainer']"]}],
+            output["excluded"],
+        )
+
+    def test_does_not_automatically_triage_backlog_item_with_open_pr(self) -> None:
+        with_pull_request = backlog_ticket(
+            24,
+            openPullRequests=[
+                {
+                    "number": 240,
+                    "url": "https://github.com/acme/repo/pull/240",
+                    "closesIssue": True,
+                },
+            ],
+        )
+
+        returncode, output = run_ranker([with_pull_request])
+
+        self.assertEqual(0, returncode)
+        self.assertEqual([], output["triageCandidates"])
+        self.assertEqual(
+            [
+                {
+                    "number": 24,
+                    "reasons": [
+                        "has open implementation PRs "
+                        "['https://github.com/acme/repo/pull/240']",
+                    ],
+                },
+            ],
+            output["excluded"],
+        )
+
     def test_invalid_unclaimed_item_does_not_stop_other_ready_work(self) -> None:
         invalid = ticket(
             20,
@@ -773,6 +939,17 @@ class RankTicketsTest(unittest.TestCase):
 
         self.assertEqual(2, result.returncode)
         self.assertIn("--priority", result.stderr)
+
+    def test_status_names_must_be_unique(self) -> None:
+        returncode, output = run_ranker(
+            [],
+            "--backlog-status",
+            "Ready",
+        )
+
+        self.assertEqual(2, returncode)
+        self.assertEqual("invalid-input", output["reason"])
+        self.assertEqual("project statuses must be unique", output["error"])
 
     def test_assignee_objects_use_login_as_identity(self) -> None:
         claimed = ticket(


### PR DESCRIPTION
## Summary

- add a separate, blocker-aware Backlog triage inventory for unassigned `needs-triage` issues
- park issues with native blockers or open descendants, then dispatch the unchanged `triage` provider only after execution, Planning, assigned Backlog cleanup, and implementation slots are clear
- preserve the provider's maintainer approval gate and leave `ready-for-agent` outcomes in Backlog until a human moves them to Planning
- extend the normalized schema, deterministic ranker, project configuration, workflow documentation, and tests while preserving autonomous replanning and crash-safe assigned Backlog cleanup

## Why

`run-github-project` previously ignored Backlog items. Issues blocked by other tickets therefore remained in `needs-triage`, but there was no blocker-aware path to re-evaluate them automatically after their dependencies cleared.

The new tail lane separates dependency parking from actionable triage without manufacturing execution authority or changing the `triage` skill.

## Impact

A project run can now recommend triage outcomes for eligible Backlog work after authorized execution is exhausted. Label, comment, and close mutations still require explicit maintainer approval, and triage cannot bypass unresolved execution, Planning, or assigned cleanup work.

## Validation

- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest skills/run-github-project/scripts/test_rank_tickets.py` — 58 tests passed
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile skills/run-github-project/scripts/rank_tickets.py skills/run-github-project/scripts/test_rank_tickets.py`
- `python3 /Users/chris/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/run-github-project`
- `npm run lint`
- `git diff --check`
- final `review-and-simplify-changes` and `ponytail-review` passes found no remaining actionable issues