### PR TITLE
Support epics and human checkpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ See [`.opencode/INSTALL.md`](.opencode/INSTALL.md) for details.
 ### Workflows
 
 - [`to-plan`](skills/to-plan/SKILL.md) — create a repository-aware implementation plan from one ready GitHub issue or a confirmed conversation specification, with a provider-neutral implementation handoff.
-- [`run-github-project`](skills/run-github-project/SKILL.md) — triage unblocked Backlog work after the execution queue clears, or plan and execute authorized GitHub Project issues through one planning lane and a two-slot-by-default parallel pipeline with portable, capability-based agent routing and suggested model levels. Requires `tdd` for implementation and preserves the `triage` provider's approval gate.
+- [`run-github-project`](skills/run-github-project/SKILL.md) — reconcile epics, surface resumable human checkpoints, triage unblocked Backlog work, and plan and execute authorized GitHub Project issues through one planning lane and a two-slot-by-default parallel pipeline. Requires `tdd` for implementation and preserves human Planning and triage approval gates.
 - [`shepherd`](skills/shepherd/SKILL.md) — autonomously poll open PRs and MRs, triage review comments, detect and fix CI failures, and keep PRs moving forward.
 
 ## Contributing

--- a/skills/run-github-project/SKILL.md
+++ b/skills/run-github-project/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: run-github-project
-description: Use when asked to triage Backlog work, plan and execute the next authorized issue, or drain authorized issues from a configured GitHub Project through implementation, review, merge, and reconciliation.
+description: Use when asked to reconcile GitHub Project epics or human checkpoints, triage Backlog work, plan and execute the next authorized issue, or drain authorized issues through implementation, review, merge, and reconciliation.
 ---
 
 # Run GitHub Project
@@ -14,6 +14,12 @@ contract-preserving re-plans, and return true human work to Backlog.
 Park dependency-blocked Backlog items. After authorized execution is empty,
 route unblocked `needs-triage` items through the unchanged `triage` approval
 gate without manufacturing Planning authority.
+
+Treat configured epics and human work as a separate live frontier. Reconcile a
+bare epic only after its native dependencies close and issue-close authority is
+present. Surface every currently actionable human step without assigning it or
+pausing independent work. Return `waiting-for-human` when that frontier is the
+only work left.
 
 Pair each occupied slot with one warm worktree and one persistent ticket agent.
 Run independent slot agents concurrently in `drain`. Keep claims, shared
@@ -34,6 +40,8 @@ Require:
 - Status field name and ID plus Backlog, Planning, Ready to implement, In
   progress, and Done option names and IDs;
 - the exact repository label mapped to the `needs-triage` role;
+- the exact repository label name and ID mapped to the epic work shape;
+- the exact repository label name and ID mapped to the human-work role;
 - Priority field name and ID plus option names and IDs in descending order;
 - execution-approver GitHub logins allowed to authorize Planning;
 - an optional trusted Project filter expression;
@@ -70,38 +78,40 @@ both before every claim and merge. Stop and preserve work if either changes.
 3. Require `tdd` before implementation work. Follow
    [references/workflow-providers.md](references/workflow-providers.md); stop
    the execution lane with its exact source and install command if `tdd` is
-   unavailable. Permit a triage-only tail run to continue. Never install it
+   unavailable. Permit controller-only epic reconciliation, human-frontier
+   reporting, and a triage-only tail run to continue. Never install it
    implicitly or approximate it.
-4. Read [references/planning-lane.md](references/planning-lane.md). Verify
+4. Read [references/human-frontier.md](references/human-frontier.md).
+5. Read [references/planning-lane.md](references/planning-lane.md). Verify
    `to-plan` before planning work; if missing, block only the planning lane.
-5. Read [references/triage-lane.md](references/triage-lane.md). Verify
+6. Read [references/triage-lane.md](references/triage-lane.md). Verify
    `triage` before Backlog work; if missing, block only the triage lane.
-6. Read [references/review-contracts.md](references/review-contracts.md).
+7. Read [references/review-contracts.md](references/review-contracts.md).
    Prefer the named review providers in
    [references/workflow-providers.md](references/workflow-providers.md), but
    permit equivalent installed skills or direct execution of the bundled
    contracts. Record the provider for each contract. Do not stop solely because
    a preferred provider is unavailable.
-7. Confirm the authenticated GitHub identity, Project read/write access,
+8. Confirm the authenticated GitHub identity, Project read/write access,
    GitHub CLI `project` scope, current default, verified base, and clean state.
-8. Inspect repository automation that can change Project Status or archive Done
+9. Inspect repository automation that can change Project Status or archive Done
    items. Stop if it conflicts with the configured Backlog, Planning, Ready to
    implement, In progress, and Done lifecycle.
-9. Select and record a run mode:
-   - `next` is the default and processes at most one selected issue;
-   - `drain` is allowed only when the user explicitly asks to drain, run all,
-     repeat, or continue until empty. Run occupied slots concurrently by
-     default. Use two as both the default in-flight ticket count and ticket
-     agent concurrency limit. Accept any positive user-specified limit; impose
-     no skill-defined maximum.
-10. Before any execution claim, require explicit merge authority for the
+10. Select and record a run mode. Use `next` by default and process at most one
+    selected issue. Allow `drain` only when the user explicitly asks to drain,
+    run all, repeat, or continue until empty. Run occupied slots concurrently
+    by default. Use two as both the default in-flight ticket count and ticket
+    agent concurrency limit. Accept any positive user-specified limit; impose
+    no skill-defined maximum.
+11. Before any execution claim, require explicit merge authority for the
    mode's scope: the one selected issue in `next`, or every eligible issue
    encountered in `drain`. Without it, stop before claiming execution; never
    bypass an executable ticket by entering triage. A triage-only selection
    requires no merge authority, and triage approval never supplies it. Also
-   require explicit issue-close authority when `close-after-merge` is
-   configured.
-11. For `drain`, read and follow
+    require explicit issue-close authority when `close-after-merge` is
+    configured. Before reconciling an epic, require explicit issue-close
+    authority covering every eligible epic in the mode's scope.
+12. For `drain`, read and follow
    [references/drain-scheduler.md](references/drain-scheduler.md).
 
 Do not support publish-only mode or impose a ticket cap in `drain`. Standing
@@ -167,19 +177,21 @@ next invocation.
    - Planning, Ready to implement, or In progress Status; or
    - Backlog Status while assigned to the authenticated runner, solely to
      recover interrupted human-work cleanup; or
-   - Backlog Status plus the exact configured `needs-triage` label for the
-     triage inventory.
+   - Backlog Status plus the exact `ready-for-agent`, configured epic,
+     configured human-work, or configured `needs-triage` label for the Backlog
+     frontier.
 4. Record draft, pull-request, redacted, cross-repository, closed, malformed,
    or filter-excluded items as ineligible. Never convert draft items into
    tickets or use a named Project view implicitly.
 5. Build execution contender classes in the exact order defined by
    [Planning Lane](references/planning-lane.md#scheduling). Build the separate
-   triage inventory through
+   Backlog frontier through
+   [Epics And Human Frontier](references/human-frontier.md) and
    [Backlog Triage Lane](references/triage-lane.md). Within each class use
    Priority, visible position, then issue number. Do not preempt a claim.
 6. Phase two: hydrate contenders in order with fresh batched GraphQL reads.
    Gather:
-   - native open `blocked by` relationships;
+   - native open `blocked by` and `blocking` relationships;
    - all open descendants in the issue's sub-issue tree;
    - for execution and assigned-Backlog cleanup contenders, the latest status
      events entering Backlog, Planning, and Ready to implement,
@@ -218,6 +230,8 @@ python3 <skill-dir>/scripts/rank_tickets.py \
   --ready-status <ready-to-implement-name> \
   --in-progress-status <in-progress-name> \
   --needs-triage-label <needs-triage-label> \
+  --epic-label <epic-label> \
+  --human-work-label <human-work-label> \
   --priority <highest-name> [--priority <next-name> ...] \
   --max-claims <mode-slot-limit> \
   < normalized-tickets.json
@@ -240,8 +254,10 @@ fill free capacity from returned `candidates`. Planning and
 `resume-backlog-cleanup` claims do not count toward `max-claims`. Finish
 Backlog cleanup before new claims. Leave an In progress item assigned to
 someone else alone. Report an unassigned In progress item as stale and
-ineligible; ignore an unassigned Backlog item without the exact configured
-`needs-triage` label until a human moves it to Planning.
+ineligible. Route an unassigned Backlog item with an exact frontier role label
+through the epic, human, Planning-authorization, or triage collection. Ignore
+an unlabelled Backlog item as human-owned until a human adds a role label or
+moves it to Planning.
 
 When no claim exists, hydrate current-user PR contenders before new work.
 Otherwise preserve the phase-one Priority, visible-position, and issue-number
@@ -252,7 +268,9 @@ item without stopping valid work. Preserve a claimed planning blocker without
 an implementation slot; block only the affected implementation slot when
 claimed implementation becomes ineligible.
 
-Preserve returned `parkedBlocked` items without invoking `triage`. Keep returned
+Preserve returned role-tagged `parkedBlocked` items without invoking `triage`.
+Process returned `readyEpics` and `humanActions` through
+[Epics And Human Frontier](references/human-frontier.md). Keep returned
 `triageCandidates` outside the execution scheduler until the authoritative
 execution-clear predicate in
 [Backlog Triage Lane](references/triage-lane.md#dispatch) is satisfied. Then
@@ -262,6 +280,11 @@ Resume a linked PR only when exactly one open PR clearly closes the issue, its
 author is the authenticated user, it targets the configured repository and
 base branch, and no competing implementation PR exists. Never adopt another
 author's PR.
+
+In `next`, reconcile at most one ready epic when no existing claim or execution
+candidate is selected, then finish after its live Project reconciliation. In
+`drain`, reconcile ready epics through the controller lane and immediately
+refresh the graph before selecting more work.
 
 ## Claim And Revalidate
 
@@ -528,8 +551,9 @@ isolation rules from the drain scheduler.
 
 Finish `next` after one selected execution issue reaches a confirmed terminal
 outcome and the post-merge live query succeeds, or after one tail-lane triage
-issue reaches a reconciled outcome when no executable issue exists. For
-`drain`, treat
+issue or ready epic reaches a reconciled outcome when no executable issue
+exists. Return `waiting-for-human` instead when no autonomous action exists and
+the live human frontier is non-empty. For `drain`, treat
 [Failure Isolation And Finish Gate](references/drain-scheduler.md#failure-isolation-and-finish-gate)
 as the authoritative success, partial-drain, preservation, and cleanup
 procedure. In `next`, preserve the worktree, branch, PR, assignment, and In
@@ -541,6 +565,7 @@ failed ticket automatically.
 Report the run mode, slot limit, Project configuration digest, live queries,
 merge-authority outcome, scheduler result, peak ticket-agent concurrency,
 named resource-lock grants, waits, recoveries, triage provider result,
+ready-epic reconciliations, the current human frontier packet,
 `parkedBlocked` inventory, triage recommendations and reconciled outcomes, and
 one row per occupied ticket containing:
 
@@ -714,3 +739,27 @@ For each changed rule, establish RED by reverting it, then require GREEN. Add a 
     Counterexamples: a mechanical documentation ticket stays routine and does
     not escalate merely because deep capacity is available, and a runtime with
     only generic subagents expresses the same roles in prompts without stopping.
+32. RED sends every Backlog parent through triage or implementation; GREEN
+    returns a bare configured epic as `readyEpics` only after its native open
+    blockers and descendants clear, then closes it in the controller lane with
+    explicit authority and reconciles Done. Novel case: its closure exposes a
+    downstream Planning-authorization action on the refreshed graph.
+    Counterexample: an epic with configured human work is never auto-closed.
+33. RED hides `ready-for-agent` Backlog work or treats conversation approval as
+    Planning authority; GREEN returns `move-to-planning` in `humanActions` and
+    waits for the approver's live Project transition. Novel case: several
+    independent human actions appear in one ordered frontier packet while an
+    unrelated implementation slot continues. Counterexample: an unchanged
+    frontier packet is not repeated.
+34. RED treats a human frontier as a failed partial drain or a successful empty
+    drain; GREEN returns `waiting-for-human` only after controller, planning,
+    implementation, monitoring, and triage work clear. Novel case: resumption
+    reconstructs the graph after a long pause and obtains fresh merge and epic-
+    close authority. Counterexample: a blocked claimed slot remains a partial
+    drain.
+35. RED parses issue prose as a dependency or permits conflicting role labels;
+    GREEN schedules only from native relationships, reports prose drift, and
+    rejects epic-plus-agent or multiple next-action roles. Novel case: an
+    assigned human gate remains a human action rather than interrupted runner
+    cleanup. Counterexample: an unassigned bare epic needs no next-action role
+    label.

--- a/skills/run-github-project/agents/openai.yaml
+++ b/skills/run-github-project/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: "Run GitHub Project"
-  short_description: "Triage and execute authorized Project work"
-  default_prompt: "Use $run-github-project in next mode to execute one authorized issue, or triage one unblocked Backlog issue when no executable work remains, after confirming the required authority."
+  short_description: "Reconcile, triage, and execute Project work"
+  default_prompt: "Use $run-github-project in next mode to reconcile one ready epic, execute one authorized issue, or surface the current human checkpoint; use explicit drain mode to continue until success, waiting-for-human, or a partial drain."
 
 policy:
   allow_implicit_invocation: false

--- a/skills/run-github-project/references/drain-scheduler.md
+++ b/skills/run-github-project/references/drain-scheduler.md
@@ -37,6 +37,10 @@ Use this scheduler only for `drain`. Keep `next` single-ticket.
    the authoritative execution-clear predicate in
    [Backlog Triage Lane](triage-lane.md#dispatch). It consumes no implementation
    slot and processes one issue at a time.
+9. Keep ready epics and human actions in the separate
+   [Epics And Human Frontier](human-frontier.md). They consume neither a slot
+   nor agent capacity. Serialize epic closure in the controller lane, surface
+   changed human actions immediately, and continue independent work.
 
 ## Parallel Workers And Controller Lane
 
@@ -146,22 +150,28 @@ dispatching the next:
 1. Finish any interrupted assigned-Backlog cleanup before new claims.
 2. Merge the oldest merge-ready slot, unless an explicit dependency requires a
    different order. Admit or merge only one at a time.
-3. Resume owning ticket agents for actionable review, CI, or base-repair events
+3. Reconcile the highest-ranked ready epic with issue-close authority, then
+   refresh the complete Project graph before taking another action.
+4. Resume owning ticket agents for actionable review, CI, or base-repair events
    in oldest-event order.
-4. Resume paused local implementation slots in claim order.
-5. Finish a current contract-preserving replan, other plan, or verified
+5. Resume paused local implementation slots in claim order.
+6. Finish a current contract-preserving replan, other plan, or verified
    planning handoff without preemption. Choose preserved replan claims before
    other Planning claims.
-6. Apply the [Conflict Admission Gate](#conflict-admission-gate), claim ranked
+7. Apply the [Conflict Admission Gate](#conflict-admission-gate), claim ranked
    `Ready to implement` tickets one at a time, and launch unrelated slot agents
    until the in-flight or active-agent limit is reached.
-7. Start the next ranked `Planning` item only when the planning lane and active
+8. Start the next ranked `Planning` item only when the planning lane and active
    agent capacity are free after maximizing runnable implementation.
-8. Monitor all remote slots together only when no local or controller action
+9. Monitor all remote slots together only when no local or controller action
    remains.
-9. After the authoritative execution-clear predicate in
+10. After the authoritative execution-clear predicate in
    [Backlog Triage Lane](triage-lane.md#dispatch) is satisfied, process the next
    unblocked Backlog `needs-triage` item through the triage tail lane.
+
+At startup and after every refreshed query, present the changed human frontier
+packet from [Epics And Human Frontier](human-frontier.md). Never wait for its
+actions while any step above remains runnable.
 
 Never preempt a valid occupied slot for newly higher-priority work. Requery and
 rank live data before every just-in-time claim.
@@ -234,10 +244,12 @@ item without the configured `needs-triage` label remains human-owned; an
 eligible labeled item belongs only to the triage tail lane.
 
 Finish successfully only when the authoritative execution-clear predicate in
-[Backlog Triage Lane](triage-lane.md#dispatch) is satisfied and a complete live
-query has no non-deferred triage candidate after merge reconciliation.
-Dependency-parked Backlog items do not prevent success; report their live
-blockers. If no runnable work remains but a claim or slot is blocked or timed
-out, or the triage provider cannot complete an eligible item, stop with a
-partial-drain report, preserve every affected worktree, branch, PR, assignment,
-and `In progress` Status, and never report success.
+[Backlog Triage Lane](triage-lane.md#dispatch) is satisfied, a complete live
+query has no non-deferred triage candidate after merge reconciliation, and no
+human action remains. Dependency-parked Backlog items do not prevent success;
+report their live blockers. If only human actions remain, return
+`waiting-for-human` through [Epics And Human Frontier](human-frontier.md). If no
+runnable work remains but a claim or slot is blocked or timed out, or the
+triage provider cannot complete an eligible item, stop with a partial-drain
+report, preserve every affected worktree, branch, PR, assignment, and
+`In progress` Status, and never report success.

--- a/skills/run-github-project/references/human-frontier.md
+++ b/skills/run-github-project/references/human-frontier.md
@@ -1,0 +1,92 @@
+# Epics And Human Frontier
+
+Use this lane for Backlog work whose next action belongs to the controller or
+a human rather than an implementation agent.
+
+## Classify Work
+
+Treat the configured `epic` label as the work shape. Treat the exact
+`ready-for-agent`, configured human-work, and configured `needs-triage` labels
+as mutually exclusive next-action roles.
+
+Classify an open Backlog issue as follows:
+
+| Labels | Result |
+| --- | --- |
+| Epic only | Closeable epic after native dependencies clear |
+| Epic plus human work | Human epic after native dependencies clear |
+| Human work only | Human action after native dependencies clear |
+| Ready for agent only | Human Planning authorization after native dependencies clear |
+| Needs triage | Existing triage lane after native dependencies clear |
+
+Reject `epic` plus `ready-for-agent` and multiple next-action labels. Treat an
+unlabelled non-epic Backlog issue as human-owned and outside this frontier.
+Permit an existing human assignee on human work, but never assign one from this
+workflow. Require a bare epic, Planning authorization request, or triage item
+to have no assignee or open implementation pull request. Use only native open
+blockers and descendants as gates. Report a prose-only dependency discrepancy,
+but never enforce it.
+
+## Build The Frontier
+
+1. Rank ready epics, human actions, and parked work by Priority, visible
+   Project position, then issue number.
+2. Return a bare unblocked epic as `readyEpics` with action `close-epic`.
+3. Return unblocked human work as `humanActions` with action
+   `perform-human-work`.
+4. Return an unblocked Backlog `ready-for-agent` issue as `humanActions` with
+   action `move-to-planning`.
+5. Return a dependency-blocked item as role-tagged `parkedBlocked`.
+6. Derive what each action unlocks from reverse native blocker and parent-child
+   relationships in the complete live graph. Do not infer unlocks from prose.
+
+Present one ordered frontier packet containing every current human action and
+its direct unlocks. Present it when its action, issue, blockers, or direct
+unlocks change. Do not repeat an unchanged packet and do not stop autonomous
+controller, planning, implementation, monitoring, or triage work merely
+because the packet is non-empty.
+
+## Reconcile A Ready Epic
+
+Enter the controller lane and require standing issue-close authority covering
+the epic. Refetch it and require all of:
+
+1. open issue state and configured repository and Project membership;
+2. Backlog Status and the configured epic label;
+3. no next-action role label, assignee, or open implementation pull request;
+4. no native open blocker or descendant; and
+5. unchanged configuration digest and verified base.
+
+Close the issue directly with the live descendant and blocker evidence. Treat
+an ambiguous response as unknown, refetch before retrying, and never issue a
+duplicate close. Reconcile the Project Status and archive state through the
+configured Done automation exactly as for a merged issue. Then perform a
+complete live Project refresh before selecting more work.
+
+In `next`, reconcile at most one ready epic and finish. In `drain`, reconcile
+ready epics serially and continue through newly unlocked work.
+
+## Wait For Human Work
+
+Never assign human work, move it to Planning, close it, or treat conversation
+approval as a durable Project transition. Require the configured execution
+approver to perform each `move-to-planning` transition. Observe human work
+completion only through refreshed authoritative GitHub state.
+
+Return `waiting-for-human` only when no controller, planning, implementation,
+monitoring, or non-deferred triage action remains and `humanActions` is
+non-empty. This result is resumable and is neither success nor partial drain.
+Report the complete frontier packet, parked dependency chain, and actions that
+would become available next.
+
+On a later invocation, reconstruct the frontier from GitHub. Expire all prior
+standing mutation authority and obtain one fresh confirmation covering the
+remaining eligible merges and epic closures. Use no local checkpoint as an
+authority source.
+
+## Finish Gate
+
+Finish successfully only when the ordinary drain finish gate passes and no
+human action remains. Return partial drain only for a failed, ambiguous,
+blocked, or timed-out claimed lane. Never call a human frontier a failure or
+successful empty drain.

--- a/skills/run-github-project/references/human-frontier.md
+++ b/skills/run-github-project/references/human-frontier.md
@@ -86,7 +86,9 @@ authority source.
 
 ## Finish Gate
 
-Finish successfully only when the ordinary drain finish gate passes and no
-human action remains. Return partial drain only for a failed, ambiguous,
-blocked, or timed-out claimed lane. Never call a human frontier a failure or
-successful empty drain.
+Use the authoritative drain finish gate in
+[Drain Scheduler](drain-scheduler.md#failure-isolation-and-finish-gate),
+including its partial-drain result for an eligible triage item that the triage
+provider cannot complete. Finish successfully only when that gate passes and no
+human action remains. Never call a human frontier a failure or successful empty
+drain.

--- a/skills/run-github-project/references/normalized-ticket.md
+++ b/skills/run-github-project/references/normalized-ticket.md
@@ -96,6 +96,11 @@ execution-only author, draft, head, and base fields:
 }
 ```
 
+Use that same Backlog shape for configured epics, human work, and
+`ready-for-agent` items awaiting Planning authorization. Preserve every exact
+label. The ranker derives the work shape and next action from configured label
+names; never add a synthetic role to its input.
+
 Use GitHub logins, never display names, for assignees, PR authors, and
 transition actors. Normalize `labels` to exact label names. Normalize
 `blockedBy` and `openDescendants` entries to integer issue numbers for the
@@ -162,6 +167,12 @@ no open implementation pull request. Return an otherwise valid item with open
 native blockers or descendants as `parkedBlocked`; return an unblocked item as
 `triageCandidates`. Never feed either collection into an implementation slot.
 
+For other unassigned Backlog work, apply
+[Epics And Human Frontier](human-frontier.md). Return a bare unblocked epic as
+`readyEpics`, and return unblocked human work or agent work awaiting Planning
+as `humanActions`. Permit an existing assignee only on human work. Role-tag
+every dependency-blocked Backlog result in `parkedBlocked`.
+
 The ranker returns valid current-user claims and ordered unclaimed candidates:
 
 ```json
@@ -186,9 +197,17 @@ The ranker returns valid current-user claims and ordered unclaimed candidates:
   "triageCandidates": [
     {"ticket": {"number": 47}, "action": "triage"}
   ],
+  "readyEpics": [
+    {"ticket": {"number": 48}, "action": "close-epic"}
+  ],
+  "humanActions": [
+    {"ticket": {"number": 49}, "action": "move-to-planning"},
+    {"ticket": {"number": 50}, "action": "perform-human-work"}
+  ],
   "parkedBlocked": [
     {
-      "ticket": {"number": 48},
+      "ticket": {"number": 51},
+      "role": "human-epic",
       "reasons": ["blocked by ['owner/repository#41']"]
     }
   ],
@@ -201,11 +220,13 @@ controller owns scheduling; the ranker only validates claims and orders
 candidates. Each `blockedClaims` entry occupies a slot and preserves a claimed
 implementation ticket that requires reconciliation. Planning claims and
 `blockedPlanningClaims` preserve ownership but do not consume an implementation
-slot; both still prevent the Backlog triage tail from starting. Triage
+slot; both still prevent the Backlog triage tail from starting. Ready epics and
+human actions consume neither slots nor agent capacity. Triage
 `resume-backlog-cleanup` also consumes no implementation slot, must finish
 before new claims, and prevents the triage tail from starting. Its cleanup is
 idempotent: already-absent owned artifacts satisfy their individual finish
 checks, but the assignment remains until the complete cleanup state is
 verified. Triage candidates are ordered separately and run only through
-[Backlog Triage Lane](triage-lane.md); parked items consume neither a slot nor
-an agent.
+[Backlog Triage Lane](triage-lane.md). Process ready epics and human actions
+through [Epics And Human Frontier](human-frontier.md); parked items consume
+neither a slot nor an agent.

--- a/skills/run-github-project/references/project-config.md
+++ b/skills/run-github-project/references/project-config.md
@@ -42,6 +42,13 @@ closest trusted `AGENTS.md` or `CLAUDE.md` must reference that exact file.
 
 - Needs-triage label: `<repository label mapped to needs-triage>`
 
+## Work Roles
+
+- Epic label: `<repository label mapped to epic>`
+- Epic label ID: `<LA_...>`
+- Human-work label: `<repository label mapped to ready-for-human>`
+- Human-work label ID: `<LA_...>`
+
 ## Priority
 
 - Field name: `<Priority>`
@@ -65,6 +72,11 @@ closest trusted `AGENTS.md` or `CLAUDE.md` must reference that exact file.
 Keep human-readable names beside IDs so startup validation can distinguish a
 rename from an ID that now identifies a different object. Preserve repository-
 specific comments and additions when repairing stale mappings.
+
+Treat the epic label as a work-shape declaration and the human-work label as a
+next-action role. Require both mappings even when the current Project has no
+matching issue. Never infer either role from issue titles or bodies. Humans
+create and rename role labels; never do so from this workflow.
 
 Humans own the Project schema. Never create or rename Status options from the
 runner. Before migrating an existing queue, require zero `In progress` items

--- a/skills/run-github-project/references/triage-lane.md
+++ b/skills/run-github-project/references/triage-lane.md
@@ -32,7 +32,10 @@ claim, runnable Planning or Ready candidate, active planning handoff, or
 occupied implementation slot. Treat `resume-backlog-cleanup` and
 `blockedPlanningClaims` as unresolved work even though they consume no
 implementation slot. Malformed or excluded unclaimed items do not block the
-tail lane. Never pause authorized execution to ask for a triage decision.
+tail lane. Ready epics run in the controller lane before triage. Human actions
+do not block triage; include any newly approved human-work or Planning action in
+the current frontier packet. Never pause authorized execution to ask for a
+triage decision.
 
 In `next`, process at most the first ranked triage contender when no executable
 ticket exists. In `drain`, process contenders one at a time until none remain,
@@ -78,8 +81,9 @@ Use the batched post-mutation read to reconcile the approved outcome:
 - For `ready-for-agent`, require the provider's durable agent brief and exact
   label transition. Leave the item in Backlog and report that it awaits a
   human Planning transition; never manufacture execution authority.
-- For `ready-for-human`, `needs-info`, or `wontfix`, require the provider's
-  approved comment, label, and closure result as applicable.
+- For the configured human-work label, `needs-info`, or `wontfix`, require the
+  provider's approved comment, label, and closure result as applicable. Leave
+  open human work in Backlog for the human frontier.
 - For `needs-triage`, a rejected recommendation, or a deferred decision, leave
   the item unchanged and mark it deferred for this invocation so it cannot
   loop.
@@ -94,6 +98,7 @@ non-deferred unblocked triage contender. Report:
 
 - every triaged issue and reconciled outcome;
 - every issue awaiting human Planning authorization;
+- every human action added to the frontier;
 - every deferred or blocked triage attempt;
 - every `parkedBlocked` issue and its live blockers; and
 - provider or GitHub failures that left the lane incomplete.

--- a/skills/run-github-project/scripts/rank_tickets.py
+++ b/skills/run-github-project/scripts/rank_tickets.py
@@ -1150,7 +1150,15 @@ def main() -> int:
                     "number": number,
                     "reasons": [str(error)],
                 }
-                if has_current_user_assignment(raw_ticket, args.current_user):
+                is_human_frontier_item = (
+                    isinstance(raw_ticket, dict)
+                    and raw_ticket.get("projectStatus") == args.backlog_status
+                    and isinstance(raw_ticket.get("labels"), list)
+                    and args.human_work_label in raw_ticket["labels"]
+                )
+                if is_human_frontier_item:
+                    invalid_unclaimed.append(invalid)
+                elif has_current_user_assignment(raw_ticket, args.current_user):
                     if (
                         isinstance(raw_ticket, dict)
                         and raw_ticket.get("projectStatus")

--- a/skills/run-github-project/scripts/rank_tickets.py
+++ b/skills/run-github-project/scripts/rank_tickets.py
@@ -16,6 +16,7 @@ class InputError(ValueError):
 
 
 IMPLEMENTATION_ACTIONS = {"resume-pr", "resume-implementation"}
+AGENT_WORK_LABEL = "ready-for-agent"
 CLAIM_ACTION_RANK = {
     "resume-backlog-cleanup": 0,
     "resume-pr": 1,
@@ -75,6 +76,16 @@ def parse_args() -> argparse.Namespace:
         "--needs-triage-label",
         default="needs-triage",
         help="Configured issue label that queues an unblocked Backlog item for triage.",
+    )
+    parser.add_argument(
+        "--epic-label",
+        required=True,
+        help="Configured issue label that identifies a non-implementation parent.",
+    )
+    parser.add_argument(
+        "--human-work-label",
+        required=True,
+        help="Configured issue label that identifies work a human must perform.",
     )
     parser.add_argument(
         "--priority",
@@ -543,8 +554,8 @@ def analyze_ticket(
 
     errors = common["errors"]
     exclusions = common["exclusions"]
-    if "ready-for-agent" not in labels and not recovering_backlog_cleanup:
-        exclusions.append("missing ready-for-agent label")
+    if AGENT_WORK_LABEL not in labels and not recovering_backlog_cleanup:
+        exclusions.append(f"missing {AGENT_WORK_LABEL} label")
 
     planning_transition = parse_transition(
         ticket["planningTransition"],
@@ -968,6 +979,8 @@ def analyze_backlog_ticket(
     ticket: dict[str, Any],
     *,
     needs_triage_label: str,
+    epic_label: str,
+    human_work_label: str,
     priorities: tuple[str, ...],
 ) -> dict[str, Any]:
     common = analyze_common_ticket(
@@ -988,12 +1001,37 @@ def analyze_backlog_ticket(
     blocker_reasons: list[str] = []
     if str(ticket["state"]).upper() != "OPEN":
         exclusions.append("not open")
-    if needs_triage_label not in labels:
-        exclusions.append("human work required in Backlog")
+    is_epic = epic_label in labels
+    is_agent_work = AGENT_WORK_LABEL in labels
+    is_human_work = human_work_label in labels
+    needs_triage = needs_triage_label in labels
+    action_roles = [is_agent_work, is_human_work, needs_triage]
+    if sum(action_roles) > 1:
+        exclusions.append("conflicting Backlog action labels")
+    if is_epic and is_agent_work:
+        exclusions.append("epic cannot be ready for agent implementation")
 
-    if assignees:
+    role: str | None = None
+    action: str | None = None
+    if not exclusions:
+        if is_human_work:
+            role = "human-epic" if is_epic else "human"
+            action = "perform-human-work"
+        elif needs_triage:
+            role = "triage"
+            action = "triage"
+        elif is_agent_work:
+            role = "agent"
+            action = "move-to-planning"
+        elif is_epic:
+            role = "epic"
+            action = "close-epic"
+        else:
+            exclusions.append("unclassified Backlog work")
+
+    if assignees and role not in ("human", "human-epic"):
         exclusions.append(f"assigned to {assignees}")
-    if pull_requests:
+    if pull_requests and role not in ("human", "human-epic"):
         exclusions.append(
             "has open implementation PRs "
             f"{[pull_request['url'] for pull_request in pull_requests]}",
@@ -1007,6 +1045,8 @@ def analyze_backlog_ticket(
         "ticket": ticket,
         "priorityRank": priority_rank,
         "projectPosition": project_position,
+        "role": role,
+        "action": action,
         "blockerReasons": blocker_reasons,
         "errors": errors,
         "exclusions": exclusions,
@@ -1042,14 +1082,22 @@ def main() -> int:
         )
         if len(set(statuses)) != len(statuses):
             raise InputError("project statuses must be unique")
-        if not args.needs_triage_label:
-            raise InputError("needs-triage label must be non-empty")
+        role_labels = (
+            args.needs_triage_label,
+            args.epic_label,
+            args.human_work_label,
+            AGENT_WORK_LABEL,
+        )
+        if any(not label for label in role_labels):
+            raise InputError("role labels must be non-empty")
+        if len(set(role_labels)) != len(role_labels):
+            raise InputError("role labels must be unique")
         if not 1 <= args.max_claims <= 3:
             raise InputError("max claims must be between 1 and 3")
 
         seen_numbers: set[int] = set()
         execution_analyses: list[dict[str, Any]] = []
-        triage_analyses: list[dict[str, Any]] = []
+        backlog_analyses: list[dict[str, Any]] = []
         invalid_unclaimed: list[dict[str, Any]] = []
         invalid_claimed: list[dict[str, Any]] = []
         invalid_planning_claimed: list[dict[str, Any]] = []
@@ -1061,15 +1109,23 @@ def main() -> int:
                 seen_numbers.add(ticket["number"])
                 if (
                     ticket["projectStatus"] == args.backlog_status
-                    and not has_current_user_assignment(
-                        ticket,
-                        args.current_user,
+                    and (
+                        not has_current_user_assignment(
+                            ticket,
+                            args.current_user,
+                        )
+                        or (
+                            isinstance(ticket["labels"], list)
+                            and args.human_work_label in ticket["labels"]
+                        )
                     )
                 ):
-                    triage_analyses.append(
+                    backlog_analyses.append(
                         analyze_backlog_ticket(
                             ticket,
                             needs_triage_label=args.needs_triage_label,
+                            epic_label=args.epic_label,
+                            human_work_label=args.human_work_label,
                             priorities=priorities,
                         ),
                     )
@@ -1208,20 +1264,38 @@ def main() -> int:
                 "number": item["ticket"]["number"],
                 "reasons": item["errors"] + item["exclusions"],
             }
-            for item in triage_analyses
+            for item in backlog_analyses
             if item["errors"] or item["exclusions"]
         ]
-        eligible_triage = [
+        eligible_backlog = [
             item
-            for item in triage_analyses
+            for item in backlog_analyses
             if not item["errors"] and not item["exclusions"]
         ]
         triage_candidates = sorted(
-            (item for item in eligible_triage if not item["blockerReasons"]),
+            (
+                item for item in eligible_backlog
+                if item["action"] == "triage" and not item["blockerReasons"]
+            ),
+            key=ticket_rank,
+        )
+        ready_epics = sorted(
+            (
+                item for item in eligible_backlog
+                if item["action"] == "close-epic" and not item["blockerReasons"]
+            ),
+            key=ticket_rank,
+        )
+        human_actions = sorted(
+            (
+                item for item in eligible_backlog
+                if item["action"] in ("move-to-planning", "perform-human-work")
+                and not item["blockerReasons"]
+            ),
             key=ticket_rank,
         )
         parked_blocked = sorted(
-            (item for item in eligible_triage if item["blockerReasons"]),
+            (item for item in eligible_backlog if item["blockerReasons"]),
             key=ticket_rank,
         )
         output = {
@@ -1248,13 +1322,28 @@ def main() -> int:
             "triageCandidates": [
                 {
                     "ticket": item["ticket"],
-                    "action": "triage",
+                    "action": item["action"],
                 }
                 for item in triage_candidates
+            ],
+            "readyEpics": [
+                {
+                    "ticket": item["ticket"],
+                    "action": item["action"],
+                }
+                for item in ready_epics
+            ],
+            "humanActions": [
+                {
+                    "ticket": item["ticket"],
+                    "action": item["action"],
+                }
+                for item in human_actions
             ],
             "parkedBlocked": [
                 {
                     "ticket": item["ticket"],
+                    "role": item["role"],
                     "reasons": item["blockerReasons"],
                 }
                 for item in parked_blocked

--- a/skills/run-github-project/scripts/test_rank_tickets.py
+++ b/skills/run-github-project/scripts/test_rank_tickets.py
@@ -36,6 +36,10 @@ DEFAULT_STATUS_ARGUMENTS = (
     "In progress",
     "--needs-triage-label",
     "needs-triage",
+    "--epic-label",
+    "epic",
+    "--human-work-label",
+    "ready-for-human",
 )
 
 
@@ -413,11 +417,11 @@ class RankTicketsTest(unittest.TestCase):
         self.assertEqual(
             [
                 {
-                    "number": 204,
-                    "reasons": ["human work required in Backlog"],
+                    "ticket": backlog,
+                    "action": "move-to-planning",
                 },
             ],
-            output["excluded"],
+            output["humanActions"],
         )
 
     def test_human_planning_transition_after_backlog_starts_fresh(self) -> None:
@@ -674,6 +678,7 @@ class RankTicketsTest(unittest.TestCase):
             [
                 {
                     "ticket": blocked,
+                    "role": "triage",
                     "reasons": ["blocked by ['17']"],
                 },
             ],
@@ -692,13 +697,101 @@ class RankTicketsTest(unittest.TestCase):
             [
                 {
                     "ticket": parent,
+                    "role": "triage",
                     "reasons": ["open descendants ['19']"],
                 },
             ],
             output["parkedBlocked"],
         )
 
-    def test_does_not_triage_backlog_item_without_needs_triage_label(self) -> None:
+    def test_unblocked_epic_is_ready_for_reconciliation(self) -> None:
+        epic = backlog_ticket(19, labels=["epic"])
+
+        returncode, output = run_ranker([epic])
+
+        self.assertEqual(0, returncode)
+        self.assertEqual(
+            [{"ticket": epic, "action": "close-epic"}],
+            output["readyEpics"],
+        )
+
+    def test_parks_epic_until_its_native_descendants_close(self) -> None:
+        epic = backlog_ticket(
+            20,
+            labels=["epic"],
+            openDescendants=[21],
+        )
+
+        returncode, output = run_ranker([epic])
+
+        self.assertEqual(0, returncode)
+        self.assertEqual([], output["readyEpics"])
+        self.assertEqual(
+            [
+                {
+                    "ticket": epic,
+                    "role": "epic",
+                    "reasons": ["open descendants ['21']"],
+                },
+            ],
+            output["parkedBlocked"],
+        )
+
+    def test_human_gated_epic_is_never_automatically_closed(self) -> None:
+        epic = backlog_ticket(
+            21,
+            labels=["epic", "ready-for-human"],
+        )
+
+        returncode, output = run_ranker([epic])
+
+        self.assertEqual(0, returncode)
+        self.assertEqual([], output["readyEpics"])
+        self.assertEqual(
+            [{"ticket": epic, "action": "perform-human-work"}],
+            output["humanActions"],
+        )
+
+    def test_human_work_waits_for_native_blockers(self) -> None:
+        human_work = backlog_ticket(
+            22,
+            labels=["ready-for-human"],
+            blockedBy=[20],
+        )
+
+        returncode, output = run_ranker([human_work])
+
+        self.assertEqual(0, returncode)
+        self.assertEqual([], output["humanActions"])
+        self.assertEqual(
+            [
+                {
+                    "ticket": human_work,
+                    "role": "human",
+                    "reasons": ["blocked by ['20']"],
+                },
+            ],
+            output["parkedBlocked"],
+        )
+
+    def test_current_user_assignment_does_not_turn_human_work_into_cleanup(self) -> None:
+        human_work = backlog_ticket(
+            23,
+            labels=["ready-for-human"],
+            assignees=["chris"],
+        )
+
+        returncode, output = run_ranker([human_work])
+
+        self.assertEqual(0, returncode)
+        self.assertEqual([], output["claims"])
+        self.assertEqual([], output["blockedPlanningClaims"])
+        self.assertEqual(
+            [{"ticket": human_work, "action": "perform-human-work"}],
+            output["humanActions"],
+        )
+
+    def test_ready_for_agent_backlog_item_requests_planning_transition(self) -> None:
         ready = backlog_ticket(22, labels=["ready-for-agent"])
 
         returncode, output = run_ranker([ready])
@@ -707,7 +800,47 @@ class RankTicketsTest(unittest.TestCase):
         self.assertEqual([], output["triageCandidates"])
         self.assertEqual([], output["parkedBlocked"])
         self.assertEqual(
-            [{"number": 22, "reasons": ["human work required in Backlog"]}],
+            [{"ticket": ready, "action": "move-to-planning"}],
+            output["humanActions"],
+        )
+
+    def test_human_action_does_not_hide_runnable_agent_work(self) -> None:
+        human_work = backlog_ticket(24, labels=["ready-for-human"])
+        agent_work = ticket(25)
+
+        returncode, output = run_ranker([human_work, agent_work])
+
+        self.assertEqual(0, returncode)
+        self.assertEqual(
+            [25],
+            [entry["ticket"]["number"] for entry in output["candidates"]],
+        )
+        self.assertEqual(
+            [24],
+            [entry["ticket"]["number"] for entry in output["humanActions"]],
+        )
+
+    def test_rejects_conflicting_backlog_action_labels(self) -> None:
+        conflicting = backlog_ticket(
+            26,
+            labels=["ready-for-agent", "ready-for-human"],
+        )
+        implementation_epic = backlog_ticket(
+            27,
+            labels=["epic", "ready-for-agent"],
+        )
+
+        returncode, output = run_ranker([conflicting, implementation_epic])
+
+        self.assertEqual(0, returncode)
+        self.assertEqual(
+            [
+                {"number": 26, "reasons": ["conflicting Backlog action labels"]},
+                {
+                    "number": 27,
+                    "reasons": ["epic cannot be ready for agent implementation"],
+                },
+            ],
             output["excluded"],
         )
 

--- a/skills/run-github-project/scripts/test_rank_tickets.py
+++ b/skills/run-github-project/scripts/test_rank_tickets.py
@@ -791,6 +791,23 @@ class RankTicketsTest(unittest.TestCase):
             output["humanActions"],
         )
 
+    def test_malformed_assigned_human_work_is_not_a_planning_claim(self) -> None:
+        human_work = backlog_ticket(
+            24,
+            labels=["ready-for-human"],
+            assignees=["chris"],
+        )
+        del human_work["projectPosition"]
+
+        returncode, output = run_ranker([human_work])
+
+        self.assertEqual(0, returncode)
+        self.assertEqual([], output["blockedPlanningClaims"])
+        self.assertEqual(
+            [{"number": 24, "reasons": ["ticket 24: missing projectPosition"]}],
+            output["excluded"],
+        )
+
     def test_ready_for_agent_backlog_item_requests_planning_transition(self) -> None:
         ready = backlog_ticket(22, labels=["ready-for-agent"])
 


### PR DESCRIPTION
## Summary
- add configured epic and human-work roles to `run-github-project`
- expose ready epics, human actions, and waiting-for-human frontier behavior
- document controller reconciliation and add deterministic ranker coverage

## Why
Coordination parents and human gates previously appeared only as blocked or triage work, preventing the drain from expressing actionable manual checkpoints while independent leaf work continued.

## Validation
- `python3 skills/run-github-project/scripts/test_rank_tickets.py` (65 tests)
- `npm run lint`
- `python3 /Users/chris/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/run-github-project`
- `git diff --check origin/main...HEAD`
- repeated `review-and-simplify-changes`, `code-review`, and `ponytail-review`