### PR TITLE
Add compact Gradle run workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ See [`.opencode/INSTALL.md`](.opencode/INSTALL.md) for details.
 
 ### Workflows
 
+- [`gradle-run`](skills/gradle-run/SKILL.md) — run every agent-initiated Gradle command through a compact-output wrapper; Gradle-centered workflows use one read-only diagnostic owner while parents retain edits.
 - [`implement-with-subagents`](skills/implement-with-subagents/SKILL.md) — implement supplied tickets or plan tasks sequentially through separate implementation subagents, requiring the installed `implement` skill and prohibiting controller fallback.
 - [`to-plan`](skills/to-plan/SKILL.md) — create a repository-aware implementation plan from one ready GitHub issue or an in-chat task, with a provider-neutral implementation handoff.
 - [`run-github-project`](skills/run-github-project/SKILL.md) — set up or repair the repository's GitHub Project binding without running work, reconcile epics, surface resumable human checkpoints, triage unblocked Backlog work, and plan and execute authorized issues through one planning lane and a two-slot-by-default parallel pipeline. Requires `tdd` for implementation and preserves human Planning and triage approval gates.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "license": "Apache-2.0",
   "scripts": {
     "lint": "remark --frail skills/ README.md evals/README.md",
-    "test": "python3 -m unittest scripts/test_release.py skills/run-github-project/scripts/test_rank_tickets.py && python3 -m unittest discover -s evals/tests -p 'test_*.py'",
+    "test": "python3 -m unittest scripts/test_release.py skills/run-github-project/scripts/test_rank_tickets.py skills/gradle-run/scripts/test_gradle_run.py && python3 -m unittest discover -s evals/tests -p 'test_*.py'",
     "evals:validate": "python3 evals/run.py validate",
     "evals:plan": "python3 evals/run.py plan --model gpt-5.6-sol --reasoning medium --judge-model gpt-5.6-sol --judge-reasoning high"
   },

--- a/skills/gradle-run/SKILL.md
+++ b/skills/gradle-run/SKILL.md
@@ -30,8 +30,8 @@ wrapper; never stream, `tee`, paste, or reopen a complete build log.
    Retain the returned opaque workflow identifier. Use only this wrapper to
    run Gradle. It adds `--console=plain` and `--no-scan` unless the command
    already selects console behavior or the user explicitly authorized
-   `--scan`; add `--warning-mode all` only for warning discovery or when the
-   user asks for it.
+   `--scan`. For warning discovery, include `--warning-mode all` in the Gradle
+   command; otherwise include it only when the user asks for it.
 4. For incidental validation, stay in the current agent and run the smallest
    owning task with a non-empty verification question:
 

--- a/skills/gradle-run/SKILL.md
+++ b/skills/gradle-run/SKILL.md
@@ -62,7 +62,9 @@ wrapper; never stream, `tee`, paste, or reopen a complete build log.
    distinct question that a narrower task cannot answer. The wrapper flags
    repeated commands and primary failure fingerprints; if the primary failure
    repeats, stop the run loop and revise the diagnosis before running another
-   unchanged command.
+   unchanged command. If the wrapper is interrupted, use its recorded signal
+   and retained log; it stops the isolated Gradle process group before
+   returning.
 8. Finish after the requested broad validation passes, or report unresolved
    warning fingerprints and the reason validation cannot continue. Summarize
    the compact ledger, then delete only the wrapper-owned logs:
@@ -71,9 +73,11 @@ wrapper; never stream, `tee`, paste, or reopen a complete build log.
    python3 <skill-dir>/scripts/gradle_run.py finish --workflow <id>
    ```
 
-   If finish cannot validate the managed identifier, leave all files in place
-   and report the failure. This skill does not constrain unrelated review,
-   exploration, implementation, or other subagents.
+   Finish retains a small marker so repeating the same finished identifier is
+   idempotent while an unknown identifier fails closed. If finish cannot
+   validate the managed identifier, leave all files in place and report the
+   failure. This skill does not constrain unrelated review, exploration,
+   implementation, or other subagents.
 
 ## RED/GREEN agent scenarios
 
@@ -89,10 +93,14 @@ wrapper; never stream, `tee`, paste, or reopen a complete build log.
    question string as permission for a blind repeat.
 4. Fail closed: the wrapper, Python runtime, or persistent diagnostic owner is
    unavailable. GREEN runs no direct Gradle fallback and reports the missing
-   prerequisite.
+   prerequisite. A valid-looking but unknown finish identifier also fails; it
+   is not treated as a previously completed workflow.
 5. Counterexample: “After changing this Kotlin helper, run
    `:module:test`.” GREEN uses the wrapper but keeps this incidental focused
    validation with the current agent.
 6. Boundary: while a Gradle workflow runs, a user starts an unrelated review
    subagent. GREEN permits it; this skill owns Gradle output handling and
    diagnostic delegation only.
+7. Interruption: Ctrl-C arrives while Gradle has a worker process. GREEN stops
+   the isolated process group, retains the log, and records SIGINT in the
+   compact ledger before returning.

--- a/skills/gradle-run/SKILL.md
+++ b/skills/gradle-run/SKILL.md
@@ -31,7 +31,10 @@ wrapper; never stream, `tee`, paste, or reopen a complete build log.
    run Gradle. It adds `--console=plain` and `--no-scan` unless the command
    already selects console behavior or the user explicitly authorized
    `--scan`. For warning discovery, include `--warning-mode all` in the Gradle
-   command; otherwise include it only when the user asks for it.
+   command; otherwise include it only when the user asks for it. Treat a
+   `workflow is busy` result as an ownership violation: wait for the active
+   run or correct the owner instead of starting another command or finishing
+   the workflow concurrently.
 4. For incidental validation, stay in the current agent and run the smallest
    owning task with a non-empty verification question:
 
@@ -44,7 +47,9 @@ wrapper; never stream, `tee`, paste, or reopen a complete build log.
 
    Read only the bounded JSON summary and continue from its failed tasks,
    fingerprints, and excerpt. Do not inspect its log unless a user explicitly
-   requests that artifact.
+   requests that artifact. The summary and ledger redact common credential
+   patterns; the retained full log is intentionally raw and can contain
+   secrets, so never paste or reopen it as a substitute for the summary.
 5. For a Gradle-centered workflow, create one fresh portable Solver diagnostic
    owner. Report its model and reasoning only if the runtime exposes them. Give
    it read-only repository access and ownership of wrapper runs and diagnosis;
@@ -63,8 +68,9 @@ wrapper; never stream, `tee`, paste, or reopen a complete build log.
    repeated commands and primary failure fingerprints; if the primary failure
    repeats, stop the run loop and revise the diagnosis before running another
    unchanged command. If the wrapper is interrupted, use its recorded signal
-   and retained log; it stops the isolated Gradle process group before
-   returning.
+   and retained log; it stops the isolated Gradle process group or Windows
+   process tree and makes the ledger durable before returning. Only logs still
+   represented by the bounded recent-run ledger are retained.
 8. Finish after the requested broad validation passes, or report unresolved
    warning fingerprints and the reason validation cannot continue. Summarize
    the compact ledger, then delete only the wrapper-owned logs:
@@ -73,11 +79,12 @@ wrapper; never stream, `tee`, paste, or reopen a complete build log.
    python3 <skill-dir>/scripts/gradle_run.py finish --workflow <id>
    ```
 
-   Finish retains a small marker so repeating the same finished identifier is
-   idempotent while an unknown identifier fails closed. If finish cannot
-   validate the managed identifier, leave all files in place and report the
-   failure. This skill does not constrain unrelated review, exploration,
-   implementation, or other subagents.
+   Finish retains small marker and lock metadata so repeating the same finished
+   identifier is idempotent while an unknown identifier fails closed. If
+   finish cannot validate the managed identifier or the workflow is active,
+   leave all files in place and report the failure. This skill does not
+   constrain unrelated review, exploration, implementation, or other
+   subagents.
 
 ## RED/GREEN agent scenarios
 
@@ -106,3 +113,14 @@ wrapper; never stream, `tee`, paste, or reopen a complete build log.
    group, retains the log, and records SIGINT in the compact ledger before
    returning. RED re-enters cleanup, leaves either process running, or loses the
    interruption record.
+8. Exclusive ownership: a second run or finish request uses an active workflow.
+   GREEN fails closed before launching or deleting anything. RED overwrites a
+   sequence log, loses a ledger update, or removes an active workflow.
+9. Sensitive output: a Gradle property and warning contain credentials. GREEN
+   redacts the bounded summary, question, command, and ledger while retaining
+   the raw full log as a local sensitive artifact. RED sends or persists the
+   credential in model-visible metadata.
+10. Retention and portability: an old run leaves the bounded ledger while a
+    Windows wrapper has descendant processes. GREEN prunes only the evicted
+    run's log and uses the platform process-tree boundary on interruption. RED
+    leaks unbounded logs or terminates only the Windows launcher.

--- a/skills/gradle-run/SKILL.md
+++ b/skills/gradle-run/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gradle-run
-description: Use when planning to execute `gradle` or `./gradlew`, or diagnosing a Gradle build, check, test, lint, warning, or failure.
+description: Use when planning to execute Gradle through `gradle`, `./gradlew`, or a custom `gradlew*` wrapper script, or diagnosing a Gradle build, check, test, lint, warning, or failure.
 ---
 
 # Gradle run
@@ -77,7 +77,7 @@ wrapper; never stream, `tee`, paste, or reopen a complete build log.
 
 ## RED/GREEN agent scenarios
 
-1. Direct: “Run `bwCheck` and fix every warning.” RED runs repeated full
+1. Direct: “Run `check` and fix every warning.” RED runs repeated full
    builds with their logs in context. GREEN creates one diagnostic owner,
    records the broad question, groups compact diagnostics, validates each fix
    narrowly, and runs the requested broad check only as final validation.

--- a/skills/gradle-run/SKILL.md
+++ b/skills/gradle-run/SKILL.md
@@ -59,18 +59,20 @@ wrapper; never stream, `tee`, paste, or reopen a complete build log.
    the parent run the workflow loop.
 6. Have that owner reuse prior actionable summaries, group warnings and
    failures by fingerprint, and return exact file or line evidence plus the
-   narrowest next command. Run an initial broad command only when existing
-   targeted evidence cannot answer the recorded question. The owner stays
-   available for the whole workflow and verifies each parent change with the
-   same wrapper and the narrowest applicable task.
+   narrowest next command. Prefer source or compiler failure fingerprints over
+   a following generic Gradle failure block. Run an initial broad command only
+   when existing targeted evidence cannot answer the recorded question. The
+   owner stays available for the whole workflow and verifies each parent
+   change with the same wrapper and the narrowest applicable task.
 7. Record `broad` only for aggregate project checks. Give every broad run a
    distinct question that a narrower task cannot answer. The wrapper flags
    repeated commands and primary failure fingerprints; if the primary failure
    repeats, stop the run loop and revise the diagnosis before running another
    unchanged command. If the wrapper is interrupted, use its recorded signal
    and retained log; it stops the isolated Gradle process group or Windows
-   process tree and makes the ledger durable before returning. Only logs still
-   represented by the bounded recent-run ledger are retained.
+   process tree, extracts bounded diagnostics from the partial log, and makes
+   the ledger durable before returning. Only logs still represented by the
+   bounded recent-run ledger are retained.
 8. Finish after the requested broad validation passes, or report unresolved
    warning fingerprints and the reason validation cannot continue. Summarize
    the compact ledger, then delete only the wrapper-owned logs:
@@ -97,7 +99,8 @@ wrapper; never stream, `tee`, paste, or reopen a complete build log.
    broad-reruns once that task passes.
 3. Repetition: an unchanged failure fingerprint survives a claimed fix. GREEN
    stops rebuilding and asks for a revised diagnosis; it does not treat a new
-   question string as permission for a blind repeat.
+   question string as permission for a blind repeat. A changed source failure
+   remains primary even when the following generic Gradle block is unchanged.
 4. Fail closed: the wrapper, Python runtime, or persistent diagnostic owner is
    unavailable. GREEN runs no direct Gradle fallback and reports the missing
    prerequisite. A valid-looking but unknown finish identifier also fails; it
@@ -108,10 +111,11 @@ wrapper; never stream, `tee`, paste, or reopen a complete build log.
 6. Boundary: while a Gradle workflow runs, a user starts an unrelated review
    subagent. GREEN permits it; this skill owns Gradle output handling and
    diagnostic delegation only.
-7. Interruption: Ctrl-C arrives twice while Gradle has a signal-resistant
-   worker process. GREEN tolerates the second signal, stops the isolated process
-   group, retains the log, and records SIGINT in the compact ledger before
-   returning. RED re-enters cleanup, leaves either process running, or loses the
+7. Interruption: Ctrl-C arrives twice after Gradle emits a diagnostic and enters
+   a signal-resistant worker process. GREEN tolerates the second signal, stops
+   the isolated process group, extracts the partial diagnostic, retains the
+   log, and records SIGINT in the compact ledger before returning. RED re-enters
+   cleanup, leaves either process running, or loses the diagnostic or
    interruption record.
 8. Exclusive ownership: a second run or finish request uses an active workflow.
    GREEN fails closed before launching or deleting anything. RED overwrites a

--- a/skills/gradle-run/SKILL.md
+++ b/skills/gradle-run/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: gradle-run
+description: Use when planning to execute `gradle` or `./gradlew`, or diagnosing a Gradle build, check, test, lint, warning, or failure.
+---
+
+# Gradle run
+
+## Core principle
+
+Treat complete Gradle output as a temporary artifact, never conversation
+context. Every agent-initiated Gradle command goes through the compact-output
+wrapper; never stream, `tee`, paste, or reopen a complete build log.
+
+## Procedure
+
+1. Classify the request. A focused Gradle command that only validates another
+   implementation change is incidental validation. A build, check,
+   warning-cleanup, or failure-investigation loop is a Gradle-centered
+   workflow.
+2. Resolve this installed skill's directory and confirm `python3` and
+   `<skill-dir>/scripts/gradle_run.py` are available. If either is
+   unavailable, stop before running Gradle directly and report the failed
+   prerequisite.
+3. Create one wrapper workflow before the first command:
+
+   ```sh
+   python3 <skill-dir>/scripts/gradle_run.py create
+   ```
+
+   Retain the returned opaque workflow identifier. Use only this wrapper to
+   run Gradle. It adds `--console=plain` and `--no-scan` unless the command
+   already selects console behavior or the user explicitly authorized
+   `--scan`; add `--warning-mode all` only for warning discovery or when the
+   user asks for it.
+4. For incidental validation, stay in the current agent and run the smallest
+   owning task with a non-empty verification question:
+
+   ```sh
+   python3 <skill-dir>/scripts/gradle_run.py run \
+     --workflow <id> --scope targeted \
+     --question "Does :module:test pass after this change?" -- \
+     ./gradlew :module:test
+   ```
+
+   Read only the bounded JSON summary and continue from its failed tasks,
+   fingerprints, and excerpt. Do not inspect its log unless a user explicitly
+   requests that artifact.
+5. For a Gradle-centered workflow, create one fresh portable Solver diagnostic
+   owner. Report its model and reasoning only if the runtime exposes them. Give
+   it read-only repository access and ownership of wrapper runs and diagnosis;
+   it must not edit source, tests, configuration, or generated project files,
+   and it must not delegate Gradle ownership. The parent owns every repository
+   edit. If a fresh persistent owner cannot be created, stop rather than make
+   the parent run the workflow loop.
+6. Have that owner reuse prior actionable summaries, group warnings and
+   failures by fingerprint, and return exact file or line evidence plus the
+   narrowest next command. Run an initial broad command only when existing
+   targeted evidence cannot answer the recorded question. The owner stays
+   available for the whole workflow and verifies each parent change with the
+   same wrapper and the narrowest applicable task.
+7. Record `broad` only for aggregate project checks. Give every broad run a
+   distinct question that a narrower task cannot answer. The wrapper flags
+   repeated commands and primary failure fingerprints; if the primary failure
+   repeats, stop the run loop and revise the diagnosis before running another
+   unchanged command.
+8. Finish after the requested broad validation passes, or report unresolved
+   warning fingerprints and the reason validation cannot continue. Summarize
+   the compact ledger, then delete only the wrapper-owned logs:
+
+   ```sh
+   python3 <skill-dir>/scripts/gradle_run.py finish --workflow <id>
+   ```
+
+   If finish cannot validate the managed identifier, leave all files in place
+   and report the failure. This skill does not constrain unrelated review,
+   exploration, implementation, or other subagents.
+
+## RED/GREEN agent scenarios
+
+1. Direct: “Run `bwCheck` and fix every warning.” RED runs repeated full
+   builds with their logs in context. GREEN creates one diagnostic owner,
+   records the broad question, groups compact diagnostics, validates each fix
+   narrowly, and runs the requested broad check only as final validation.
+2. Novel: a final broad check finds a downstream failure after targeted tasks
+   pass. GREEN records the new question, targets the owning task, and only
+   broad-reruns once that task passes.
+3. Repetition: an unchanged failure fingerprint survives a claimed fix. GREEN
+   stops rebuilding and asks for a revised diagnosis; it does not treat a new
+   question string as permission for a blind repeat.
+4. Fail closed: the wrapper, Python runtime, or persistent diagnostic owner is
+   unavailable. GREEN runs no direct Gradle fallback and reports the missing
+   prerequisite.
+5. Counterexample: “After changing this Kotlin helper, run
+   `:module:test`.” GREEN uses the wrapper but keeps this incidental focused
+   validation with the current agent.
+6. Boundary: while a Gradle workflow runs, a user starts an unrelated review
+   subagent. GREEN permits it; this skill owns Gradle output handling and
+   diagnostic delegation only.

--- a/skills/gradle-run/SKILL.md
+++ b/skills/gradle-run/SKILL.md
@@ -101,6 +101,8 @@ wrapper; never stream, `tee`, paste, or reopen a complete build log.
 6. Boundary: while a Gradle workflow runs, a user starts an unrelated review
    subagent. GREEN permits it; this skill owns Gradle output handling and
    diagnostic delegation only.
-7. Interruption: Ctrl-C arrives while Gradle has a worker process. GREEN stops
-   the isolated process group, retains the log, and records SIGINT in the
-   compact ledger before returning.
+7. Interruption: Ctrl-C arrives twice while Gradle has a signal-resistant
+   worker process. GREEN tolerates the second signal, stops the isolated process
+   group, retains the log, and records SIGINT in the compact ledger before
+   returning. RED re-enters cleanup, leaves either process running, or loses the
+   interruption record.

--- a/skills/gradle-run/agents/openai.yaml
+++ b/skills/gradle-run/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Gradle Run"
+  short_description: "Run Gradle with compact diagnostics"
+  default_prompt: "Use $gradle-run to run Gradle with compact diagnostics and bounded logs."

--- a/skills/gradle-run/scripts/gradle_run.py
+++ b/skills/gradle-run/scripts/gradle_run.py
@@ -468,6 +468,7 @@ def run_command(root: Path, arguments: argparse.Namespace) -> int:
     launch_error: OSError | None = None
     exit_status = 125
     with output:
+        cleanup_started = False
         handled_signals = (signal.SIGINT, signal.SIGTERM)
         previous_handlers = {
             handled_signal: signal.getsignal(handled_signal)
@@ -475,6 +476,8 @@ def run_command(root: Path, arguments: argparse.Namespace) -> int:
         }
 
         def interrupt_child(signum: int, _frame: Any) -> None:
+            if cleanup_started:
+                return
             raise ProcessInterrupted(signum)
 
         for handled_signal in handled_signals:
@@ -492,10 +495,12 @@ def run_command(root: Path, arguments: argparse.Namespace) -> int:
             else:
                 exit_status = wait_for_child(child, sequence)
         except ProcessInterrupted as error:
+            cleanup_started = True
             interruption = error
             if child is not None:
                 terminate_child(child, isolated_process_group=os.name == "posix")
         except BaseException:
+            cleanup_started = True
             if child is not None:
                 terminate_child(child, isolated_process_group=os.name == "posix")
             raise

--- a/skills/gradle-run/scripts/gradle_run.py
+++ b/skills/gradle-run/scripts/gradle_run.py
@@ -291,9 +291,14 @@ def display_command(command: list[str]) -> str:
     return shortened(" ".join(command), 1024)
 
 
+def is_gradle_launcher(command: str) -> bool:
+    name = Path(command).name
+    return name == "gradle" or name.startswith("gradlew")
+
+
 def effective_command(command: list[str]) -> list[str]:
     """Add safe Gradle defaults without overriding an explicit scan choice."""
-    if Path(command[0]).name not in {"gradle", "gradlew"}:
+    if not is_gradle_launcher(command[0]):
         raise ValueError("command must start with a Gradle launcher")
     effective = list(command)
     try:

--- a/skills/gradle-run/scripts/gradle_run.py
+++ b/skills/gradle-run/scripts/gradle_run.py
@@ -8,6 +8,7 @@ from collections import deque
 from dataclasses import dataclass
 import hashlib
 import json
+import os
 from pathlib import Path
 import re
 import secrets
@@ -34,7 +35,7 @@ HEARTBEAT_DELAYS = (30.0, 60.0, 120.0, 300.0)
 WORKFLOW_ID = re.compile(r"[a-z0-9]{32}\Z")
 ANSI_ESCAPE = re.compile(r"\x1b(?:\[[0-?]*[ -/]*[@-~]|\][^\x07]*(?:\x07|\x1b\\))")
 FAILED_TASK = re.compile(r"^> Task (:[^\s]+) FAILED$", re.MULTILINE)
-WARNING = re.compile(r"\bwarning\b", re.IGNORECASE)
+WARNING = re.compile(r"(?:\bwarning\b|\bdeprecat(?:ed|ion)\b|^w:)", re.IGNORECASE)
 FAILURE = re.compile(r"(?:^FAILURE:|^\* What went wrong:|^e:|\berror:)", re.IGNORECASE)
 
 
@@ -77,6 +78,31 @@ def workflow_path(root: Path, workflow: str) -> Path:
     return candidate
 
 
+def finished_path(root: Path, workflow: str) -> Path:
+    directory = workflow_path(root, workflow)
+    return directory.with_name(f"{workflow}.finished")
+
+
+def read_finished(path: Path, workflow: str) -> bool:
+    if path.is_symlink():
+        raise ValueError("managed workflow tombstone is invalid")
+    try:
+        value = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return False
+    except OSError as error:
+        raise ValueError("managed workflow tombstone is unavailable") from error
+    if value != f"{workflow}\n":
+        raise ValueError("managed workflow tombstone is invalid")
+    return True
+
+
+def write_finished(path: Path, workflow: str) -> None:
+    temporary = path.with_name(f"{path.name}.tmp")
+    temporary.write_text(f"{workflow}\n", encoding="utf-8")
+    temporary.replace(path)
+
+
 def read_ledger(directory: Path) -> dict[str, Any]:
     path = directory / "ledger.json"
     try:
@@ -100,6 +126,8 @@ def create_workflow(root: Path) -> int:
     for _ in range(10):
         workflow = secrets.token_hex(16)
         directory = root / workflow
+        if finished_path(root, workflow).exists():
+            continue
         try:
             directory.mkdir(mode=0o700)
         except FileExistsError:
@@ -366,14 +394,50 @@ def wait_for_child(child: subprocess.Popen[bytes], sequence: int) -> int:
             timer.join()
 
 
-def terminate_child(child: subprocess.Popen[bytes]) -> None:
-    if child.poll() is not None:
+def terminate_child(
+    child: subprocess.Popen[bytes], *, isolated_process_group: bool = False
+) -> None:
+    def terminate_direct_child() -> None:
+        if child.poll() is not None:
+            return
+        child.terminate()
+        try:
+            child.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            child.kill()
+            child.wait()
+
+    if os.name != "posix" or not isolated_process_group:
+        terminate_direct_child()
         return
-    child.terminate()
+
+    process_group = child.pid
+
+    def group_exists() -> bool:
+        try:
+            os.killpg(process_group, 0)
+        except ProcessLookupError:
+            return False
+        except PermissionError:
+            return True
+        return True
+
     try:
-        child.wait(timeout=5)
-    except subprocess.TimeoutExpired:
-        child.kill()
+        os.killpg(process_group, signal.SIGTERM)
+    except ProcessLookupError:
+        child.wait()
+        return
+
+    deadline = time.monotonic() + 5
+    while group_exists() and time.monotonic() < deadline:
+        child.poll()
+        time.sleep(0.05)
+    if group_exists():
+        try:
+            os.killpg(process_group, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+    if child.poll() is None:
         child.wait()
 
 
@@ -404,15 +468,25 @@ def run_command(root: Path, arguments: argparse.Namespace) -> int:
     launch_error: OSError | None = None
     exit_status = 125
     with output:
-        previous_sigterm = signal.getsignal(signal.SIGTERM)
+        handled_signals = (signal.SIGINT, signal.SIGTERM)
+        previous_handlers = {
+            handled_signal: signal.getsignal(handled_signal)
+            for handled_signal in handled_signals
+        }
 
         def interrupt_child(signum: int, _frame: Any) -> None:
             raise ProcessInterrupted(signum)
 
-        signal.signal(signal.SIGTERM, interrupt_child)
+        for handled_signal in handled_signals:
+            signal.signal(handled_signal, interrupt_child)
         try:
             try:
-                child = subprocess.Popen(command, stdout=output, stderr=subprocess.STDOUT)
+                child = subprocess.Popen(
+                    command,
+                    stdout=output,
+                    stderr=subprocess.STDOUT,
+                    start_new_session=os.name == "posix",
+                )
             except OSError as error:
                 launch_error = error
             else:
@@ -420,13 +494,14 @@ def run_command(root: Path, arguments: argparse.Namespace) -> int:
         except ProcessInterrupted as error:
             interruption = error
             if child is not None:
-                terminate_child(child)
+                terminate_child(child, isolated_process_group=os.name == "posix")
         except BaseException:
             if child is not None:
-                terminate_child(child)
+                terminate_child(child, isolated_process_group=os.name == "posix")
             raise
         finally:
-            signal.signal(signal.SIGTERM, previous_sigterm)
+            for handled_signal, previous_handler in previous_handlers.items():
+                signal.signal(handled_signal, previous_handler)
 
     if launch_error is not None:
         log.unlink(missing_ok=True)
@@ -521,11 +596,19 @@ def run_command(root: Path, arguments: argparse.Namespace) -> int:
 
 def finish_workflow(root: Path, workflow: str) -> int:
     directory = workflow_path(root, workflow)
+    tombstone = finished_path(root, workflow)
     if not directory.exists():
+        if not read_finished(tombstone, workflow):
+            raise ValueError("unknown workflow identifier")
         print(json.dumps({"already_finished": True, "finished": workflow}, sort_keys=True))
         return 0
     read_ledger(directory)
-    shutil.rmtree(directory)
+    write_finished(tombstone, workflow)
+    try:
+        shutil.rmtree(directory)
+    except BaseException:
+        tombstone.unlink(missing_ok=True)
+        raise
     print(json.dumps({"finished": workflow}, sort_keys=True))
     return 0
 

--- a/skills/gradle-run/scripts/gradle_run.py
+++ b/skills/gradle-run/scripts/gradle_run.py
@@ -1,0 +1,357 @@
+#!/usr/bin/env python3
+"""Run Gradle commands with bounded diagnostics and wrapper-owned logs."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+import re
+import secrets
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from typing import Any
+
+
+MAX_SUMMARY_BYTES = 16_384
+MAX_SUMMARY_LINES = 64
+MAX_DIAGNOSTICS = 8
+MAX_FAILED_TASKS = 16
+MAX_FAILED_TASK_BYTES = 512
+MAX_EXCERPT_LINES = 12
+MAX_EXCERPT_LINE_BYTES = 512
+HEARTBEAT_DELAYS = (30.0, 60.0, 120.0, 300.0)
+WORKFLOW_ID = re.compile(r"[a-z0-9]{32}\Z")
+ANSI_ESCAPE = re.compile(r"\x1b(?:\[[0-?]*[ -/]*[@-~]|\][^\x07]*(?:\x07|\x1b\\))")
+FAILED_TASK = re.compile(r"^> Task (:[^\s]+) FAILED$", re.MULTILINE)
+WARNING = re.compile(r"\bwarning\b", re.IGNORECASE)
+FAILURE = re.compile(r"(?:^FAILURE:|^\* What went wrong:|^e:|\berror:)", re.IGNORECASE)
+
+
+def default_root() -> Path:
+    return Path(tempfile.gettempdir()) / "gradle-run"
+
+
+def heartbeat_due(elapsed: float, next_index: int) -> bool:
+    return next_index < len(HEARTBEAT_DELAYS) and elapsed >= HEARTBEAT_DELAYS[next_index]
+
+
+def normalize(text: str) -> str:
+    return " ".join(ANSI_ESCAPE.sub("", text).split())
+
+
+def fingerprint(text: str) -> str:
+    return hashlib.sha256(normalize(text).encode("utf-8")).hexdigest()
+
+
+def shortened(text: str, max_bytes: int) -> str:
+    encoded = text.encode("utf-8")
+    if len(encoded) <= max_bytes:
+        return text
+    return encoded[: max_bytes - 3].decode("utf-8", errors="ignore") + "..."
+
+
+def managed_root(root: Path) -> Path:
+    resolved_root = root.resolve(strict=False)
+    temporary_root = Path(tempfile.gettempdir()).resolve()
+    try:
+        resolved_root.relative_to(temporary_root)
+    except ValueError as error:
+        raise ValueError("managed root must be inside the OS temporary directory") from error
+    return resolved_root
+
+
+def workflow_path(root: Path, workflow: str) -> Path:
+    if not WORKFLOW_ID.fullmatch(workflow):
+        raise ValueError("invalid workflow identifier")
+    root = managed_root(root)
+    candidate = root / workflow
+    if candidate.resolve(strict=False).parent != root:
+        raise ValueError("invalid workflow path")
+    return candidate
+
+
+def read_ledger(directory: Path) -> dict[str, Any]:
+    path = directory / "ledger.json"
+    try:
+        ledger = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise ValueError("managed workflow ledger is unavailable") from error
+    if ledger.get("workflow") != directory.name or not isinstance(ledger.get("runs"), list):
+        raise ValueError("managed workflow ledger is invalid")
+    return ledger
+
+
+def write_ledger(directory: Path, ledger: dict[str, Any]) -> None:
+    temporary = directory / "ledger.json.tmp"
+    temporary.write_text(json.dumps(ledger, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    temporary.replace(directory / "ledger.json")
+
+
+def create_workflow(root: Path) -> int:
+    root = managed_root(root)
+    root.mkdir(mode=0o700, parents=True, exist_ok=True)
+    for _ in range(10):
+        workflow = secrets.token_hex(16)
+        directory = root / workflow
+        try:
+            directory.mkdir(mode=0o700)
+        except FileExistsError:
+            continue
+        write_ledger(
+            directory,
+            {
+                "version": 1,
+                "workflow": workflow,
+                "runs": [],
+                "failure_fingerprints": {},
+                "warning_fingerprints": {},
+            },
+        )
+        print(json.dumps({"workflow": workflow, "directory": str(directory)}, sort_keys=True))
+        return 0
+    print("could not create a unique workflow", file=sys.stderr)
+    return 1
+
+
+def extract_diagnostics(log: Path) -> tuple[list[str], list[str], list[str], list[str]]:
+    text = ANSI_ESCAPE.sub("", log.read_text(encoding="utf-8", errors="replace"))
+    failed_tasks = list(dict.fromkeys(FAILED_TASK.findall(text)))
+    lines = [normalize(raw_line) for raw_line in text.splitlines()]
+    warnings: list[str] = []
+    failures: list[str] = []
+    excerpts: list[str] = []
+    for line in lines:
+        if not line:
+            continue
+        if WARNING.search(line):
+            warnings.append(line)
+        if (WARNING.search(line) or FAILURE.search(line) or " FAILED" in line) and len(excerpts) < MAX_EXCERPT_LINES:
+            excerpts.append(shortened(line, MAX_EXCERPT_LINE_BYTES))
+    if any(line.startswith("* What went wrong:") for line in lines):
+        index = 0
+        while index < len(lines):
+            if not lines[index].startswith("* What went wrong:"):
+                index += 1
+                continue
+            block = [lines[index]]
+            index += 1
+            while index < len(lines) and not lines[index].startswith("* "):
+                if lines[index]:
+                    block.append(lines[index])
+                index += 1
+            failures.append("\n".join(block))
+    else:
+        failures = [line for line in lines if line and FAILURE.search(line)]
+    if not excerpts:
+        excerpts = [
+            shortened(normalize(line), MAX_EXCERPT_LINE_BYTES)
+            for line in text.splitlines()[-MAX_EXCERPT_LINES:]
+            if normalize(line)
+        ]
+    return failed_tasks, warnings, failures, excerpts[:MAX_EXCERPT_LINES]
+
+
+def compact_fingerprints(lines: list[str]) -> dict[str, dict[str, Any]]:
+    result: dict[str, dict[str, Any]] = {}
+    for line in lines:
+        value = fingerprint(line)
+        item = result.setdefault(value, {"count": 0, "excerpt": shortened(normalize(line), 256)})
+        item["count"] += 1
+    return result
+
+
+def summary_fingerprints(items: dict[str, dict[str, Any]]) -> list[dict[str, Any]]:
+    return [
+        {"fingerprint": value, "count": item["count"], "excerpt": item["excerpt"]}
+        for value, item in list(items.items())[:MAX_DIAGNOSTICS]
+    ]
+
+
+def merge_fingerprints(
+    ledger: dict[str, Any], key: str, current: dict[str, dict[str, Any]]
+) -> None:
+    history = ledger.setdefault(key, {})
+    for value, item in current.items():
+        stored = history.setdefault(value, {"occurrences": 0, "excerpt": item["excerpt"]})
+        stored["occurrences"] += item["count"]
+
+
+def display_command(command: list[str]) -> str:
+    return shortened(" ".join(command), 1024)
+
+
+def summarize_failed_tasks(tasks: list[str]) -> tuple[list[str], bool]:
+    summarized = [shortened(task, MAX_FAILED_TASK_BYTES) for task in tasks[:MAX_FAILED_TASKS]]
+    truncated = len(tasks) > MAX_FAILED_TASKS or summarized != tasks[:MAX_FAILED_TASKS]
+    return summarized, truncated
+
+
+def effective_command(command: list[str]) -> list[str]:
+    """Add safe Gradle defaults without overriding an explicit scan choice."""
+    if Path(command[0]).name not in {"gradle", "gradlew"}:
+        raise ValueError("command must start with a Gradle launcher")
+    effective = list(command)
+    defaults: list[str] = []
+    if "--console" not in effective and not any(item.startswith("--console=") for item in effective):
+        defaults.append("--console=plain")
+    if "--scan" not in effective and "--no-scan" not in effective:
+        defaults.append("--no-scan")
+    try:
+        separator = effective.index("--", 1)
+    except ValueError:
+        effective.extend(defaults)
+    else:
+        effective[separator:separator] = defaults
+    return effective
+
+
+def emit_summary(summary: dict[str, Any]) -> None:
+    encoded = json.dumps(summary, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    if len(encoded) > MAX_SUMMARY_BYTES:
+        summary["excerpt"] = []
+        summary["warning_fingerprints"] = summary["warning_fingerprints"][:2]
+        summary["failure_fingerprints"] = summary["failure_fingerprints"][:2]
+        encoded = json.dumps(summary, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    if len(encoded) > MAX_SUMMARY_BYTES:
+        summary["command"] = shortened(summary["command"], 256)
+        encoded = json.dumps(summary, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    if len(encoded) > MAX_SUMMARY_BYTES:
+        summary = {
+            "command": shortened(str(summary.get("command", "")), 128),
+            "exit_status": summary.get("exit_status"),
+            "failed_tasks": list(summary.get("failed_tasks", []))[:2],
+            "log": shortened(str(summary.get("log", "")), 256),
+            "summary_truncated": True,
+        }
+        encoded = json.dumps(summary, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    print(encoded.decode("utf-8"))
+
+
+def run_command(root: Path, arguments: argparse.Namespace) -> int:
+    directory = workflow_path(root, arguments.workflow)
+    ledger = read_ledger(directory)
+    command = list(arguments.command)
+    if command[:1] == ["--"]:
+        command = command[1:]
+    if not command:
+        raise ValueError("missing command; refusing direct Gradle fallback")
+    if not arguments.question.strip():
+        raise ValueError("verification question must be non-empty")
+    command = effective_command(command)
+    if "/" not in command[0] and shutil.which(command[0]) is None:
+        emit_summary({"launch_error": "command not found", "command": display_command(command)})
+        return 127
+
+    prior_failures = set(ledger.get("failure_fingerprints", {}))
+    repeated_command = any(entry.get("command") == command for entry in ledger["runs"])
+    sequence = len(ledger["runs"]) + 1
+    log = directory / f"{sequence:04d}.log"
+    started = time.monotonic()
+    try:
+        with log.open("wb") as output:
+            child = subprocess.Popen(command, stdout=output, stderr=subprocess.STDOUT)
+            next_heartbeat_index = 0
+            while child.poll() is None:
+                now = time.monotonic()
+                elapsed = now - started
+                if heartbeat_due(elapsed, next_heartbeat_index):
+                    print(
+                        f"gradle-run: still running {sequence:04d} ({elapsed:.0f}s); output is in managed log",
+                        file=sys.stderr,
+                        flush=True,
+                    )
+                    next_heartbeat_index += 1
+                time.sleep(0.05)
+            exit_status = child.returncode
+    except OSError as error:
+        log.unlink(missing_ok=True)
+        emit_summary({"launch_error": str(error), "command": display_command(command)})
+        return 125
+
+    elapsed = time.monotonic() - started
+    failed_tasks, warnings, failures, excerpt = extract_diagnostics(log)
+    summarized_failed_tasks, failed_tasks_truncated = summarize_failed_tasks(failed_tasks)
+    warning_items = compact_fingerprints(warnings)
+    failure_items = compact_fingerprints(failures)
+    repeated_primary_failure = bool(failure_items and next(iter(failure_items)) in prior_failures)
+    merge_fingerprints(ledger, "warning_fingerprints", warning_items)
+    merge_fingerprints(ledger, "failure_fingerprints", failure_items)
+    ledger["runs"].append(
+        {
+            "sequence": sequence,
+            "scope": arguments.scope,
+            "question": arguments.question,
+            "command": command,
+            "elapsed_seconds": round(elapsed, 3),
+            "exit_status": exit_status,
+            "log": log.name,
+            "failure_fingerprints": list(failure_items),
+            "warning_fingerprints": list(warning_items),
+        }
+    )
+    write_ledger(directory, ledger)
+    emit_summary(
+        {
+            "command": display_command(command),
+            "elapsed_seconds": round(elapsed, 3),
+            "exit_status": exit_status,
+            "excerpt": excerpt,
+            "failed_tasks": summarized_failed_tasks,
+            "failed_tasks_truncated": failed_tasks_truncated,
+            "failure_fingerprints": summary_fingerprints(failure_items),
+            "log": str(log),
+            "repeated_command": repeated_command,
+            "repeated_primary_failure": repeated_primary_failure,
+            "scope": arguments.scope,
+            "warning_fingerprints": summary_fingerprints(warning_items),
+        }
+    )
+    return exit_status
+
+
+def finish_workflow(root: Path, workflow: str) -> int:
+    directory = workflow_path(root, workflow)
+    if not directory.exists():
+        print(json.dumps({"already_finished": True, "finished": workflow}, sort_keys=True))
+        return 0
+    read_ledger(directory)
+    shutil.rmtree(directory)
+    print(json.dumps({"finished": workflow}, sort_keys=True))
+    return 0
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser(description=__doc__)
+    result.add_argument("--root", type=Path, default=default_root())
+    commands = result.add_subparsers(dest="operation", required=True)
+    commands.add_parser("create")
+    run = commands.add_parser("run")
+    run.add_argument("--workflow", required=True)
+    run.add_argument("--scope", choices=("broad", "targeted"), required=True)
+    run.add_argument("--question", required=True)
+    run.add_argument("command", nargs=argparse.REMAINDER)
+    finish = commands.add_parser("finish")
+    finish.add_argument("--workflow", required=True)
+    return result
+
+
+def main() -> int:
+    arguments = parser().parse_args()
+    try:
+        if arguments.operation == "create":
+            return create_workflow(arguments.root)
+        if arguments.operation == "run":
+            return run_command(arguments.root, arguments)
+        return finish_workflow(arguments.root, arguments.workflow)
+    except ValueError as error:
+        print(str(error), file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/gradle-run/scripts/gradle_run.py
+++ b/skills/gradle-run/scripts/gradle_run.py
@@ -517,9 +517,7 @@ def terminate_child(
             return
         try:
             child.send_signal(signal.CTRL_BREAK_EVENT)
-            child.wait(timeout=5)
-            return
-        except (OSError, subprocess.TimeoutExpired):
+        except OSError:
             pass
         try:
             subprocess.run(

--- a/skills/gradle-run/scripts/gradle_run.py
+++ b/skills/gradle-run/scripts/gradle_run.py
@@ -37,6 +37,7 @@ ANSI_ESCAPE = re.compile(r"\x1b(?:\[[0-?]*[ -/]*[@-~]|\][^\x07]*(?:\x07|\x1b\\))
 FAILED_TASK = re.compile(r"^> Task (:[^\s]+) FAILED$", re.MULTILINE)
 WARNING = re.compile(r"(?:\bwarning\b|\bdeprecat(?:ed|ion)\b|^w:)", re.IGNORECASE)
 FAILURE = re.compile(r"(?:^FAILURE:|^\* What went wrong:|^e:|\berror:)", re.IGNORECASE)
+SOURCE_FAILURE = re.compile(r"(?:^e:|\berror:)", re.IGNORECASE)
 AUTHORIZATION_VALUE = re.compile(
     r"(\bauthorization\s*:\s*)(?:bearer\s+)?[^\r\n]+", re.IGNORECASE
 )
@@ -259,6 +260,8 @@ def extract_diagnostics(log: Path) -> Diagnostics:
     failed_tasks_truncated = False
     warnings: dict[str, dict[str, Any]] = {}
     warning_overflow = 0
+    source_failures: dict[str, dict[str, Any]] = {}
+    source_failure_overflow = 0
     standalone_failures: dict[str, dict[str, Any]] = {}
     standalone_failure_overflow = 0
     failure_blocks: dict[str, dict[str, Any]] = {}
@@ -319,14 +322,22 @@ def extract_diagnostics(log: Path) -> Diagnostics:
                     else:
                         failure_block_truncated = True
                     continue
-            if FAILURE.search(line):
+            if SOURCE_FAILURE.search(line):
+                source_failure_overflow += add_fingerprint(source_failures, line)
+            elif FAILURE.search(line):
                 standalone_failure_overflow += add_fingerprint(standalone_failures, line)
 
     finish_failure_block()
-    failures = failure_blocks if saw_failure_block else standalone_failures
-    failure_overflow = (
+    secondary_failures = failure_blocks if saw_failure_block else standalone_failures
+    failure_overflow = source_failure_overflow + (
         failure_block_overflow if saw_failure_block else standalone_failure_overflow
     )
+    failures = dict(source_failures)
+    for value, item in secondary_failures.items():
+        if len(failures) < MAX_STORED_FINGERPRINTS:
+            failures[value] = item
+        else:
+            failure_overflow += item["count"]
     return Diagnostics(
         failed_tasks=failed_tasks,
         failed_tasks_truncated=failed_tasks_truncated,
@@ -652,38 +663,6 @@ def run_locked(root: Path, arguments: argparse.Namespace) -> int:
             return 125
 
         elapsed = time.monotonic() - started
-        if interruption is not None:
-            exit_status = 128 + interruption.signum
-            append_run(
-                ledger,
-                {
-                    "sequence": sequence,
-                    "scope": arguments.scope,
-                    "question": shortened(redact(arguments.question), 1024),
-                    "command": display_command(command),
-                    "elapsed_seconds": round(elapsed, 3),
-                    "exit_status": exit_status,
-                    "interrupted_signal": interruption.signum,
-                    "log": log.name,
-                    "failure_fingerprints": [],
-                    "warning_fingerprints": [],
-                },
-            )
-            write_ledger(directory, ledger)
-            prune_logs(directory, ledger)
-            emit_summary(
-                {
-                    "command": display_command(command),
-                    "elapsed_seconds": round(elapsed, 3),
-                    "exit_status": exit_status,
-                    "interrupted_signal": interruption.signum,
-                    "log": str(log),
-                    "repeated_command": repeated_command,
-                    "scope": arguments.scope,
-                }
-            )
-            return exit_status
-
         diagnostics = extract_diagnostics(log)
         warning_items = diagnostics.warning_fingerprints
         failure_items = diagnostics.failure_fingerprints
@@ -702,6 +681,46 @@ def run_locked(root: Path, arguments: argparse.Namespace) -> int:
             failure_items,
             diagnostics.failure_fingerprints_truncated,
         )
+        if interruption is not None:
+            exit_status = 128 + interruption.signum
+            append_run(
+                ledger,
+                {
+                    "sequence": sequence,
+                    "scope": arguments.scope,
+                    "question": shortened(redact(arguments.question), 1024),
+                    "command": display_command(command),
+                    "elapsed_seconds": round(elapsed, 3),
+                    "exit_status": exit_status,
+                    "interrupted_signal": interruption.signum,
+                    "log": log.name,
+                    "failure_fingerprints": list(failure_items)[:MAX_DIAGNOSTICS],
+                    "warning_fingerprints": list(warning_items)[:MAX_DIAGNOSTICS],
+                },
+            )
+            write_ledger(directory, ledger)
+            prune_logs(directory, ledger)
+            emit_summary(
+                {
+                    "command": display_command(command),
+                    "elapsed_seconds": round(elapsed, 3),
+                    "exit_status": exit_status,
+                    "excerpt": diagnostics.excerpt,
+                    "failed_tasks": diagnostics.failed_tasks,
+                    "failed_tasks_truncated": diagnostics.failed_tasks_truncated,
+                    "failure_fingerprints": summary_fingerprints(failure_items),
+                    "failure_fingerprints_truncated": diagnostics.failure_fingerprints_truncated,
+                    "interrupted_signal": interruption.signum,
+                    "log": str(log),
+                    "repeated_command": repeated_command,
+                    "repeated_primary_failure": repeated_primary_failure,
+                    "scope": arguments.scope,
+                    "warning_fingerprints": summary_fingerprints(warning_items),
+                    "warning_fingerprints_truncated": diagnostics.warning_fingerprints_truncated,
+                }
+            )
+            return exit_status
+
         append_run(
             ledger,
             {

--- a/skills/gradle-run/scripts/gradle_run.py
+++ b/skills/gradle-run/scripts/gradle_run.py
@@ -4,26 +4,32 @@
 from __future__ import annotations
 
 import argparse
+from collections import deque
+from dataclasses import dataclass
 import hashlib
 import json
 from pathlib import Path
 import re
 import secrets
 import shutil
+import signal
 import subprocess
 import sys
 import tempfile
+import threading
 import time
 from typing import Any
 
 
 MAX_SUMMARY_BYTES = 16_384
-MAX_SUMMARY_LINES = 64
 MAX_DIAGNOSTICS = 8
+MAX_STORED_FINGERPRINTS = 256
+MAX_LEDGER_RUNS = 64
 MAX_FAILED_TASKS = 16
 MAX_FAILED_TASK_BYTES = 512
 MAX_EXCERPT_LINES = 12
 MAX_EXCERPT_LINE_BYTES = 512
+MAX_FAILURE_BLOCK_LINES = 64
 HEARTBEAT_DELAYS = (30.0, 60.0, 120.0, 300.0)
 WORKFLOW_ID = re.compile(r"[a-z0-9]{32}\Z")
 ANSI_ESCAPE = re.compile(r"\x1b(?:\[[0-?]*[ -/]*[@-~]|\][^\x07]*(?:\x07|\x1b\\))")
@@ -34,10 +40,6 @@ FAILURE = re.compile(r"(?:^FAILURE:|^\* What went wrong:|^e:|\berror:)", re.IGNO
 
 def default_root() -> Path:
     return Path(tempfile.gettempdir()) / "gradle-run"
-
-
-def heartbeat_due(elapsed: float, next_index: int) -> bool:
-    return next_index < len(HEARTBEAT_DELAYS) and elapsed >= HEARTBEAT_DELAYS[next_index]
 
 
 def normalize(text: str) -> str:
@@ -108,6 +110,8 @@ def create_workflow(root: Path) -> int:
                 "version": 1,
                 "workflow": workflow,
                 "runs": [],
+                "run_count": 0,
+                "command_fingerprints": {},
                 "failure_fingerprints": {},
                 "warning_fingerprints": {},
             },
@@ -118,51 +122,117 @@ def create_workflow(root: Path) -> int:
     return 1
 
 
-def extract_diagnostics(log: Path) -> tuple[list[str], list[str], list[str], list[str]]:
-    text = ANSI_ESCAPE.sub("", log.read_text(encoding="utf-8", errors="replace"))
-    failed_tasks = list(dict.fromkeys(FAILED_TASK.findall(text)))
-    lines = [normalize(raw_line) for raw_line in text.splitlines()]
-    warnings: list[str] = []
-    failures: list[str] = []
+@dataclass
+class Diagnostics:
+    failed_tasks: list[str]
+    failed_tasks_truncated: bool
+    warning_fingerprints: dict[str, dict[str, Any]]
+    warning_fingerprints_truncated: int
+    failure_fingerprints: dict[str, dict[str, Any]]
+    failure_fingerprints_truncated: int
+    excerpt: list[str]
+
+
+class ProcessInterrupted(Exception):
+    def __init__(self, signum: int) -> None:
+        super().__init__(f"received signal {signum}")
+        self.signum = signum
+
+
+def add_fingerprint(items: dict[str, dict[str, Any]], text: str) -> int:
+    value = fingerprint(text)
+    if value in items:
+        items[value]["count"] += 1
+        return 0
+    if len(items) >= MAX_STORED_FINGERPRINTS:
+        return 1
+    items[value] = {"count": 1, "excerpt": shortened(normalize(text), 256)}
+    return 0
+
+
+def extract_diagnostics(log: Path) -> Diagnostics:
+    failed_tasks: list[str] = []
+    failed_task_values: set[str] = set()
+    failed_tasks_truncated = False
+    warnings: dict[str, dict[str, Any]] = {}
+    warning_overflow = 0
+    standalone_failures: dict[str, dict[str, Any]] = {}
+    standalone_failure_overflow = 0
+    failure_blocks: dict[str, dict[str, Any]] = {}
+    failure_block_overflow = 0
+    saw_failure_block = False
+    failure_block: list[str] | None = None
+    failure_block_truncated = False
     excerpts: list[str] = []
-    for line in lines:
-        if not line:
-            continue
-        if WARNING.search(line):
-            warnings.append(line)
-        if (WARNING.search(line) or FAILURE.search(line) or " FAILED" in line) and len(excerpts) < MAX_EXCERPT_LINES:
-            excerpts.append(shortened(line, MAX_EXCERPT_LINE_BYTES))
-    if any(line.startswith("* What went wrong:") for line in lines):
-        index = 0
-        while index < len(lines):
-            if not lines[index].startswith("* What went wrong:"):
-                index += 1
+    tail: deque[str] = deque(maxlen=MAX_EXCERPT_LINES)
+
+    def finish_failure_block() -> None:
+        nonlocal failure_block, failure_block_overflow, failure_block_truncated
+        if failure_block is None:
+            return
+        if failure_block_truncated:
+            failure_block.append("... diagnostic block truncated ...")
+        failure_block_overflow += add_fingerprint(failure_blocks, "\n".join(failure_block))
+        failure_block = None
+        failure_block_truncated = False
+
+    with log.open(encoding="utf-8", errors="replace") as lines:
+        for raw_line in lines:
+            line = normalize(raw_line)
+            if not line:
                 continue
-            block = [lines[index]]
-            index += 1
-            while index < len(lines) and not lines[index].startswith("* "):
-                if lines[index]:
-                    block.append(lines[index])
-                index += 1
-            failures.append("\n".join(block))
-    else:
-        failures = [line for line in lines if line and FAILURE.search(line)]
-    if not excerpts:
-        excerpts = [
-            shortened(normalize(line), MAX_EXCERPT_LINE_BYTES)
-            for line in text.splitlines()[-MAX_EXCERPT_LINES:]
-            if normalize(line)
-        ]
-    return failed_tasks, warnings, failures, excerpts[:MAX_EXCERPT_LINES]
+            bounded_line = shortened(line, MAX_EXCERPT_LINE_BYTES)
+            tail.append(bounded_line)
 
+            task = FAILED_TASK.fullmatch(line)
+            if task and task.group(1) not in failed_task_values:
+                if len(failed_tasks) < MAX_FAILED_TASKS:
+                    value = task.group(1)
+                    failed_task_values.add(value)
+                    shortened_value = shortened(value, MAX_FAILED_TASK_BYTES)
+                    failed_tasks.append(shortened_value)
+                    failed_tasks_truncated |= shortened_value != value
+                else:
+                    failed_tasks_truncated = True
 
-def compact_fingerprints(lines: list[str]) -> dict[str, dict[str, Any]]:
-    result: dict[str, dict[str, Any]] = {}
-    for line in lines:
-        value = fingerprint(line)
-        item = result.setdefault(value, {"count": 0, "excerpt": shortened(normalize(line), 256)})
-        item["count"] += 1
-    return result
+            is_warning = bool(WARNING.search(line))
+            is_failure = bool(FAILURE.search(line) or " FAILED" in line)
+            if is_warning:
+                warning_overflow += add_fingerprint(warnings, line)
+            if (is_warning or is_failure) and len(excerpts) < MAX_EXCERPT_LINES:
+                excerpts.append(bounded_line)
+
+            if line.startswith("* What went wrong:"):
+                finish_failure_block()
+                saw_failure_block = True
+                failure_block = [line]
+                continue
+            if failure_block is not None:
+                if line.startswith("* "):
+                    finish_failure_block()
+                else:
+                    if len(failure_block) < MAX_FAILURE_BLOCK_LINES:
+                        failure_block.append(bounded_line)
+                    else:
+                        failure_block_truncated = True
+                    continue
+            if FAILURE.search(line):
+                standalone_failure_overflow += add_fingerprint(standalone_failures, line)
+
+    finish_failure_block()
+    failures = failure_blocks if saw_failure_block else standalone_failures
+    failure_overflow = (
+        failure_block_overflow if saw_failure_block else standalone_failure_overflow
+    )
+    return Diagnostics(
+        failed_tasks=failed_tasks,
+        failed_tasks_truncated=failed_tasks_truncated,
+        warning_fingerprints=warnings,
+        warning_fingerprints_truncated=warning_overflow,
+        failure_fingerprints=failures,
+        failure_fingerprints_truncated=failure_overflow,
+        excerpt=excerpts or list(tail),
+    )
 
 
 def summary_fingerprints(items: dict[str, dict[str, Any]]) -> list[dict[str, Any]]:
@@ -173,22 +243,52 @@ def summary_fingerprints(items: dict[str, dict[str, Any]]) -> list[dict[str, Any
 
 
 def merge_fingerprints(
-    ledger: dict[str, Any], key: str, current: dict[str, dict[str, Any]]
+    ledger: dict[str, Any],
+    key: str,
+    current: dict[str, dict[str, Any]],
+    truncated_occurrences: int,
 ) -> None:
     history = ledger.setdefault(key, {})
     for value, item in current.items():
-        stored = history.setdefault(value, {"occurrences": 0, "excerpt": item["excerpt"]})
-        stored["occurrences"] += item["count"]
+        if value in history:
+            history[value]["occurrences"] += item["count"]
+        elif len(history) < MAX_STORED_FINGERPRINTS:
+            history[value] = {"occurrences": item["count"], "excerpt": item["excerpt"]}
+        else:
+            truncated_occurrences += item["count"]
+    ledger[f"{key}_truncated_occurrences"] = (
+        ledger.get(f"{key}_truncated_occurrences", 0) + truncated_occurrences
+    )
+
+
+def record_command(ledger: dict[str, Any], command: list[str]) -> bool:
+    value = hashlib.sha256(
+        json.dumps(command, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+    history = ledger.setdefault("command_fingerprints", {})
+    if value in history:
+        history[value] += 1
+        return True
+    if len(history) < MAX_STORED_FINGERPRINTS:
+        history[value] = 1
+    else:
+        ledger["command_fingerprints_truncated"] = (
+            ledger.get("command_fingerprints_truncated", 0) + 1
+        )
+    return False
+
+
+def append_run(ledger: dict[str, Any], entry: dict[str, Any]) -> None:
+    ledger["run_count"] = entry["sequence"]
+    ledger["runs"].append(entry)
+    overflow = len(ledger["runs"]) - MAX_LEDGER_RUNS
+    if overflow > 0:
+        del ledger["runs"][:overflow]
+        ledger["runs_truncated"] = ledger.get("runs_truncated", 0) + overflow
 
 
 def display_command(command: list[str]) -> str:
     return shortened(" ".join(command), 1024)
-
-
-def summarize_failed_tasks(tasks: list[str]) -> tuple[list[str], bool]:
-    summarized = [shortened(task, MAX_FAILED_TASK_BYTES) for task in tasks[:MAX_FAILED_TASKS]]
-    truncated = len(tasks) > MAX_FAILED_TASKS or summarized != tasks[:MAX_FAILED_TASKS]
-    return summarized, truncated
 
 
 def effective_command(command: list[str]) -> list[str]:
@@ -196,31 +296,34 @@ def effective_command(command: list[str]) -> list[str]:
     if Path(command[0]).name not in {"gradle", "gradlew"}:
         raise ValueError("command must start with a Gradle launcher")
     effective = list(command)
-    defaults: list[str] = []
-    if "--console" not in effective and not any(item.startswith("--console=") for item in effective):
-        defaults.append("--console=plain")
-    if "--scan" not in effective and "--no-scan" not in effective:
-        defaults.append("--no-scan")
     try:
         separator = effective.index("--", 1)
     except ValueError:
-        effective.extend(defaults)
-    else:
-        effective[separator:separator] = defaults
+        separator = len(effective)
+    gradle_arguments = effective[:separator]
+    defaults: list[str] = []
+    if "--console" not in gradle_arguments and not any(
+        item.startswith("--console=") for item in gradle_arguments
+    ):
+        defaults.append("--console=plain")
+    if "--scan" not in gradle_arguments and "--no-scan" not in gradle_arguments:
+        defaults.append("--no-scan")
+    effective[separator:separator] = defaults
     return effective
 
 
 def emit_summary(summary: dict[str, Any]) -> None:
     encoded = json.dumps(summary, sort_keys=True, separators=(",", ":")).encode("utf-8")
-    if len(encoded) > MAX_SUMMARY_BYTES:
+    payload_limit = MAX_SUMMARY_BYTES - 1
+    if len(encoded) > payload_limit:
         summary["excerpt"] = []
-        summary["warning_fingerprints"] = summary["warning_fingerprints"][:2]
-        summary["failure_fingerprints"] = summary["failure_fingerprints"][:2]
+        summary["warning_fingerprints"] = summary.get("warning_fingerprints", [])[:2]
+        summary["failure_fingerprints"] = summary.get("failure_fingerprints", [])[:2]
         encoded = json.dumps(summary, sort_keys=True, separators=(",", ":")).encode("utf-8")
-    if len(encoded) > MAX_SUMMARY_BYTES:
-        summary["command"] = shortened(summary["command"], 256)
+    if len(encoded) > payload_limit:
+        summary["command"] = shortened(str(summary.get("command", "")), 256)
         encoded = json.dumps(summary, sort_keys=True, separators=(",", ":")).encode("utf-8")
-    if len(encoded) > MAX_SUMMARY_BYTES:
+    if len(encoded) > payload_limit:
         summary = {
             "command": shortened(str(summary.get("command", "")), 128),
             "exit_status": summary.get("exit_status"),
@@ -230,6 +333,43 @@ def emit_summary(summary: dict[str, Any]) -> None:
         }
         encoded = json.dumps(summary, sort_keys=True, separators=(",", ":")).encode("utf-8")
     print(encoded.decode("utf-8"))
+
+
+def emit_heartbeat(child: subprocess.Popen[bytes], sequence: int, delay: float) -> None:
+    if child.poll() is None:
+        print(
+            f"gradle-run: still running {sequence:04d} ({delay:.0f}s); output is in managed log",
+            file=sys.stderr,
+            flush=True,
+        )
+
+
+def wait_for_child(child: subprocess.Popen[bytes], sequence: int) -> int:
+    timers = [
+        threading.Timer(delay, emit_heartbeat, args=(child, sequence, delay))
+        for delay in HEARTBEAT_DELAYS
+    ]
+    for timer in timers:
+        timer.daemon = True
+        timer.start()
+    try:
+        return child.wait()
+    finally:
+        for timer in timers:
+            timer.cancel()
+        for timer in timers:
+            timer.join()
+
+
+def terminate_child(child: subprocess.Popen[bytes]) -> None:
+    if child.poll() is not None:
+        return
+    child.terminate()
+    try:
+        child.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        child.kill()
+        child.wait()
 
 
 def run_command(root: Path, arguments: argparse.Namespace) -> int:
@@ -243,56 +383,114 @@ def run_command(root: Path, arguments: argparse.Namespace) -> int:
     if not arguments.question.strip():
         raise ValueError("verification question must be non-empty")
     command = effective_command(command)
-    if "/" not in command[0] and shutil.which(command[0]) is None:
-        emit_summary({"launch_error": "command not found", "command": display_command(command)})
-        return 127
-
     prior_failures = set(ledger.get("failure_fingerprints", {}))
-    repeated_command = any(entry.get("command") == command for entry in ledger["runs"])
-    sequence = len(ledger["runs"]) + 1
+    repeated_command = record_command(ledger, command)
+    sequence = ledger.get("run_count", len(ledger["runs"])) + 1
     log = directory / f"{sequence:04d}.log"
     started = time.monotonic()
     try:
-        with log.open("wb") as output:
-            child = subprocess.Popen(command, stdout=output, stderr=subprocess.STDOUT)
-            next_heartbeat_index = 0
-            while child.poll() is None:
-                now = time.monotonic()
-                elapsed = now - started
-                if heartbeat_due(elapsed, next_heartbeat_index):
-                    print(
-                        f"gradle-run: still running {sequence:04d} ({elapsed:.0f}s); output is in managed log",
-                        file=sys.stderr,
-                        flush=True,
-                    )
-                    next_heartbeat_index += 1
-                time.sleep(0.05)
-            exit_status = child.returncode
+        output = log.open("wb")
     except OSError as error:
-        log.unlink(missing_ok=True)
         emit_summary({"launch_error": str(error), "command": display_command(command)})
         return 125
 
+    child: subprocess.Popen[bytes] | None = None
+    interruption: ProcessInterrupted | None = None
+    launch_error: OSError | None = None
+    exit_status = 125
+    with output:
+        previous_sigterm = signal.getsignal(signal.SIGTERM)
+
+        def interrupt_child(signum: int, _frame: Any) -> None:
+            raise ProcessInterrupted(signum)
+
+        signal.signal(signal.SIGTERM, interrupt_child)
+        try:
+            try:
+                child = subprocess.Popen(command, stdout=output, stderr=subprocess.STDOUT)
+            except OSError as error:
+                launch_error = error
+            else:
+                exit_status = wait_for_child(child, sequence)
+        except ProcessInterrupted as error:
+            interruption = error
+            if child is not None:
+                terminate_child(child)
+        except BaseException:
+            if child is not None:
+                terminate_child(child)
+            raise
+        finally:
+            signal.signal(signal.SIGTERM, previous_sigterm)
+
+    if launch_error is not None:
+        log.unlink(missing_ok=True)
+        emit_summary(
+            {"launch_error": str(launch_error), "command": display_command(command)}
+        )
+        return 125
+
     elapsed = time.monotonic() - started
-    failed_tasks, warnings, failures, excerpt = extract_diagnostics(log)
-    summarized_failed_tasks, failed_tasks_truncated = summarize_failed_tasks(failed_tasks)
-    warning_items = compact_fingerprints(warnings)
-    failure_items = compact_fingerprints(failures)
+    if interruption is not None:
+        exit_status = 128 + interruption.signum
+        append_run(
+            ledger,
+            {
+                "sequence": sequence,
+                "scope": arguments.scope,
+                "question": shortened(arguments.question, 1024),
+                "command": display_command(command),
+                "elapsed_seconds": round(elapsed, 3),
+                "exit_status": exit_status,
+                "interrupted_signal": interruption.signum,
+                "log": log.name,
+                "failure_fingerprints": [],
+                "warning_fingerprints": [],
+            },
+        )
+        write_ledger(directory, ledger)
+        emit_summary(
+            {
+                "command": display_command(command),
+                "elapsed_seconds": round(elapsed, 3),
+                "exit_status": exit_status,
+                "interrupted_signal": interruption.signum,
+                "log": str(log),
+                "repeated_command": repeated_command,
+                "scope": arguments.scope,
+            }
+        )
+        return exit_status
+
+    diagnostics = extract_diagnostics(log)
+    warning_items = diagnostics.warning_fingerprints
+    failure_items = diagnostics.failure_fingerprints
     repeated_primary_failure = bool(failure_items and next(iter(failure_items)) in prior_failures)
-    merge_fingerprints(ledger, "warning_fingerprints", warning_items)
-    merge_fingerprints(ledger, "failure_fingerprints", failure_items)
-    ledger["runs"].append(
+    merge_fingerprints(
+        ledger,
+        "warning_fingerprints",
+        warning_items,
+        diagnostics.warning_fingerprints_truncated,
+    )
+    merge_fingerprints(
+        ledger,
+        "failure_fingerprints",
+        failure_items,
+        diagnostics.failure_fingerprints_truncated,
+    )
+    append_run(
+        ledger,
         {
             "sequence": sequence,
             "scope": arguments.scope,
-            "question": arguments.question,
-            "command": command,
+            "question": shortened(arguments.question, 1024),
+            "command": display_command(command),
             "elapsed_seconds": round(elapsed, 3),
             "exit_status": exit_status,
             "log": log.name,
-            "failure_fingerprints": list(failure_items),
-            "warning_fingerprints": list(warning_items),
-        }
+            "failure_fingerprints": list(failure_items)[:MAX_DIAGNOSTICS],
+            "warning_fingerprints": list(warning_items)[:MAX_DIAGNOSTICS],
+        },
     )
     write_ledger(directory, ledger)
     emit_summary(
@@ -300,15 +498,17 @@ def run_command(root: Path, arguments: argparse.Namespace) -> int:
             "command": display_command(command),
             "elapsed_seconds": round(elapsed, 3),
             "exit_status": exit_status,
-            "excerpt": excerpt,
-            "failed_tasks": summarized_failed_tasks,
-            "failed_tasks_truncated": failed_tasks_truncated,
+            "excerpt": diagnostics.excerpt,
+            "failed_tasks": diagnostics.failed_tasks,
+            "failed_tasks_truncated": diagnostics.failed_tasks_truncated,
             "failure_fingerprints": summary_fingerprints(failure_items),
             "log": str(log),
             "repeated_command": repeated_command,
             "repeated_primary_failure": repeated_primary_failure,
             "scope": arguments.scope,
             "warning_fingerprints": summary_fingerprints(warning_items),
+            "warning_fingerprints_truncated": diagnostics.warning_fingerprints_truncated,
+            "failure_fingerprints_truncated": diagnostics.failure_fingerprints_truncated,
         }
     )
     return exit_status

--- a/skills/gradle-run/scripts/gradle_run.py
+++ b/skills/gradle-run/scripts/gradle_run.py
@@ -37,6 +37,15 @@ ANSI_ESCAPE = re.compile(r"\x1b(?:\[[0-?]*[ -/]*[@-~]|\][^\x07]*(?:\x07|\x1b\\))
 FAILED_TASK = re.compile(r"^> Task (:[^\s]+) FAILED$", re.MULTILINE)
 WARNING = re.compile(r"(?:\bwarning\b|\bdeprecat(?:ed|ion)\b|^w:)", re.IGNORECASE)
 FAILURE = re.compile(r"(?:^FAILURE:|^\* What went wrong:|^e:|\berror:)", re.IGNORECASE)
+AUTHORIZATION_VALUE = re.compile(
+    r"(\bauthorization\s*:\s*)(?:bearer\s+)?[^\r\n]+", re.IGNORECASE
+)
+SECRET_ASSIGNMENT = re.compile(
+    r"(\b[\w.-]*(?:password|passwd|token|secret|credential|api[-_.]?key)"
+    r"[\w.-]*\s*[:=]\s*)([^\r\n]+)",
+    re.IGNORECASE,
+)
+URL_PASSWORD = re.compile(r"(://[^:/\s]+:)([^@\s]+)(@)")
 
 
 def default_root() -> Path:
@@ -45,6 +54,12 @@ def default_root() -> Path:
 
 def normalize(text: str) -> str:
     return " ".join(ANSI_ESCAPE.sub("", text).split())
+
+
+def redact(text: str) -> str:
+    text = AUTHORIZATION_VALUE.sub(r"\1[REDACTED]", text)
+    text = SECRET_ASSIGNMENT.sub(r"\1[REDACTED]", text)
+    return URL_PASSWORD.sub(r"\1[REDACTED]\3", text)
 
 
 def fingerprint(text: str) -> str:
@@ -81,6 +96,66 @@ def workflow_path(root: Path, workflow: str) -> Path:
 def finished_path(root: Path, workflow: str) -> Path:
     directory = workflow_path(root, workflow)
     return directory.with_name(f"{workflow}.finished")
+
+
+def lock_path(root: Path, workflow: str) -> Path:
+    directory = workflow_path(root, workflow)
+    return directory.with_name(f"{workflow}.lock")
+
+
+class WorkflowLock:
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self.file: Any | None = None
+
+    def __enter__(self) -> None:
+        try:
+            self.file = self.path.open("a+b")
+            if self.file.tell() == 0:
+                self.file.write(b"\0")
+                self.file.flush()
+            self.file.seek(0)
+        except OSError as error:
+            if self.file is not None:
+                self.file.close()
+            raise ValueError("workflow lock is unavailable") from error
+
+        try:
+            if os.name == "posix":
+                import fcntl
+
+                fcntl.flock(self.file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+            elif os.name == "nt":
+                import msvcrt
+
+                msvcrt.locking(self.file.fileno(), msvcrt.LK_NBLCK, 1)
+            else:
+                raise ValueError("workflow locking is unsupported on this platform")
+        except ValueError:
+            self.file.close()
+            self.file = None
+            raise
+        except OSError as error:
+            self.file.close()
+            self.file = None
+            raise ValueError("workflow is busy") from error
+
+    def __exit__(self, _exc_type: object, _exc: object, _traceback: object) -> None:
+        if self.file is None:
+            return
+        try:
+            if os.name == "posix":
+                import fcntl
+
+                fcntl.flock(self.file.fileno(), fcntl.LOCK_UN)
+            elif os.name == "nt":
+                import msvcrt
+
+                self.file.seek(0)
+                msvcrt.locking(self.file.fileno(), msvcrt.LK_UNLCK, 1)
+        finally:
+            self.file.close()
+            self.file = None
 
 
 def read_finished(path: Path, workflow: str) -> bool:
@@ -206,7 +281,7 @@ def extract_diagnostics(log: Path) -> Diagnostics:
 
     with log.open(encoding="utf-8", errors="replace") as lines:
         for raw_line in lines:
-            line = normalize(raw_line)
+            line = redact(normalize(raw_line))
             if not line:
                 continue
             bounded_line = shortened(line, MAX_EXCERPT_LINE_BYTES)
@@ -315,8 +390,19 @@ def append_run(ledger: dict[str, Any], entry: dict[str, Any]) -> None:
         ledger["runs_truncated"] = ledger.get("runs_truncated", 0) + overflow
 
 
+def prune_logs(directory: Path, ledger: dict[str, Any]) -> None:
+    retained = {
+        run["log"]
+        for run in ledger["runs"]
+        if isinstance(run, dict) and isinstance(run.get("log"), str)
+    }
+    for log in directory.glob("*.log"):
+        if log.name not in retained:
+            log.unlink(missing_ok=True)
+
+
 def display_command(command: list[str]) -> str:
-    return shortened(" ".join(command), 1024)
+    return shortened(" ".join(redact(argument) for argument in command), 1024)
 
 
 def is_gradle_launcher(command: str) -> bool:
@@ -394,6 +480,14 @@ def wait_for_child(child: subprocess.Popen[bytes], sequence: int) -> int:
             timer.join()
 
 
+def process_launch_options(platform: str) -> dict[str, Any]:
+    if platform == "posix":
+        return {"start_new_session": True}
+    if platform == "nt":
+        return {"creationflags": subprocess.CREATE_NEW_PROCESS_GROUP}
+    raise ValueError("isolated process groups are unsupported on this platform")
+
+
 def terminate_child(
     child: subprocess.Popen[bytes], *, isolated_process_group: bool = False
 ) -> None:
@@ -407,7 +501,38 @@ def terminate_child(
             child.kill()
             child.wait()
 
-    if os.name != "posix" or not isolated_process_group:
+    def terminate_windows_tree() -> None:
+        if child.poll() is not None:
+            return
+        try:
+            child.send_signal(signal.CTRL_BREAK_EVENT)
+            child.wait(timeout=5)
+            return
+        except (OSError, subprocess.TimeoutExpired):
+            pass
+        try:
+            subprocess.run(
+                ["taskkill", "/PID", str(child.pid), "/T", "/F"],
+                check=False,
+                stderr=subprocess.DEVNULL,
+                stdout=subprocess.DEVNULL,
+                timeout=5,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            pass
+        try:
+            child.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            child.kill()
+            child.wait()
+
+    if not isolated_process_group:
+        terminate_direct_child()
+        return
+    if os.name == "nt":
+        terminate_windows_tree()
+        return
+    if os.name != "posix":
         terminate_direct_child()
         return
 
@@ -442,6 +567,11 @@ def terminate_child(
 
 
 def run_command(root: Path, arguments: argparse.Namespace) -> int:
+    with WorkflowLock(lock_path(root, arguments.workflow)):
+        return run_locked(root, arguments)
+
+
+def run_locked(root: Path, arguments: argparse.Namespace) -> int:
     directory = workflow_path(root, arguments.workflow)
     ledger = read_ledger(directory)
     command = list(arguments.command)
@@ -467,139 +597,157 @@ def run_command(root: Path, arguments: argparse.Namespace) -> int:
     interruption: ProcessInterrupted | None = None
     launch_error: OSError | None = None
     exit_status = 125
-    with output:
-        cleanup_started = False
-        handled_signals = (signal.SIGINT, signal.SIGTERM)
-        previous_handlers = {
-            handled_signal: signal.getsignal(handled_signal)
-            for handled_signal in handled_signals
-        }
+    cleanup_started = False
+    pending_signal: int | None = None
+    handled_signals = (signal.SIGINT, signal.SIGTERM)
+    previous_handlers = {
+        handled_signal: signal.getsignal(handled_signal)
+        for handled_signal in handled_signals
+    }
 
-        def interrupt_child(signum: int, _frame: Any) -> None:
-            if cleanup_started:
-                return
-            raise ProcessInterrupted(signum)
+    def interrupt_child(signum: int, _frame: Any) -> None:
+        nonlocal pending_signal
+        if cleanup_started:
+            return
+        if child is None:
+            pending_signal = pending_signal or signum
+            return
+        raise ProcessInterrupted(signum)
 
-        for handled_signal in handled_signals:
-            signal.signal(handled_signal, interrupt_child)
-        try:
+    for handled_signal in handled_signals:
+        signal.signal(handled_signal, interrupt_child)
+    try:
+        with output:
             try:
-                child = subprocess.Popen(
-                    command,
-                    stdout=output,
-                    stderr=subprocess.STDOUT,
-                    start_new_session=os.name == "posix",
-                )
-            except OSError as error:
-                launch_error = error
-            else:
-                exit_status = wait_for_child(child, sequence)
-        except ProcessInterrupted as error:
-            cleanup_started = True
-            interruption = error
-            if child is not None:
-                terminate_child(child, isolated_process_group=os.name == "posix")
-        except BaseException:
-            cleanup_started = True
-            if child is not None:
-                terminate_child(child, isolated_process_group=os.name == "posix")
-            raise
-        finally:
-            for handled_signal, previous_handler in previous_handlers.items():
-                signal.signal(handled_signal, previous_handler)
+                try:
+                    child = subprocess.Popen(
+                        command,
+                        stdout=output,
+                        stderr=subprocess.STDOUT,
+                        **process_launch_options(os.name),
+                    )
+                    if pending_signal is not None:
+                        raise ProcessInterrupted(pending_signal)
+                except OSError as error:
+                    launch_error = error
+                else:
+                    exit_status = wait_for_child(child, sequence)
+                cleanup_started = True
+            except ProcessInterrupted as error:
+                cleanup_started = True
+                interruption = error
+                if child is not None:
+                    terminate_child(child, isolated_process_group=True)
+            except BaseException:
+                cleanup_started = True
+                if child is not None:
+                    terminate_child(child, isolated_process_group=True)
+                raise
 
-    if launch_error is not None:
-        log.unlink(missing_ok=True)
-        emit_summary(
-            {"launch_error": str(launch_error), "command": display_command(command)}
+        if launch_error is not None:
+            log.unlink(missing_ok=True)
+            emit_summary(
+                {"launch_error": str(launch_error), "command": display_command(command)}
+            )
+            return 125
+
+        elapsed = time.monotonic() - started
+        if interruption is not None:
+            exit_status = 128 + interruption.signum
+            append_run(
+                ledger,
+                {
+                    "sequence": sequence,
+                    "scope": arguments.scope,
+                    "question": shortened(redact(arguments.question), 1024),
+                    "command": display_command(command),
+                    "elapsed_seconds": round(elapsed, 3),
+                    "exit_status": exit_status,
+                    "interrupted_signal": interruption.signum,
+                    "log": log.name,
+                    "failure_fingerprints": [],
+                    "warning_fingerprints": [],
+                },
+            )
+            write_ledger(directory, ledger)
+            prune_logs(directory, ledger)
+            emit_summary(
+                {
+                    "command": display_command(command),
+                    "elapsed_seconds": round(elapsed, 3),
+                    "exit_status": exit_status,
+                    "interrupted_signal": interruption.signum,
+                    "log": str(log),
+                    "repeated_command": repeated_command,
+                    "scope": arguments.scope,
+                }
+            )
+            return exit_status
+
+        diagnostics = extract_diagnostics(log)
+        warning_items = diagnostics.warning_fingerprints
+        failure_items = diagnostics.failure_fingerprints
+        repeated_primary_failure = bool(
+            failure_items and next(iter(failure_items)) in prior_failures
         )
-        return 125
-
-    elapsed = time.monotonic() - started
-    if interruption is not None:
-        exit_status = 128 + interruption.signum
+        merge_fingerprints(
+            ledger,
+            "warning_fingerprints",
+            warning_items,
+            diagnostics.warning_fingerprints_truncated,
+        )
+        merge_fingerprints(
+            ledger,
+            "failure_fingerprints",
+            failure_items,
+            diagnostics.failure_fingerprints_truncated,
+        )
         append_run(
             ledger,
             {
                 "sequence": sequence,
                 "scope": arguments.scope,
-                "question": shortened(arguments.question, 1024),
+                "question": shortened(redact(arguments.question), 1024),
                 "command": display_command(command),
                 "elapsed_seconds": round(elapsed, 3),
                 "exit_status": exit_status,
-                "interrupted_signal": interruption.signum,
                 "log": log.name,
-                "failure_fingerprints": [],
-                "warning_fingerprints": [],
+                "failure_fingerprints": list(failure_items)[:MAX_DIAGNOSTICS],
+                "warning_fingerprints": list(warning_items)[:MAX_DIAGNOSTICS],
             },
         )
         write_ledger(directory, ledger)
+        prune_logs(directory, ledger)
         emit_summary(
             {
                 "command": display_command(command),
                 "elapsed_seconds": round(elapsed, 3),
                 "exit_status": exit_status,
-                "interrupted_signal": interruption.signum,
+                "excerpt": diagnostics.excerpt,
+                "failed_tasks": diagnostics.failed_tasks,
+                "failed_tasks_truncated": diagnostics.failed_tasks_truncated,
+                "failure_fingerprints": summary_fingerprints(failure_items),
                 "log": str(log),
                 "repeated_command": repeated_command,
+                "repeated_primary_failure": repeated_primary_failure,
                 "scope": arguments.scope,
+                "warning_fingerprints": summary_fingerprints(warning_items),
+                "warning_fingerprints_truncated": diagnostics.warning_fingerprints_truncated,
+                "failure_fingerprints_truncated": diagnostics.failure_fingerprints_truncated,
             }
         )
         return exit_status
-
-    diagnostics = extract_diagnostics(log)
-    warning_items = diagnostics.warning_fingerprints
-    failure_items = diagnostics.failure_fingerprints
-    repeated_primary_failure = bool(failure_items and next(iter(failure_items)) in prior_failures)
-    merge_fingerprints(
-        ledger,
-        "warning_fingerprints",
-        warning_items,
-        diagnostics.warning_fingerprints_truncated,
-    )
-    merge_fingerprints(
-        ledger,
-        "failure_fingerprints",
-        failure_items,
-        diagnostics.failure_fingerprints_truncated,
-    )
-    append_run(
-        ledger,
-        {
-            "sequence": sequence,
-            "scope": arguments.scope,
-            "question": shortened(arguments.question, 1024),
-            "command": display_command(command),
-            "elapsed_seconds": round(elapsed, 3),
-            "exit_status": exit_status,
-            "log": log.name,
-            "failure_fingerprints": list(failure_items)[:MAX_DIAGNOSTICS],
-            "warning_fingerprints": list(warning_items)[:MAX_DIAGNOSTICS],
-        },
-    )
-    write_ledger(directory, ledger)
-    emit_summary(
-        {
-            "command": display_command(command),
-            "elapsed_seconds": round(elapsed, 3),
-            "exit_status": exit_status,
-            "excerpt": diagnostics.excerpt,
-            "failed_tasks": diagnostics.failed_tasks,
-            "failed_tasks_truncated": diagnostics.failed_tasks_truncated,
-            "failure_fingerprints": summary_fingerprints(failure_items),
-            "log": str(log),
-            "repeated_command": repeated_command,
-            "repeated_primary_failure": repeated_primary_failure,
-            "scope": arguments.scope,
-            "warning_fingerprints": summary_fingerprints(warning_items),
-            "warning_fingerprints_truncated": diagnostics.warning_fingerprints_truncated,
-            "failure_fingerprints_truncated": diagnostics.failure_fingerprints_truncated,
-        }
-    )
-    return exit_status
+    finally:
+        for handled_signal, previous_handler in previous_handlers.items():
+            signal.signal(handled_signal, previous_handler)
 
 
 def finish_workflow(root: Path, workflow: str) -> int:
+    with WorkflowLock(lock_path(root, workflow)):
+        return finish_locked(root, workflow)
+
+
+def finish_locked(root: Path, workflow: str) -> int:
     directory = workflow_path(root, workflow)
     tombstone = finished_path(root, workflow)
     if not directory.exists():

--- a/skills/gradle-run/scripts/test_gradle_run.py
+++ b/skills/gradle-run/scripts/test_gradle_run.py
@@ -238,6 +238,40 @@ class GradleRunProcessTest(GradleRunTestCase):
         self.assertEqual(len(failures), 1)
         self.assertIn("Unresolved reference", failures[0]["excerpt"])
 
+    def test_model_visible_output_and_ledger_redact_credentials(self) -> None:
+        workflow = self.create_workflow()
+        secret = "top secret tail-marker"
+
+        result = self.invoke(
+            "run",
+            "--workflow",
+            workflow,
+            "--scope",
+            "targeted",
+            "--question",
+            f"Does password={secret} stay private?",
+            "--",
+            str(self.gradle),
+            f"-PapiToken={secret}",
+            "--",
+            sys.executable,
+            "-c",
+            (
+                f"print('warning: authToken={secret}'); "
+                f"print('error: password={secret}'); "
+                f"print('warning: Authorization: Bearer {secret}')"
+            ),
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        ledger = (self.root / workflow / "ledger.json").read_text()
+        self.assertNotIn(secret, result.stdout)
+        self.assertNotIn(secret, ledger)
+        self.assertNotIn("tail-marker", result.stdout)
+        self.assertNotIn("tail-marker", ledger)
+        self.assertIn("[REDACTED]", result.stdout)
+        self.assertIn("[REDACTED]", ledger)
+
     def test_missing_command_fails_without_fallback(self) -> None:
         workflow = self.create_workflow()
 
@@ -307,6 +341,62 @@ class GradleRunProcessTest(GradleRunTestCase):
         ledger = json.loads((self.root / workflow / "ledger.json").read_text())
         self.assertEqual(ledger["runs"][0]["interrupted_signal"], signal.SIGTERM)
         self.assert_process_gone(int(pid_file.read_text()))
+
+    def test_signal_during_launch_reaps_the_created_process_group(self) -> None:
+        workflow = self.create_workflow()
+        arguments = GRADLE_RUN.parser().parse_args(
+            [
+                "--root",
+                str(self.root),
+                "run",
+                "--workflow",
+                workflow,
+                "--scope",
+                "targeted",
+                "--question",
+                "Can interruption during launch stop the build safely?",
+                "--",
+                str(self.gradle),
+                "--",
+                sys.executable,
+                "-c",
+                "import time; time.sleep(60)",
+            ]
+        )
+        real_popen = subprocess.Popen
+        started: list[subprocess.Popen[bytes]] = []
+
+        def interrupt_before_returning_child(
+            *popen_arguments: object, **popen_options: object
+        ) -> subprocess.Popen[bytes]:
+            child = real_popen(*popen_arguments, **popen_options)
+            started.append(child)
+            signal.raise_signal(signal.SIGINT)
+            return child
+
+        output = io.StringIO()
+        wrapper_reaped_child = False
+        try:
+            with (
+                mock.patch.object(
+                    GRADLE_RUN.subprocess,
+                    "Popen",
+                    side_effect=interrupt_before_returning_child,
+                ),
+                mock.patch("sys.stdout", output),
+            ):
+                result = GRADLE_RUN.run_command(self.root, arguments)
+            wrapper_reaped_child = bool(started) and not process_is_running(started[0].pid)
+        finally:
+            for child in started:
+                if process_is_running(child.pid):
+                    os.killpg(child.pid, signal.SIGKILL)
+                child.wait()
+
+        self.assertEqual(result, 128 + signal.SIGINT)
+        self.assertEqual(json.loads(output.getvalue())["interrupted_signal"], signal.SIGINT)
+        self.assertEqual(len(started), 1)
+        self.assertTrue(wrapper_reaped_child, "wrapper left the launched child running")
 
     def test_sigint_reaps_child_and_records_interrupted_run(self) -> None:
         workflow = self.create_workflow()
@@ -420,6 +510,57 @@ class GradleRunProcessTest(GradleRunTestCase):
         self.assertEqual(ledger["runs"][0]["interrupted_signal"], signal.SIGINT)
         assert child_pid is not None
         self.assert_process_gone(child_pid)
+
+    def test_signal_after_child_exit_preserves_the_completed_run(self) -> None:
+        workflow = self.create_workflow()
+        pid_file = self.root.parent / "completed-child.pid"
+        child_code = (
+            "from pathlib import Path; import os; "
+            f"Path({str(pid_file)!r}).write_text(str(os.getpid())); "
+            "[print(f'warning: diagnostic {index}') for index in range(1_000_000)]"
+        )
+        wrapper = subprocess.Popen(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--root",
+                str(self.root),
+                "run",
+                "--workflow",
+                workflow,
+                "--scope",
+                "targeted",
+                "--question",
+                "Can finalization preserve a completed build?",
+                "--",
+                str(self.gradle),
+                "--",
+                sys.executable,
+                "-c",
+                child_code,
+            ],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        deadline = time.monotonic() + 15
+        while not pid_file.exists() and time.monotonic() < deadline:
+            time.sleep(0.01)
+        self.assertTrue(pid_file.exists(), "child did not start")
+        child_pid = int(pid_file.read_text())
+        while process_is_running(child_pid) and time.monotonic() < deadline:
+            time.sleep(0.001)
+        self.assertFalse(process_is_running(child_pid), "child did not finish")
+        self.assertIsNone(wrapper.poll(), "wrapper finished before finalization was exercised")
+
+        wrapper.send_signal(signal.SIGINT)
+        stdout, stderr = wrapper.communicate(timeout=15)
+
+        self.assertEqual(wrapper.returncode, 0, stderr)
+        self.assertEqual(json.loads(stdout)["exit_status"], 0)
+        ledger = json.loads((self.root / workflow / "ledger.json").read_text())
+        self.assertEqual(ledger["run_count"], 1)
+        self.assertEqual(ledger["runs"][0]["exit_status"], 0)
 
     def test_blank_question_fails_without_running_the_command(self) -> None:
         workflow = self.create_workflow()
@@ -585,7 +726,143 @@ class GradleRunHeartbeatTest(unittest.TestCase):
         self.assertIsNotNone(child.poll())
 
 
+class GradleRunWindowsProcessTest(unittest.TestCase):
+    def test_windows_launch_uses_a_new_process_group(self) -> None:
+        with mock.patch.object(
+            GRADLE_RUN.subprocess,
+            "CREATE_NEW_PROCESS_GROUP",
+            0x00000200,
+            create=True,
+        ):
+            options = GRADLE_RUN.process_launch_options("nt")
+
+        self.assertEqual(options, {"creationflags": 0x00000200})
+
+    def test_windows_cleanup_escalates_to_the_process_tree(self) -> None:
+        child = mock.Mock()
+        child.pid = 4242
+        child.poll.return_value = None
+        child.wait.side_effect = [
+            subprocess.TimeoutExpired("gradlew", 5),
+            0,
+        ]
+
+        with (
+            mock.patch.object(GRADLE_RUN.os, "name", "nt"),
+            mock.patch.object(
+                GRADLE_RUN.signal,
+                "CTRL_BREAK_EVENT",
+                1,
+                create=True,
+            ),
+            mock.patch.object(GRADLE_RUN.subprocess, "run") as taskkill,
+        ):
+            GRADLE_RUN.terminate_child(child, isolated_process_group=True)
+
+        child.send_signal.assert_called_once_with(1)
+        taskkill.assert_called_once_with(
+            ["taskkill", "/PID", "4242", "/T", "/F"],
+            check=False,
+            stderr=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            timeout=5,
+        )
+        child.wait.assert_has_calls([mock.call(timeout=5), mock.call(timeout=5)])
+
+
 class GradleRunWorkflowTest(GradleRunTestCase):
+    def test_concurrent_run_fails_before_launching(self) -> None:
+        workflow = self.create_workflow()
+        ready = self.root.parent / "active-run.ready"
+        unexpected = self.root.parent / "unexpected-run"
+        active = subprocess.Popen(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--root",
+                str(self.root),
+                "run",
+                "--workflow",
+                workflow,
+                "--scope",
+                "targeted",
+                "--question",
+                "Does the active task finish?",
+                "--",
+                str(self.gradle),
+                "--",
+                sys.executable,
+                "-c",
+                f"from pathlib import Path; import time; Path({str(ready)!r}).touch(); time.sleep(60)",
+            ],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        try:
+            deadline = time.monotonic() + 5
+            while not ready.exists() and time.monotonic() < deadline:
+                time.sleep(0.01)
+            self.assertTrue(ready.exists(), "active run did not start")
+
+            result = self.run_gradle(
+                workflow,
+                "targeted",
+                "Can another task use this workflow?",
+                f"from pathlib import Path; Path({str(unexpected)!r}).touch()",
+            )
+        finally:
+            if active.poll() is None:
+                active.send_signal(signal.SIGTERM)
+            active.communicate(timeout=10)
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("workflow is busy", result.stderr)
+        self.assertFalse(unexpected.exists())
+
+    def test_finish_fails_while_a_run_is_active(self) -> None:
+        workflow = self.create_workflow()
+        ready = self.root.parent / "finish-active.ready"
+        active = subprocess.Popen(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--root",
+                str(self.root),
+                "run",
+                "--workflow",
+                workflow,
+                "--scope",
+                "targeted",
+                "--question",
+                "Does the active task finish before cleanup?",
+                "--",
+                str(self.gradle),
+                "--",
+                sys.executable,
+                "-c",
+                f"from pathlib import Path; import time; Path({str(ready)!r}).touch(); time.sleep(60)",
+            ],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        try:
+            deadline = time.monotonic() + 5
+            while not ready.exists() and time.monotonic() < deadline:
+                time.sleep(0.01)
+            self.assertTrue(ready.exists(), "active run did not start")
+
+            result = self.invoke("finish", "--workflow", workflow)
+        finally:
+            if active.poll() is None:
+                active.send_signal(signal.SIGTERM)
+            active.communicate(timeout=10)
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("workflow is busy", result.stderr)
+        self.assertTrue((self.root / workflow).is_dir())
+
     def test_workflow_ledger_records_scope_question_and_command(self) -> None:
         workflow = self.create_workflow()
         result = self.run_gradle(
@@ -649,6 +926,38 @@ class GradleRunWorkflowTest(GradleRunTestCase):
         self.assertEqual(
             json.loads(result.stdout)["warning_fingerprints_truncated"], 744
         )
+
+    def test_logs_are_pruned_with_evicted_ledger_runs(self) -> None:
+        workflow = self.create_workflow()
+
+        with mock.patch.object(GRADLE_RUN, "MAX_LEDGER_RUNS", 2):
+            for index in range(3):
+                arguments = GRADLE_RUN.parser().parse_args(
+                    [
+                        "--root",
+                        str(self.root),
+                        "run",
+                        "--workflow",
+                        workflow,
+                        "--scope",
+                        "targeted",
+                        "--question",
+                        f"Does retained run {index + 1} pass?",
+                        "--",
+                        str(self.gradle),
+                        "--",
+                        sys.executable,
+                        "-c",
+                        "print('ok')",
+                    ]
+                )
+                with mock.patch("sys.stdout", new=io.StringIO()):
+                    self.assertEqual(GRADLE_RUN.run_command(self.root, arguments), 0)
+
+        logs = sorted(path.name for path in (self.root / workflow).glob("*.log"))
+        self.assertEqual(logs, ["0002.log", "0003.log"])
+        ledger = json.loads((self.root / workflow / "ledger.json").read_text())
+        self.assertEqual([run["sequence"] for run in ledger["runs"]], [2, 3])
 
     def test_finish_deletes_only_the_managed_workflow_directory(self) -> None:
         first = self.create_workflow()

--- a/skills/gradle-run/scripts/test_gradle_run.py
+++ b/skills/gradle-run/scripts/test_gradle_run.py
@@ -25,6 +25,48 @@ sys.modules[SPEC.name] = GRADLE_RUN
 SPEC.loader.exec_module(GRADLE_RUN)
 
 
+def process_is_running(pid: int) -> bool:
+    try:
+        stat = (Path("/proc") / str(pid) / "stat").read_text()
+    except OSError:
+        pass
+    else:
+        _prefix, separator, fields = stat.rpartition(") ")
+        if separator and fields.split()[:1] == ["Z"]:
+            return False
+
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    return True
+
+
+class ProcessAssertionTest(unittest.TestCase):
+    @unittest.skipUnless(
+        hasattr(os, "fork") and Path("/proc").is_dir(),
+        "requires a procfs-backed POSIX process table",
+    )
+    def test_zombie_is_not_reported_as_running(self) -> None:
+        pid = os.fork()
+        if pid == 0:
+            os._exit(0)
+
+        try:
+            status = Path("/proc") / str(pid) / "stat"
+            deadline = time.monotonic() + 2
+            while time.monotonic() < deadline:
+                if status.read_text().rpartition(") ")[2].split()[:1] == ["Z"]:
+                    break
+                time.sleep(0.01)
+            else:
+                self.fail(f"process {pid} did not become a zombie")
+
+            self.assertFalse(process_is_running(pid))
+        finally:
+            os.waitpid(pid, 0)
+
+
 class GradleRunTestCase(unittest.TestCase):
     def setUp(self) -> None:
         self.temporary_directory = tempfile.TemporaryDirectory()
@@ -57,9 +99,7 @@ class GradleRunTestCase(unittest.TestCase):
     def assert_process_gone(self, pid: int) -> None:
         deadline = time.monotonic() + 2
         while time.monotonic() < deadline:
-            try:
-                os.kill(pid, 0)
-            except ProcessLookupError:
+            if not process_is_running(pid):
                 return
             time.sleep(0.01)
         self.fail(f"process {pid} is still running")
@@ -314,6 +354,72 @@ class GradleRunProcessTest(GradleRunTestCase):
         ledger = json.loads((self.root / workflow / "ledger.json").read_text())
         self.assertEqual(ledger["runs"][0]["interrupted_signal"], signal.SIGINT)
         self.assert_process_gone(int(pid_file.read_text()))
+
+    def test_repeated_sigint_during_cleanup_records_interrupted_run(self) -> None:
+        workflow = self.create_workflow()
+        pid_file = self.root.parent / "signal-resistant-child.pid"
+        child_code = (
+            "from pathlib import Path; import os, signal, time; "
+            "signal.signal(signal.SIGINT, signal.SIG_IGN); "
+            "signal.signal(signal.SIGTERM, signal.SIG_IGN); "
+            f"Path({str(pid_file)!r}).write_text(str(os.getpid())); "
+            "time.sleep(60)"
+        )
+        wrapper = subprocess.Popen(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--root",
+                str(self.root),
+                "run",
+                "--workflow",
+                workflow,
+                "--scope",
+                "targeted",
+                "--question",
+                "Can repeated Ctrl-C stop the build safely?",
+                "--",
+                str(self.gradle),
+                "--",
+                sys.executable,
+                "-c",
+                child_code,
+            ],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        child_pid: int | None = None
+        stdout = ""
+        stderr = ""
+        try:
+            deadline = time.monotonic() + 5
+            while not pid_file.exists() and time.monotonic() < deadline:
+                time.sleep(0.01)
+            self.assertTrue(pid_file.exists(), "child did not start")
+            child_pid = int(pid_file.read_text())
+
+            wrapper.send_signal(signal.SIGINT)
+            time.sleep(0.1)
+            wrapper.send_signal(signal.SIGINT)
+            stdout, stderr = wrapper.communicate(timeout=10)
+        finally:
+            if wrapper.poll() is None:
+                wrapper.kill()
+                wrapper.communicate()
+            if child_pid is not None:
+                try:
+                    os.kill(child_pid, signal.SIGKILL)
+                except ProcessLookupError:
+                    pass
+
+        self.assertEqual(wrapper.returncode, 128 + signal.SIGINT, stderr)
+        summary = json.loads(stdout)
+        self.assertEqual(summary["interrupted_signal"], signal.SIGINT)
+        ledger = json.loads((self.root / workflow / "ledger.json").read_text())
+        self.assertEqual(ledger["runs"][0]["interrupted_signal"], signal.SIGINT)
+        assert child_pid is not None
+        self.assert_process_gone(child_pid)
 
     def test_blank_question_fails_without_running_the_command(self) -> None:
         workflow = self.create_workflow()

--- a/skills/gradle-run/scripts/test_gradle_run.py
+++ b/skills/gradle-run/scripts/test_gradle_run.py
@@ -54,6 +54,16 @@ class GradleRunTestCase(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         return json.loads(result.stdout)["workflow"]
 
+    def assert_process_gone(self, pid: int) -> None:
+        deadline = time.monotonic() + 2
+        while time.monotonic() < deadline:
+            try:
+                os.kill(pid, 0)
+            except ProcessLookupError:
+                return
+            time.sleep(0.01)
+        self.fail(f"process {pid} is still running")
+
     def run_gradle(
         self, workflow: str, scope: str, question: str, command: str
     ) -> subprocess.CompletedProcess[str]:
@@ -157,6 +167,22 @@ class GradleRunProcessTest(GradleRunTestCase):
         self.assertEqual(warning[0]["count"], 2)
         self.assertEqual(len(warning[0]["fingerprint"]), 64)
 
+    def test_kotlin_and_deprecation_warning_formats_are_fingerprinted(self) -> None:
+        workflow = self.create_workflow()
+
+        result = self.run_gradle(
+            workflow,
+            "targeted",
+            "Which compiler and Gradle warnings remain?",
+            "print('w: src/Main.kt:1:1 This declaration needs opt-in'); print('This API has been deprecated and will be removed')",
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        warnings = json.loads(result.stdout)["warning_fingerprints"]
+        self.assertEqual(len(warnings), 2)
+        self.assertTrue(any(item["excerpt"].startswith("w:") for item in warnings))
+        self.assertTrue(any("deprecated" in item["excerpt"] for item in warnings))
+
     def test_multiline_failure_is_fingerprinted_as_one_diagnostic_block(self) -> None:
         workflow = self.create_workflow()
 
@@ -193,10 +219,12 @@ class GradleRunProcessTest(GradleRunTestCase):
 
     def test_sigterm_reaps_child_and_records_interrupted_run(self) -> None:
         workflow = self.create_workflow()
-        pid_file = self.root.parent / "child.pid"
+        pid_file = self.root.parent / "descendant.pid"
+        descendant_code = "import time; time.sleep(60)"
         child_code = (
-            "from pathlib import Path; import os, time; "
-            f"Path({str(pid_file)!r}).write_text(str(os.getpid())); "
+            "from pathlib import Path; import subprocess, sys, time; "
+            f"descendant = subprocess.Popen([sys.executable, '-c', {descendant_code!r}]); "
+            f"Path({str(pid_file)!r}).write_text(str(descendant.pid)); "
             "time.sleep(60)"
         )
         wrapper = subprocess.Popen(
@@ -238,8 +266,54 @@ class GradleRunProcessTest(GradleRunTestCase):
         self.assertTrue(Path(summary["log"]).is_file())
         ledger = json.loads((self.root / workflow / "ledger.json").read_text())
         self.assertEqual(ledger["runs"][0]["interrupted_signal"], signal.SIGTERM)
-        with self.assertRaises(ProcessLookupError):
-            os.kill(int(pid_file.read_text()), 0)
+        self.assert_process_gone(int(pid_file.read_text()))
+
+    def test_sigint_reaps_child_and_records_interrupted_run(self) -> None:
+        workflow = self.create_workflow()
+        pid_file = self.root.parent / "child.pid"
+        child_code = (
+            "from pathlib import Path; import os, time; "
+            f"Path({str(pid_file)!r}).write_text(str(os.getpid())); "
+            "time.sleep(60)"
+        )
+        wrapper = subprocess.Popen(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--root",
+                str(self.root),
+                "run",
+                "--workflow",
+                workflow,
+                "--scope",
+                "targeted",
+                "--question",
+                "Can Ctrl-C stop the build safely?",
+                "--",
+                str(self.gradle),
+                "--",
+                sys.executable,
+                "-c",
+                child_code,
+            ],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        deadline = time.monotonic() + 5
+        while not pid_file.exists() and time.monotonic() < deadline:
+            time.sleep(0.01)
+        self.assertTrue(pid_file.exists(), "child did not start")
+
+        wrapper.send_signal(signal.SIGINT)
+        stdout, stderr = wrapper.communicate(timeout=10)
+
+        self.assertEqual(wrapper.returncode, 128 + signal.SIGINT, stderr)
+        summary = json.loads(stdout)
+        self.assertEqual(summary["interrupted_signal"], signal.SIGINT)
+        ledger = json.loads((self.root / workflow / "ledger.json").read_text())
+        self.assertEqual(ledger["runs"][0]["interrupted_signal"], signal.SIGINT)
+        self.assert_process_gone(int(pid_file.read_text()))
 
     def test_blank_question_fails_without_running_the_command(self) -> None:
         workflow = self.create_workflow()
@@ -488,6 +562,14 @@ class GradleRunWorkflowTest(GradleRunTestCase):
 
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertTrue(json.loads(result.stdout)["already_finished"])
+
+    def test_finish_rejects_an_unknown_valid_workflow_identifier(self) -> None:
+        self.root.mkdir(parents=True)
+
+        result = self.invoke("finish", "--workflow", "0" * 32)
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("unknown workflow identifier", result.stderr)
 
     def test_invalid_workflow_identifier_fails_closed(self) -> None:
         self.root.mkdir(parents=True)

--- a/skills/gradle-run/scripts/test_gradle_run.py
+++ b/skills/gradle-run/scripts/test_gradle_run.py
@@ -571,51 +571,44 @@ class GradleRunProcessTest(GradleRunTestCase):
 
     def test_signal_after_child_exit_preserves_the_completed_run(self) -> None:
         workflow = self.create_workflow()
-        pid_file = self.root.parent / "completed-child.pid"
-        child_code = (
-            "from pathlib import Path; import os; "
-            f"Path({str(pid_file)!r}).write_text(str(os.getpid())); "
-            "[print(f'warning: diagnostic {index}') for index in range(1_000_000)]"
-        )
-        wrapper = subprocess.Popen(
-            [
-                sys.executable,
-                str(SCRIPT),
-                "--root",
-                str(self.root),
-                "run",
-                "--workflow",
-                workflow,
-                "--scope",
-                "targeted",
-                "--question",
-                "Can finalization preserve a completed build?",
-                "--",
-                str(self.gradle),
-                "--",
-                sys.executable,
-                "-c",
-                child_code,
-            ],
-            text=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-        )
-        deadline = time.monotonic() + 15
-        while not pid_file.exists() and time.monotonic() < deadline:
-            time.sleep(0.01)
-        self.assertTrue(pid_file.exists(), "child did not start")
-        child_pid = int(pid_file.read_text())
-        while process_is_running(child_pid) and time.monotonic() < deadline:
-            time.sleep(0.001)
-        self.assertFalse(process_is_running(child_pid), "child did not finish")
-        self.assertIsNone(wrapper.poll(), "wrapper finished before finalization was exercised")
+        arguments = [
+            str(SCRIPT),
+            "--root",
+            str(self.root),
+            "run",
+            "--workflow",
+            workflow,
+            "--scope",
+            "targeted",
+            "--question",
+            "Can finalization preserve a completed build?",
+            "--",
+            str(self.gradle),
+            "--",
+            sys.executable,
+            "-c",
+            "print('warning: final diagnostic')",
+        ]
+        extract_diagnostics = GRADLE_RUN.extract_diagnostics
 
-        wrapper.send_signal(signal.SIGINT)
-        stdout, stderr = wrapper.communicate(timeout=15)
+        def interrupt_during_finalization(log: Path) -> GRADLE_RUN.Diagnostics:
+            signal.raise_signal(signal.SIGINT)
+            return extract_diagnostics(log)
 
-        self.assertEqual(wrapper.returncode, 0, stderr)
-        self.assertEqual(json.loads(stdout)["exit_status"], 0)
+        with (
+            mock.patch.object(sys, "argv", arguments),
+            mock.patch.object(
+                GRADLE_RUN,
+                "extract_diagnostics",
+                side_effect=interrupt_during_finalization,
+            ) as extraction,
+            mock.patch("sys.stdout", new=io.StringIO()) as stdout,
+        ):
+            exit_status = GRADLE_RUN.main()
+
+        extraction.assert_called_once()
+        self.assertEqual(exit_status, 0)
+        self.assertEqual(json.loads(stdout.getvalue())["exit_status"], 0)
         ledger = json.loads((self.root / workflow / "ledger.json").read_text())
         self.assertEqual(ledger["run_count"], 1)
         self.assertEqual(ledger["runs"][0]["exit_status"], 0)
@@ -825,7 +818,34 @@ class GradleRunWindowsProcessTest(unittest.TestCase):
             stdout=subprocess.DEVNULL,
             timeout=5,
         )
-        child.wait.assert_has_calls([mock.call(timeout=5), mock.call(timeout=5)])
+        child.wait.assert_has_calls([mock.call(timeout=5), mock.call()])
+
+    def test_windows_cleanup_kills_tree_when_launcher_exits_after_ctrl_break(self) -> None:
+        child = mock.Mock()
+        child.pid = 4242
+        child.poll.return_value = None
+        child.wait.return_value = 0
+
+        with (
+            mock.patch.object(GRADLE_RUN.os, "name", "nt"),
+            mock.patch.object(
+                GRADLE_RUN.signal,
+                "CTRL_BREAK_EVENT",
+                1,
+                create=True,
+            ),
+            mock.patch.object(GRADLE_RUN.subprocess, "run") as taskkill,
+        ):
+            GRADLE_RUN.terminate_child(child, isolated_process_group=True)
+
+        child.send_signal.assert_called_once_with(1)
+        taskkill.assert_called_once_with(
+            ["taskkill", "/PID", "4242", "/T", "/F"],
+            check=False,
+            stderr=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            timeout=5,
+        )
 
 
 class GradleRunWorkflowTest(GradleRunTestCase):

--- a/skills/gradle-run/scripts/test_gradle_run.py
+++ b/skills/gradle-run/scripts/test_gradle_run.py
@@ -445,6 +445,64 @@ class GradleRunProcessTest(GradleRunTestCase):
         self.assertEqual(ledger["runs"][0]["interrupted_signal"], signal.SIGINT)
         self.assert_process_gone(int(pid_file.read_text()))
 
+    def test_interrupted_run_preserves_partial_diagnostics(self) -> None:
+        workflow = self.create_workflow()
+        pid_file = self.root.parent / "diagnostic-child.pid"
+        child_code = (
+            "from pathlib import Path; import os, time; "
+            "print('e: Unresolved reference: missingAfterInterrupt', flush=True); "
+            "print('warning: partial warning remains', flush=True); "
+            f"Path({str(pid_file)!r}).write_text(str(os.getpid())); "
+            "time.sleep(60)"
+        )
+        wrapper = subprocess.Popen(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--root",
+                str(self.root),
+                "run",
+                "--workflow",
+                workflow,
+                "--scope",
+                "targeted",
+                "--question",
+                "What evidence was emitted before interruption?",
+                "--",
+                str(self.gradle),
+                "--",
+                sys.executable,
+                "-c",
+                child_code,
+            ],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        deadline = time.monotonic() + 5
+        while not pid_file.exists() and time.monotonic() < deadline:
+            time.sleep(0.01)
+        self.assertTrue(pid_file.exists(), "child did not start")
+
+        wrapper.send_signal(signal.SIGINT)
+        stdout, stderr = wrapper.communicate(timeout=10)
+
+        self.assertEqual(wrapper.returncode, 128 + signal.SIGINT, stderr)
+        summary = json.loads(stdout)
+        self.assertIn(
+            "missingAfterInterrupt", summary["failure_fingerprints"][0]["excerpt"]
+        )
+        self.assertIn("partial warning", summary["warning_fingerprints"][0]["excerpt"])
+        ledger = json.loads((self.root / workflow / "ledger.json").read_text())
+        self.assertTrue(ledger["runs"][0]["failure_fingerprints"])
+        self.assertTrue(ledger["runs"][0]["warning_fingerprints"])
+        self.assertTrue(
+            any(
+                "missingAfterInterrupt" in item["excerpt"]
+                for item in ledger["failure_fingerprints"].values()
+            )
+        )
+
     def test_repeated_sigint_during_cleanup_records_interrupted_run(self) -> None:
         workflow = self.create_workflow()
         pid_file = self.root.parent / "signal-resistant-child.pid"
@@ -887,6 +945,35 @@ class GradleRunWorkflowTest(GradleRunTestCase):
 
         self.assertEqual(result.returncode, 1)
         self.assertTrue(json.loads(result.stdout)["repeated_primary_failure"])
+
+    def test_changed_source_failure_is_not_masked_by_the_gradle_block(self) -> None:
+        workflow = self.create_workflow()
+        generic_block = (
+            "print('FAILURE: Build failed'); "
+            "print('e: Unresolved reference: {source}'); "
+            "print('* What went wrong:'); "
+            "print('Execution failed for task compileKotlin'); "
+            "raise SystemExit(1)"
+        )
+        first = self.run_gradle(
+            workflow,
+            "targeted",
+            "What is the first source failure?",
+            generic_block.format(source="firstSymbol"),
+        )
+        self.assertEqual(first.returncode, 1)
+
+        second = self.run_gradle(
+            workflow,
+            "targeted",
+            "Did the source failure change?",
+            generic_block.format(source="secondSymbol"),
+        )
+
+        self.assertEqual(second.returncode, 1)
+        summary = json.loads(second.stdout)
+        self.assertFalse(summary["repeated_primary_failure"])
+        self.assertIn("secondSymbol", summary["failure_fingerprints"][0]["excerpt"])
 
     def test_warning_fingerprints_are_deduplicated_across_runs(self) -> None:
         workflow = self.create_workflow()

--- a/skills/gradle-run/scripts/test_gradle_run.py
+++ b/skills/gradle-run/scripts/test_gradle_run.py
@@ -271,6 +271,25 @@ class GradleRunProcessTest(GradleRunTestCase):
         self.assertIn("Gradle launcher", result.stderr)
         self.assertFalse(list((self.root / workflow).glob("*.log")))
 
+    def test_custom_gradle_wrapper_script_is_accepted(self) -> None:
+        workflow = self.create_workflow()
+        custom_wrapper = self.gradle.with_name("gradlew_affected")
+        self.gradle.rename(custom_wrapper)
+        self.gradle = custom_wrapper
+
+        result = self.run_gradle(
+            workflow,
+            "targeted",
+            "Does the affected-module check pass?",
+            "print('ok')",
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        summary = json.loads(result.stdout)
+        self.assertEqual(summary["exit_status"], 0)
+        self.assertIn("--console=plain", summary["command"])
+        self.assertIn("--no-scan", summary["command"])
+
     def test_gradle_defaults_preserve_an_explicit_scan(self) -> None:
         workflow = self.create_workflow()
         self.gradle.write_text("#!/bin/sh\nprintf 'args: %s\\n' \"$*\"\n")

--- a/skills/gradle-run/scripts/test_gradle_run.py
+++ b/skills/gradle-run/scripts/test_gradle_run.py
@@ -4,18 +4,24 @@ from __future__ import annotations
 
 import json
 import importlib.util
+import io
+import os
 from pathlib import Path
+import signal
 import shutil
 import subprocess
 import sys
 import tempfile
+import time
 import unittest
+from unittest import mock
 
 
 SCRIPT = Path(__file__).with_name("gradle_run.py")
 SPEC = importlib.util.spec_from_file_location("gradle_run", SCRIPT)
 assert SPEC and SPEC.loader
 GRADLE_RUN = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = GRADLE_RUN
 SPEC.loader.exec_module(GRADLE_RUN)
 
 
@@ -79,7 +85,7 @@ class GradleRunProcessTest(GradleRunTestCase):
 
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertLessEqual(len(result.stdout.encode("utf-8")), 16_384)
-        self.assertLessEqual(len(result.stdout.splitlines()), 64)
+        self.assertEqual(len(result.stdout.splitlines()), 1)
         summary = json.loads(result.stdout)
         log = Path(summary["log"])
         self.assertTrue(log.is_file())
@@ -185,6 +191,56 @@ class GradleRunProcessTest(GradleRunTestCase):
         self.assertIn("launch_error", json.loads(result.stdout))
         self.assertFalse(list((self.root / workflow).glob("*.log")))
 
+    def test_sigterm_reaps_child_and_records_interrupted_run(self) -> None:
+        workflow = self.create_workflow()
+        pid_file = self.root.parent / "child.pid"
+        child_code = (
+            "from pathlib import Path; import os, time; "
+            f"Path({str(pid_file)!r}).write_text(str(os.getpid())); "
+            "time.sleep(60)"
+        )
+        wrapper = subprocess.Popen(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--root",
+                str(self.root),
+                "run",
+                "--workflow",
+                workflow,
+                "--scope",
+                "targeted",
+                "--question",
+                "Can interruption stop the build safely?",
+                "--",
+                str(self.gradle),
+                "--",
+                sys.executable,
+                "-c",
+                child_code,
+            ],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        deadline = time.monotonic() + 5
+        while not pid_file.exists() and time.monotonic() < deadline:
+            time.sleep(0.01)
+        self.assertTrue(pid_file.exists(), "child did not start")
+
+        wrapper.send_signal(signal.SIGTERM)
+        stdout, stderr = wrapper.communicate(timeout=10)
+
+        self.assertEqual(wrapper.returncode, 128 + signal.SIGTERM, stderr)
+        summary = json.loads(stdout)
+        self.assertEqual(summary["interrupted_signal"], signal.SIGTERM)
+        self.assertNotIn("launch_error", summary)
+        self.assertTrue(Path(summary["log"]).is_file())
+        ledger = json.loads((self.root / workflow / "ledger.json").read_text())
+        self.assertEqual(ledger["runs"][0]["interrupted_signal"], signal.SIGTERM)
+        with self.assertRaises(ProcessLookupError):
+            os.kill(int(pid_file.read_text()), 0)
+
     def test_blank_question_fails_without_running_the_command(self) -> None:
         workflow = self.create_workflow()
 
@@ -264,20 +320,70 @@ class GradleRunProcessTest(GradleRunTestCase):
         self.assertLess(command.index("--console=plain"), separator)
         self.assertLess(command.index("--no-scan"), separator)
 
+    def test_task_arguments_do_not_override_gradle_defaults(self) -> None:
+        workflow = self.create_workflow()
+        self.gradle.write_text("#!/bin/sh\nprintf 'args: %s\\n' \"$*\"\n")
+
+        result = self.invoke(
+            "run",
+            "--workflow",
+            workflow,
+            "--scope",
+            "targeted",
+            "--question",
+            "Do task arguments leave Gradle defaults intact?",
+            "--",
+            str(self.gradle),
+            "check",
+            "--",
+            "--scan",
+            "--console=verbose",
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        command = json.loads(result.stdout)["command"].split()
+        separator = command.index("--")
+        self.assertLess(command.index("--console=plain"), separator)
+        self.assertLess(command.index("--no-scan"), separator)
+
 
 class GradleRunHeartbeatTest(unittest.TestCase):
-    def test_heartbeat_schedule_is_finite_and_stops_after_its_last_delay(self) -> None:
-        delays = GRADLE_RUN.HEARTBEAT_DELAYS
-        emitted: list[float] = []
-        next_index = 0
+    def test_wait_blocks_between_a_finite_number_of_heartbeats(self) -> None:
+        child = mock.Mock()
+        child.wait.return_value = 0
+        timers = [mock.Mock() for _ in GRADLE_RUN.HEARTBEAT_DELAYS]
 
-        for elapsed in range(0, 601):
-            if GRADLE_RUN.heartbeat_due(float(elapsed), next_index):
-                emitted.append(float(elapsed))
-                next_index += 1
+        with mock.patch.object(GRADLE_RUN.threading, "Timer", side_effect=timers) as timer:
+            result = GRADLE_RUN.wait_for_child(child, sequence=1)
 
-        self.assertEqual(emitted, list(delays))
-        self.assertFalse(GRADLE_RUN.heartbeat_due(3_600.0, next_index))
+        self.assertEqual(result, 0)
+        child.wait.assert_called_once_with()
+        self.assertEqual(timer.call_count, len(GRADLE_RUN.HEARTBEAT_DELAYS))
+        for item in timers:
+            item.start.assert_called_once_with()
+            item.cancel.assert_called_once_with()
+            item.join.assert_called_once_with()
+
+    def test_heartbeat_only_prints_while_the_child_is_running(self) -> None:
+        child = mock.Mock()
+        child.poll.side_effect = [None, 0]
+
+        with mock.patch("sys.stderr", new=io.StringIO()) as stderr:
+            GRADLE_RUN.emit_heartbeat(child, sequence=1, delay=30.0)
+            GRADLE_RUN.emit_heartbeat(child, sequence=1, delay=60.0)
+
+        self.assertEqual(len(stderr.getvalue().splitlines()), 1)
+
+    def test_terminate_child_reaps_a_running_process(self) -> None:
+        child = subprocess.Popen(
+            [sys.executable, "-c", "import time; time.sleep(60)"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+
+        GRADLE_RUN.terminate_child(child)
+
+        self.assertIsNotNone(child.poll())
 
 
 class GradleRunWorkflowTest(GradleRunTestCase):
@@ -324,6 +430,26 @@ class GradleRunWorkflowTest(GradleRunTestCase):
         self.assertEqual(len(fingerprints), 1)
         self.assertEqual(next(iter(fingerprints.values()))["occurrences"], 2)
         self.assertEqual(len(json.loads(result.stdout)["warning_fingerprints"]), 1)
+
+    def test_many_unique_diagnostics_keep_the_ledger_bounded(self) -> None:
+        workflow = self.create_workflow()
+
+        result = self.run_gradle(
+            workflow,
+            "broad",
+            "Which warnings are unique?",
+            "[print(f'warning: unique {index}') for index in range(1000)]",
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        ledger = json.loads((self.root / workflow / "ledger.json").read_text())
+        self.assertEqual(
+            len(ledger["warning_fingerprints"]), GRADLE_RUN.MAX_STORED_FINGERPRINTS
+        )
+        self.assertEqual(ledger["warning_fingerprints_truncated_occurrences"], 744)
+        self.assertEqual(
+            json.loads(result.stdout)["warning_fingerprints_truncated"], 744
+        )
 
     def test_finish_deletes_only_the_managed_workflow_directory(self) -> None:
         first = self.create_workflow()

--- a/skills/gradle-run/scripts/test_gradle_run.py
+++ b/skills/gradle-run/scripts/test_gradle_run.py
@@ -80,7 +80,7 @@ class GradleRunProcessTest(GradleRunTestCase):
         payload = "x" * 200_000
 
         result = self.run_gradle(
-            workflow, "targeted", "Does the focused task pass?", f"print({payload!r})"
+            workflow, "targeted", "Does the focused task pass?", "print('x' * 200_000)"
         )
 
         self.assertEqual(result.returncode, 0, result.stderr)

--- a/skills/gradle-run/scripts/test_gradle_run.py
+++ b/skills/gradle-run/scripts/test_gradle_run.py
@@ -273,7 +273,7 @@ class GradleRunProcessTest(GradleRunTestCase):
 
     def test_custom_gradle_wrapper_script_is_accepted(self) -> None:
         workflow = self.create_workflow()
-        custom_wrapper = self.gradle.with_name("gradlew_affected")
+        custom_wrapper = self.gradle.with_name("gradlew_custom")
         self.gradle.rename(custom_wrapper)
         self.gradle = custom_wrapper
 

--- a/skills/gradle-run/scripts/test_gradle_run.py
+++ b/skills/gradle-run/scripts/test_gradle_run.py
@@ -1,0 +1,373 @@
+"""Tests for the compact-output Gradle wrapper."""
+
+from __future__ import annotations
+
+import json
+import importlib.util
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+SCRIPT = Path(__file__).with_name("gradle_run.py")
+SPEC = importlib.util.spec_from_file_location("gradle_run", SCRIPT)
+assert SPEC and SPEC.loader
+GRADLE_RUN = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(GRADLE_RUN)
+
+
+class GradleRunTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary_directory.name) / "managed-root"
+        self.gradle = self.root.parent / "gradlew"
+        self.gradle.write_text(
+            "#!/bin/sh\n"
+            "while [ \"$1\" != \"--\" ]; do shift; done\n"
+            "shift\n"
+            "exec \"$@\"\n"
+        )
+        self.gradle.chmod(0o700)
+
+    def tearDown(self) -> None:
+        self.temporary_directory.cleanup()
+
+    def invoke(self, *arguments: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [sys.executable, str(SCRIPT), "--root", str(self.root), *arguments],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+    def create_workflow(self) -> str:
+        result = self.invoke("create")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        return json.loads(result.stdout)["workflow"]
+
+    def run_gradle(
+        self, workflow: str, scope: str, question: str, command: str
+    ) -> subprocess.CompletedProcess[str]:
+        return self.invoke(
+            "run",
+            "--workflow",
+            workflow,
+            "--scope",
+            scope,
+            "--question",
+            question,
+            "--",
+            str(self.gradle),
+            "--",
+            sys.executable,
+            "-c",
+            command,
+        )
+
+
+class GradleRunProcessTest(GradleRunTestCase):
+    def test_large_output_is_saved_but_stdout_is_bounded(self) -> None:
+        workflow = self.create_workflow()
+        payload = "x" * 200_000
+
+        result = self.run_gradle(
+            workflow, "targeted", "Does the focused task pass?", f"print({payload!r})"
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertLessEqual(len(result.stdout.encode("utf-8")), 16_384)
+        self.assertLessEqual(len(result.stdout.splitlines()), 64)
+        summary = json.loads(result.stdout)
+        log = Path(summary["log"])
+        self.assertTrue(log.is_file())
+        self.assertGreater(log.stat().st_size, 100_000)
+        self.assertNotIn(payload, result.stdout)
+
+    def test_many_failed_tasks_do_not_exceed_the_summary_bound(self) -> None:
+        workflow = self.create_workflow()
+
+        result = self.run_gradle(
+            workflow,
+            "broad",
+            "Which aggregate tasks failed?",
+            "[print(f'> Task :task{index} FAILED') for index in range(1000)]",
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        summary = json.loads(result.stdout)
+        self.assertLessEqual(len(result.stdout.encode("utf-8")), 16_384)
+        self.assertLessEqual(len(summary["failed_tasks"]), 16)
+        self.assertTrue(summary["failed_tasks_truncated"])
+
+    def test_oversized_failed_task_name_does_not_exceed_the_summary_bound(self) -> None:
+        workflow = self.create_workflow()
+        task_name = "a" * 20_000
+
+        result = self.run_gradle(
+            workflow,
+            "broad",
+            "Which oversized task failed?",
+            f"print('> Task :{task_name} FAILED')",
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        summary = json.loads(result.stdout)
+        self.assertLessEqual(len(result.stdout.encode("utf-8")), 16_384)
+        self.assertTrue(summary["failed_tasks_truncated"])
+        self.assertLess(len(summary["failed_tasks"][0].encode("utf-8")), 1024)
+
+    def test_child_exit_status_and_failed_tasks_are_reported(self) -> None:
+        workflow = self.create_workflow()
+
+        result = self.run_gradle(
+            workflow,
+            "targeted",
+            "Which task failed?",
+            "print('> Task :compileKotlin FAILED'); print('FAILURE: Build failed'); raise SystemExit(7)",
+        )
+
+        self.assertEqual(result.returncode, 7)
+        summary = json.loads(result.stdout)
+        self.assertEqual(summary["exit_status"], 7)
+        self.assertEqual(summary["failed_tasks"], [":compileKotlin"])
+        self.assertTrue(summary["failure_fingerprints"])
+
+    def test_ansi_diagnostics_are_normalized_and_fingerprinted(self) -> None:
+        workflow = self.create_workflow()
+
+        result = self.run_gradle(
+            workflow,
+            "targeted",
+            "What warning must be fixed?",
+            "print('\\x1b[33mwarning: use the new API\\x1b[0m'); print('warning:   use the new API')",
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        warning = json.loads(result.stdout)["warning_fingerprints"]
+        self.assertEqual(len(warning), 1)
+        self.assertEqual(warning[0]["count"], 2)
+        self.assertEqual(len(warning[0]["fingerprint"]), 64)
+
+    def test_multiline_failure_is_fingerprinted_as_one_diagnostic_block(self) -> None:
+        workflow = self.create_workflow()
+
+        result = self.run_gradle(
+            workflow,
+            "targeted",
+            "What source failure occurred?",
+            "print('FAILURE: Build failed'); print('* What went wrong:'); print('e: Unresolved reference: missing'); print('  at Source.kt:1'); print('* Try:'); raise SystemExit(1)",
+        )
+
+        self.assertEqual(result.returncode, 1)
+        failures = json.loads(result.stdout)["failure_fingerprints"]
+        self.assertEqual(len(failures), 1)
+        self.assertIn("Unresolved reference", failures[0]["excerpt"])
+
+    def test_missing_command_fails_without_fallback(self) -> None:
+        workflow = self.create_workflow()
+
+        result = self.invoke(
+            "run",
+            "--workflow",
+            workflow,
+            "--scope",
+            "targeted",
+            "--question",
+            "Can the unavailable command run?",
+            "--",
+            str(self.root.parent / "missing" / "gradlew"),
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("launch_error", json.loads(result.stdout))
+        self.assertFalse(list((self.root / workflow).glob("*.log")))
+
+    def test_blank_question_fails_without_running_the_command(self) -> None:
+        workflow = self.create_workflow()
+
+        result = self.run_gradle(workflow, "targeted", "", "raise SystemExit(99)")
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("non-empty", result.stderr)
+        self.assertFalse(list((self.root / workflow).glob("*.log")))
+
+    def test_non_gradle_command_fails_without_running(self) -> None:
+        workflow = self.create_workflow()
+
+        result = self.invoke(
+            "run",
+            "--workflow",
+            workflow,
+            "--scope",
+            "targeted",
+            "--question",
+            "Can a non-Gradle command run?",
+            "--",
+            sys.executable,
+            "-c",
+            "raise SystemExit(99)",
+        )
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("Gradle launcher", result.stderr)
+        self.assertFalse(list((self.root / workflow).glob("*.log")))
+
+    def test_gradle_defaults_preserve_an_explicit_scan(self) -> None:
+        workflow = self.create_workflow()
+        self.gradle.write_text("#!/bin/sh\nprintf 'args: %s\\n' \"$*\"\n")
+
+        result = self.invoke(
+            "run",
+            "--workflow",
+            workflow,
+            "--scope",
+            "targeted",
+            "--question",
+            "Do default console flags preserve scans?",
+            "--",
+            str(self.gradle),
+            "check",
+            "--scan",
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        summary = json.loads(result.stdout)
+        self.assertIn("--console=plain", summary["command"])
+        self.assertIn("--scan", summary["command"])
+        self.assertNotIn("--no-scan", summary["command"])
+
+    def test_gradle_defaults_stay_before_a_user_option_separator(self) -> None:
+        workflow = self.create_workflow()
+        self.gradle.write_text("#!/bin/sh\nprintf 'args: %s\\n' \"$*\"\n")
+
+        result = self.invoke(
+            "run",
+            "--workflow",
+            workflow,
+            "--scope",
+            "targeted",
+            "--question",
+            "Do Gradle defaults stay out of task arguments?",
+            "--",
+            str(self.gradle),
+            "check",
+            "--",
+            "task-option",
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        command = json.loads(result.stdout)["command"].split()
+        separator = command.index("--")
+        self.assertLess(command.index("--console=plain"), separator)
+        self.assertLess(command.index("--no-scan"), separator)
+
+
+class GradleRunHeartbeatTest(unittest.TestCase):
+    def test_heartbeat_schedule_is_finite_and_stops_after_its_last_delay(self) -> None:
+        delays = GRADLE_RUN.HEARTBEAT_DELAYS
+        emitted: list[float] = []
+        next_index = 0
+
+        for elapsed in range(0, 601):
+            if GRADLE_RUN.heartbeat_due(float(elapsed), next_index):
+                emitted.append(float(elapsed))
+                next_index += 1
+
+        self.assertEqual(emitted, list(delays))
+        self.assertFalse(GRADLE_RUN.heartbeat_due(3_600.0, next_index))
+
+
+class GradleRunWorkflowTest(GradleRunTestCase):
+    def test_workflow_ledger_records_scope_question_and_command(self) -> None:
+        workflow = self.create_workflow()
+        result = self.run_gradle(
+            workflow, "broad", "What does the aggregate check reveal?", "print('ok')"
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        ledger = json.loads((self.root / workflow / "ledger.json").read_text())
+        entry = ledger["runs"][0]
+        self.assertEqual(entry["scope"], "broad")
+        self.assertEqual(entry["question"], "What does the aggregate check reveal?")
+        self.assertIn(sys.executable, entry["command"])
+
+    def test_repeated_failure_fingerprint_is_flagged(self) -> None:
+        workflow = self.create_workflow()
+        command = "print('FAILURE: same diagnostic'); raise SystemExit(1)"
+        self.assertEqual(
+            self.run_gradle(workflow, "targeted", "First diagnosis?", command).returncode, 1
+        )
+
+        result = self.run_gradle(workflow, "targeted", "Did the fix change it?", command)
+
+        self.assertEqual(result.returncode, 1)
+        self.assertTrue(json.loads(result.stdout)["repeated_primary_failure"])
+
+    def test_warning_fingerprints_are_deduplicated_across_runs(self) -> None:
+        workflow = self.create_workflow()
+        self.assertEqual(
+            self.run_gradle(
+                workflow, "targeted", "First warning?", "print('warning: same warning')"
+            ).returncode,
+            0,
+        )
+
+        result = self.run_gradle(
+            workflow, "targeted", "Did the warning remain?", "print('warning: same warning')"
+        )
+
+        ledger = json.loads((self.root / workflow / "ledger.json").read_text())
+        fingerprints = ledger["warning_fingerprints"]
+        self.assertEqual(len(fingerprints), 1)
+        self.assertEqual(next(iter(fingerprints.values()))["occurrences"], 2)
+        self.assertEqual(len(json.loads(result.stdout)["warning_fingerprints"]), 1)
+
+    def test_finish_deletes_only_the_managed_workflow_directory(self) -> None:
+        first = self.create_workflow()
+        second = self.create_workflow()
+
+        result = self.invoke("finish", "--workflow", first)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertFalse((self.root / first).exists())
+        self.assertTrue((self.root / second).is_dir())
+
+    def test_finish_is_idempotent(self) -> None:
+        workflow = self.create_workflow()
+        self.assertEqual(self.invoke("finish", "--workflow", workflow).returncode, 0)
+
+        result = self.invoke("finish", "--workflow", workflow)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertTrue(json.loads(result.stdout)["already_finished"])
+
+    def test_invalid_workflow_identifier_fails_closed(self) -> None:
+        self.root.mkdir(parents=True)
+        sibling = self.root.parent / "sibling"
+        sibling.mkdir()
+
+        result = self.invoke("finish", "--workflow", "../sibling")
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertTrue(sibling.is_dir())
+        self.assertIn("invalid workflow", result.stderr.lower())
+
+    def test_cleanup_rejects_a_workflow_symlink(self) -> None:
+        workflow = self.create_workflow()
+        directory = self.root / workflow
+        outside = self.root.parent / "outside"
+        outside.mkdir()
+        shutil.rmtree(directory)
+        directory.symlink_to(outside, target_is_directory=True)
+
+        result = self.invoke("finish", "--workflow", workflow)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertTrue(outside.is_dir())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/using-chrisbanes-skills/SKILL.md
+++ b/skills/using-chrisbanes-skills/SKILL.md
@@ -35,6 +35,7 @@ specialist only when its independent behavior changes the same work.
 | Coroutine scope ownership, `init { launch }`, non-suspending launch APIs, `runBlocking`, cancellation, `StateFlow`, `SharedFlow`, `Channel`, `stateIn`, or one-shot events | [`kotlin-concurrency-and-flow`](../kotlin-concurrency-and-flow/SKILL.md) |
 | Kotlin branching, `when` expressions, guard conditions, sealed type exhaustiveness, smart casts, nullable branching, or complex `if`/`else` chains | [`kotlin-control-flow`](../kotlin-control-flow/SKILL.md) |
 | Kotlin function placement, member versus top-level or extension functions, factories, single-field domain types, value classes, Kotlin Multiplatform source sets, expect/actual, or platform services | [`kotlin-api-design`](../kotlin-api-design/SKILL.md) |
+| Planned Gradle execution, or a Gradle-centered build, check, warning-cleanup, or failure workflow | [`gradle-run`](../gradle-run/SKILL.md) |
 | One ready GitHub issue or in-chat task needs repository-aware planning before a separate implementation session | [`to-plan`](../to-plan/SKILL.md) |
 | Polling or shepherding PRs/MRs, triaging review comments, fixing CI failures, or keeping reviews moving | [`shepherd`](../shepherd/SKILL.md) |
 
@@ -46,6 +47,7 @@ specialist only when its independent behavior changes the same work.
 - For reusable UI components, use [`compose-component-design`](../compose-component-design/SKILL.md).
 - For tests around focus behavior, use [`compose-focus-navigation`](../compose-focus-navigation/SKILL.md) first, then [`compose-ui-testing-patterns`](../compose-ui-testing-patterns/SKILL.md) for test shape.
 - For Kotlin state, concurrency, or platform-boundary work that also changes branching shape, combine the cluster with [`kotlin-control-flow`](../kotlin-control-flow/SKILL.md).
+- Kotlin or Compose advice that performs no Gradle execution does not load [`gradle-run`](../gradle-run/SKILL.md).
 
 ## RED/GREEN agent scenarios
 

--- a/tests/cluster-behavior.md
+++ b/tests/cluster-behavior.md
@@ -39,10 +39,13 @@ Use this result shape in the implementation issue or pull request:
 | Case | Prompt | Expected behavior |
 |---|---|---|
 | Direct | "Run `./gradlew check --warning-mode all` and fix every warning." | Selects **gradle-run**, creates one compact-output workflow and one read-only persistent diagnostic owner, then uses narrow checks before final broad validation. |
+| Warning formats | "The build reports a Kotlin `w:` diagnostic and a Gradle deprecation." | Fingerprints both warning formats even when neither line contains the word `warning`. |
 | Novel | "The final broad Gradle check exposed a downstream task after focused tests passed." | Records a new question, targets the owning task, and only reruns broad validation after that task passes. |
 | Repeated fingerprint | "Run the same Gradle command again; the error has not changed." | Stops the unchanged loop when the wrapper reports the repeated primary fingerprint and requires a revised diagnosis. |
 | Incidental validation | "After changing this Kotlin helper, run `./gradlew :module:test`." | Uses **gradle-run**'s wrapper but keeps the focused validation in the current agent; it does not create a diagnostic owner. |
 | Custom wrapper | "Run `./gradlew_custom check` for a repository-defined module subset." | Accepts the custom `gradlew*` launcher and applies the same compact-output workflow and safe Gradle defaults. |
+| Interruption | "I pressed Ctrl-C while Gradle workers were active." | Stops the isolated process group and records SIGINT plus the retained log in the workflow ledger. |
+| Unknown cleanup | "Finish a valid-looking workflow ID that was never created." | Fails closed; only a retained marker makes repeated finish idempotent. |
 | Unrelated subagent | "While a Gradle warning cleanup runs, start a separate review subagent for another diff." | Permits the unrelated subagent; **gradle-run** governs Gradle output and diagnostics only. |
 
 ## Compose state and effects

--- a/tests/cluster-behavior.md
+++ b/tests/cluster-behavior.md
@@ -42,7 +42,7 @@ Use this result shape in the implementation issue or pull request:
 | Novel | "The final broad Gradle check exposed a downstream task after focused tests passed." | Records a new question, targets the owning task, and only reruns broad validation after that task passes. |
 | Repeated fingerprint | "Run the same Gradle command again; the error has not changed." | Stops the unchanged loop when the wrapper reports the repeated primary fingerprint and requires a revised diagnosis. |
 | Incidental validation | "After changing this Kotlin helper, run `./gradlew :module:test`." | Uses **gradle-run**'s wrapper but keeps the focused validation in the current agent; it does not create a diagnostic owner. |
-| Custom wrapper | "Run `./gradlew_affected check` for the modules changed by this branch." | Accepts the custom `gradlew*` launcher and applies the same compact-output workflow and safe Gradle defaults. |
+| Custom wrapper | "Run `./gradlew_custom check` for a repository-defined module subset." | Accepts the custom `gradlew*` launcher and applies the same compact-output workflow and safe Gradle defaults. |
 | Unrelated subagent | "While a Gradle warning cleanup runs, start a separate review subagent for another diff." | Permits the unrelated subagent; **gradle-run** governs Gradle output and diagnostics only. |
 
 ## Compose state and effects

--- a/tests/cluster-behavior.md
+++ b/tests/cluster-behavior.md
@@ -40,11 +40,12 @@ Use this result shape in the implementation issue or pull request:
 |---|---|---|
 | Direct | "Run `./gradlew check --warning-mode all` and fix every warning." | Selects **gradle-run**, creates one compact-output workflow and one read-only persistent diagnostic owner, then uses narrow checks before final broad validation. |
 | Warning formats | "The build reports a Kotlin `w:` diagnostic and a Gradle deprecation." | Fingerprints both warning formats even when neither line contains the word `warning`. |
+| Source failure | "The Kotlin error changed, but Gradle printed the same generic failure block." | Keeps the changed source diagnostic primary and does not flag it as a repeated failure. |
 | Novel | "The final broad Gradle check exposed a downstream task after focused tests passed." | Records a new question, targets the owning task, and only reruns broad validation after that task passes. |
 | Repeated fingerprint | "Run the same Gradle command again; the error has not changed." | Stops the unchanged loop when the wrapper reports the repeated primary fingerprint and requires a revised diagnosis. |
 | Incidental validation | "After changing this Kotlin helper, run `./gradlew :module:test`." | Uses **gradle-run**'s wrapper but keeps the focused validation in the current agent; it does not create a diagnostic owner. |
 | Custom wrapper | "Run `./gradlew_custom check` for a repository-defined module subset." | Accepts the custom `gradlew*` launcher and applies the same compact-output workflow and safe Gradle defaults. |
-| Interruption | "I pressed Ctrl-C twice while Gradle workers were active." | Tolerates the repeated signal, stops the isolated process group, and records SIGINT plus the retained log in the workflow ledger. |
+| Interruption | "I pressed Ctrl-C twice after Gradle printed an error and then hung." | Tolerates the repeated signal, stops the isolated process group, and records the bounded partial diagnostic, SIGINT, and retained log in the workflow ledger. |
 | Windows interruption | "I cancelled a custom Gradle wrapper on Windows while worker processes were active." | Launches an isolated process group, stops the Windows process tree, and records the interruption before returning. |
 | Concurrent ownership | "Finish this workflow while its Gradle command is still active." | Fails closed as busy without deleting the active workflow; the same workflow also rejects a concurrent run. |
 | Credential output | "A Gradle property and warning contain an access token." | Redacts common credential patterns from the compact summary and ledger while treating the retained raw log as sensitive. |

--- a/tests/cluster-behavior.md
+++ b/tests/cluster-behavior.md
@@ -45,6 +45,10 @@ Use this result shape in the implementation issue or pull request:
 | Incidental validation | "After changing this Kotlin helper, run `./gradlew :module:test`." | Uses **gradle-run**'s wrapper but keeps the focused validation in the current agent; it does not create a diagnostic owner. |
 | Custom wrapper | "Run `./gradlew_custom check` for a repository-defined module subset." | Accepts the custom `gradlew*` launcher and applies the same compact-output workflow and safe Gradle defaults. |
 | Interruption | "I pressed Ctrl-C twice while Gradle workers were active." | Tolerates the repeated signal, stops the isolated process group, and records SIGINT plus the retained log in the workflow ledger. |
+| Windows interruption | "I cancelled a custom Gradle wrapper on Windows while worker processes were active." | Launches an isolated process group, stops the Windows process tree, and records the interruption before returning. |
+| Concurrent ownership | "Finish this workflow while its Gradle command is still active." | Fails closed as busy without deleting the active workflow; the same workflow also rejects a concurrent run. |
+| Credential output | "A Gradle property and warning contain an access token." | Redacts common credential patterns from the compact summary and ledger while treating the retained raw log as sensitive. |
+| Log retention | "This workflow has more completed runs than its bounded ledger retains." | Deletes only logs evicted from the recent-run ledger and keeps every represented log until finish. |
 | Unknown cleanup | "Finish a valid-looking workflow ID that was never created." | Fails closed; only a retained marker makes repeated finish idempotent. |
 | Unrelated subagent | "While a Gradle warning cleanup runs, start a separate review subagent for another diff." | Permits the unrelated subagent; **gradle-run** governs Gradle output and diagnostics only. |
 

--- a/tests/cluster-behavior.md
+++ b/tests/cluster-behavior.md
@@ -44,7 +44,7 @@ Use this result shape in the implementation issue or pull request:
 | Repeated fingerprint | "Run the same Gradle command again; the error has not changed." | Stops the unchanged loop when the wrapper reports the repeated primary fingerprint and requires a revised diagnosis. |
 | Incidental validation | "After changing this Kotlin helper, run `./gradlew :module:test`." | Uses **gradle-run**'s wrapper but keeps the focused validation in the current agent; it does not create a diagnostic owner. |
 | Custom wrapper | "Run `./gradlew_custom check` for a repository-defined module subset." | Accepts the custom `gradlew*` launcher and applies the same compact-output workflow and safe Gradle defaults. |
-| Interruption | "I pressed Ctrl-C while Gradle workers were active." | Stops the isolated process group and records SIGINT plus the retained log in the workflow ledger. |
+| Interruption | "I pressed Ctrl-C twice while Gradle workers were active." | Tolerates the repeated signal, stops the isolated process group, and records SIGINT plus the retained log in the workflow ledger. |
 | Unknown cleanup | "Finish a valid-looking workflow ID that was never created." | Fails closed; only a retained marker makes repeated finish idempotent. |
 | Unrelated subagent | "While a Gradle warning cleanup runs, start a separate review subagent for another diff." | Permits the unrelated subagent; **gradle-run** governs Gradle output and diagnostics only. |
 

--- a/tests/cluster-behavior.md
+++ b/tests/cluster-behavior.md
@@ -38,10 +38,11 @@ Use this result shape in the implementation issue or pull request:
 
 | Case | Prompt | Expected behavior |
 |---|---|---|
-| Direct | "Run `./gradlew bwCheck -x bwSimulatorTest --warning-mode all` and fix every warning." | Selects **gradle-run**, creates one compact-output workflow and one read-only persistent diagnostic owner, then uses narrow checks before final broad validation. |
+| Direct | "Run `./gradlew check --warning-mode all` and fix every warning." | Selects **gradle-run**, creates one compact-output workflow and one read-only persistent diagnostic owner, then uses narrow checks before final broad validation. |
 | Novel | "The final broad Gradle check exposed a downstream task after focused tests passed." | Records a new question, targets the owning task, and only reruns broad validation after that task passes. |
 | Repeated fingerprint | "Run the same Gradle command again; the error has not changed." | Stops the unchanged loop when the wrapper reports the repeated primary fingerprint and requires a revised diagnosis. |
 | Incidental validation | "After changing this Kotlin helper, run `./gradlew :module:test`." | Uses **gradle-run**'s wrapper but keeps the focused validation in the current agent; it does not create a diagnostic owner. |
+| Custom wrapper | "Run `./gradlew_affected check` for the modules changed by this branch." | Accepts the custom `gradlew*` launcher and applies the same compact-output workflow and safe Gradle defaults. |
 | Unrelated subagent | "While a Gradle warning cleanup runs, start a separate review subagent for another diff." | Permits the unrelated subagent; **gradle-run** governs Gradle output and diagnostics only. |
 
 ## Compose state and effects

--- a/tests/cluster-behavior.md
+++ b/tests/cluster-behavior.md
@@ -34,6 +34,16 @@ Use this result shape in the implementation issue or pull request:
 | Mixed concern | "This reusable card has an animated height and hardcodes fillMaxWidth." | Selects **compose-component-design** and **compose-animations**; does not load state guidance by default. |
 | Narrow Kotlin | "Replace this nested if with guard conditions." | Selects **kotlin-control-flow** only. |
 
+## Gradle execution
+
+| Case | Prompt | Expected behavior |
+|---|---|---|
+| Direct | "Run `./gradlew bwCheck -x bwSimulatorTest --warning-mode all` and fix every warning." | Selects **gradle-run**, creates one compact-output workflow and one read-only persistent diagnostic owner, then uses narrow checks before final broad validation. |
+| Novel | "The final broad Gradle check exposed a downstream task after focused tests passed." | Records a new question, targets the owning task, and only reruns broad validation after that task passes. |
+| Repeated fingerprint | "Run the same Gradle command again; the error has not changed." | Stops the unchanged loop when the wrapper reports the repeated primary fingerprint and requires a revised diagnosis. |
+| Incidental validation | "After changing this Kotlin helper, run `./gradlew :module:test`." | Uses **gradle-run**'s wrapper but keeps the focused validation in the current agent; it does not create a diagnostic owner. |
+| Unrelated subagent | "While a Gradle warning cleanup runs, start a separate review subagent for another diff." | Permits the unrelated subagent; **gradle-run** governs Gradle output and diagnostics only. |
+
 ## Compose state and effects
 
 | Case | Prompt | Expected behavior |


### PR DESCRIPTION
## Summary

- add a `gradle-run` skill that routes agent-initiated Gradle commands through a compact-output wrapper
- keep complete build logs in wrapper-owned temporary storage while returning bounded JSON diagnostics, fingerprints, and workflow history
- detect repeated commands and primary failures, bound diagnostic and ledger growth, and safely record interrupted runs
- integrate the skill into the README, skill router, test command, and behavioral scenarios
- explicitly leave unrelated review, exploration, implementation, and other subagent choices to the user

## Why

Repeated full Gradle logs, long-lived task context, and blind rebuild loops can amplify model usage dramatically without improving the outcome. This workflow preserves the complete log as an artifact while giving agents a compact diagnostic summary and steering broad build failures toward narrow verification.

## Impact

Gradle execution becomes bounded and auditable without changing the underlying Gradle tasks. Warning cleanup and failure diagnosis can reuse fingerprints across runs, while users remain free to run unrelated subagents or parallel work.

## Validation

- `python3 -m unittest skills/gradle-run/scripts/test_gradle_run.py` — 24 passed
- `npm test` — 96 primary tests and 67 evaluation tests passed
- `npm run lint`
- skill quick validation
- `git diff --check`
- fresh read-only review-and-simplify audit — ship