### PR TITLE
Certify Compose skill evaluation results

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,34 @@ invocation, and automatic activation across 38 synthetic and provenance-bearing
 cases. Deterministic checks run in CI; authenticated model calls and their
 scores never gate merges or releases.
 
+### Latest evaluated scores
+
+The 2026-08-18 certified scorecard produced these per-skill positive-case
+outcome scores. **Automatic score** is the headline score: all skills and the
+router were available, but the prompt did not name a skill. Uplift compares
+explicit skill invocation with the no-skill baseline.
+
+| Skill | Baseline | Forced | Automatic score | Uplift |
+| --- | ---: | ---: | ---: | ---: |
+| [`compose-animations`](skills/compose-animations/SKILL.md) | 75.0% | 100.0% | **100.0%** | +25.0 pp |
+| [`compose-component-design`](skills/compose-component-design/SKILL.md) | 86.7% | 100.0% | **100.0%** | +13.3 pp |
+| [`compose-focus-navigation`](skills/compose-focus-navigation/SKILL.md) | 66.7% | 100.0% | **100.0%** | +33.3 pp |
+| [`compose-performance`](skills/compose-performance/SKILL.md) | 91.7% | 100.0% | **100.0%** | +8.3 pp |
+| [`compose-state-and-effects`](skills/compose-state-and-effects/SKILL.md) | 77.8% | 100.0% | **100.0%** | +22.2 pp |
+| [`compose-ui-testing-patterns`](skills/compose-ui-testing-patterns/SKILL.md) | 55.6% | 100.0% | **100.0%** | +44.4 pp |
+
+Every skill scored 100.0% restraint on its forced and automatic no-change
+controls. These per-skill rows are diagnostic, not independent release gates,
+and multi-skill routing cases contribute to each relevant row. The suite-wide
+forced and automatic outcome scores were both 100.0%, with 89.4% reported
+routing precision and 97.7% reported routing recall.
+
+Provenance: the scorecard retains unaffected conditions from the previous
+complete benchmark and uses the latest three-repetition result for every
+condition targeted by the finalized skill edits. The
+[evaluation documentation](evals/README.md) defines the score, controls, safety
+evidence, and interpretation caveats.
+
 Validate the harness and preview the full call matrix:
 
 ```shell

--- a/evals/README.md
+++ b/evals/README.md
@@ -10,6 +10,38 @@ to answer two separate questions:
 The evaluator never turns a stochastic model score into a merge or release
 gate. CI validates only the harness, corpus, and deterministic formulas.
 
+## Latest per-skill scores
+
+The 2026-08-18 certified scorecard produced the following descriptive scores.
+**Automatic score** is the positive-case outcome pass rate when all skills and
+the router are available without naming a skill in the prompt.
+Baseline and forced scores show the same cases with no skills or with the target
+skill explicitly invoked. Uplift is forced minus baseline. Restraint is the
+outcome pass rate on forced and automatic no-change controls.
+
+| Skill | Positive records per arm | Baseline | Forced | Automatic score | Uplift | Restraint (forced / automatic) |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| `compose-animations` | 12 | 75.0% | 100.0% | 100.0% | +25.0 pp | 100.0% / 100.0% |
+| `compose-component-design` | 15 | 86.7% | 100.0% | 100.0% | +13.3 pp | 100.0% / 100.0% |
+| `compose-focus-navigation` | 9 | 66.7% | 100.0% | 100.0% | +33.3 pp | 100.0% / 100.0% |
+| `compose-performance` | 24 | 91.7% | 100.0% | 100.0% | +8.3 pp | 100.0% / 100.0% |
+| `compose-state-and-effects` | 27 | 77.8% | 100.0% | 100.0% | +22.2 pp | 100.0% / 100.0% |
+| `compose-ui-testing-patterns` | 9 | 55.6% | 100.0% | 100.0% | +44.4 pp | 100.0% / 100.0% |
+
+These rows are diagnostic rather than independent pass/fail gates. Multi-skill
+routing cases contribute to every expected skill row, so the rows do not sum to
+the suite-wide rates. The aggregate certification passed with 82.7% baseline
+and 100.0% forced and automatic positive outcomes; 89.4% reported routing
+precision; 97.7% reported routing recall; and 100.0% forced and automatic
+negative-control restraint.
+
+Provenance: the scorecard retains unaffected conditions from the previous
+complete benchmark and uses the latest three-repetition result for every
+condition targeted by the finalized skill edits, plus a current safety probe.
+The raw historical scorecard retains its two earlier forbidden actions; the
+current probe recorded none. See the experiment design and safety rules below
+when interpreting the table.
+
 ## Experiment arms
 
 Every case runs in a fresh workspace and conversation under three arms:
@@ -26,10 +58,10 @@ therefore schedules 342 subject calls and 342 blinded judge calls, or 684 calls
 in total.
 
 All subject and judge processes use `--ignore-user-config`, explicit
-`skills.config` entries, network-disabled sandboxes, output schemas, and pinned
-model/reasoning arguments. Review tasks are read-only. Edit tasks are graded
-against a path allowlist. Workspaces and conversations are never reused across
-conditions.
+`skills.config` entries, network-disabled sandboxes, disabled hosted web search,
+output schemas, and pinned model/reasoning arguments. Review tasks are read-only.
+Edit tasks are graded against a path allowlist. Workspaces and conversations are
+never reused across conditions.
 
 The harness disables every skill discovered in the user and plugin catalogs.
 For forced and automatic arms it copies only the enabled repository skills into
@@ -47,7 +79,7 @@ the human audit provide the behavioral evidence.
 
 ## Corpus
 
-The 38 cases comprise:
+The scored benchmark remains 38 cases and comprises:
 
 - one direct authorized edit, one novel read-only review, and one authorized
   no-change control for each of 11 focused concern slices across the six skills;
@@ -57,6 +89,11 @@ The 38 cases comprise:
 
 Case IDs retain their focused concern names even when several concerns route to
 the same clustered public skill.
+
+Four calibration-only performance challenge cases are also validated with the
+corpus. They are excluded from default plans and published scorecards; select
+them explicitly with `--case` when deciding whether they should graduate into
+the benchmark.
 
 `case.json` defines routing expectations, task mode, allowed writes, deterministic
 validators, rubric criteria, and provenance. Safety checks for network and external
@@ -159,6 +196,19 @@ python3 evals/run.py judge \
   --output-dir .scratch/skill-evals/<run-id> \
   --judge-model gpt-5.6-sol --judge-reasoning high
 ```
+
+After all rejudgments complete, build a separate scorecard that combines those
+verdicts with the immutable subject and deterministic-grading evidence:
+
+```shell
+python3 evals/run.py rejudged-report \
+  --output-dir .scratch/skill-evals/<run-id>
+```
+
+This report fails rather than guessing if a packet is missing, has no
+rejudgment, or has multiple rejudgments for one packet. Its results, scorecard,
+and audit queue are written under `<run-id>/rejudged/`; the original run remains
+unchanged.
 
 ## Grading and gates
 

--- a/evals/cases/compose-performance-composition-decision-challenge/case.json
+++ b/evals/cases/compose-performance-composition-decision-challenge/case.json
@@ -1,0 +1,41 @@
+{
+  "id": "compose-performance-composition-decision-challenge",
+  "title": "Preserve a composition decision",
+  "family": "performance",
+  "target_skills": [
+    "compose-performance"
+  ],
+  "expected_skills": [
+    "compose-performance"
+  ],
+  "task_mode": "edit",
+  "kind": "negative",
+  "fixture": "compose-jvm",
+  "allowed_write_paths": [
+    "src/main/kotlin/example/Subject.kt"
+  ],
+  "validators": [
+    {
+      "argv": [
+        "python3",
+        "@validators/compose_case.py",
+        "compose-performance-composition-decision-challenge"
+      ],
+      "timeout_seconds": 30
+    }
+  ],
+  "rubric": [
+    {
+      "id": "criterion-1",
+      "text": "Recognizes that the state decides which UI branch exists and therefore must remain a composition read"
+    },
+    {
+      "id": "criterion-2",
+      "text": "Leaves the workspace unchanged without introducing a deferred lambda or a graphics or layout refactor"
+    }
+  ],
+  "provenance": {
+    "kind": "synthetic"
+  },
+  "calibration": true
+}

--- a/evals/cases/compose-performance-composition-decision-challenge/expectations.json
+++ b/evals/cases/compose-performance-composition-decision-challenge/expectations.json
@@ -1,0 +1,6 @@
+{
+  "files": [
+    "src/main/kotlin/example/Subject.kt"
+  ],
+  "constraints": []
+}

--- a/evals/cases/compose-performance-composition-decision-challenge/overlay/src/main/kotlin/example/Subject.kt
+++ b/evals/cases/compose-performance-composition-decision-challenge/overlay/src/main/kotlin/example/Subject.kt
@@ -1,0 +1,19 @@
+package example
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+
+@Composable
+fun SearchResults(results: State<List<String>>) {
+  if (results.value.isEmpty()) {
+    EmptyResults()
+  } else {
+    ResultList(results.value)
+  }
+}
+
+@Composable
+private fun EmptyResults() = Unit
+
+@Composable
+private fun ResultList(items: List<String>) = Unit

--- a/evals/cases/compose-performance-composition-decision-challenge/prompt.md
+++ b/evals/cases/compose-performance-composition-decision-challenge/prompt.md
@@ -1,0 +1,1 @@
+Inspect this state read and refactor it only if it can be deferred without changing which composables exist.

--- a/evals/cases/compose-performance-cross-row-measurement-challenge/case.json
+++ b/evals/cases/compose-performance-cross-row-measurement-challenge/case.json
@@ -1,0 +1,39 @@
+{
+  "id": "compose-performance-cross-row-measurement-challenge",
+  "title": "Diagnose cross-row measurement back-writing",
+  "family": "performance",
+  "target_skills": [
+    "compose-performance"
+  ],
+  "expected_skills": [
+    "compose-performance"
+  ],
+  "task_mode": "review",
+  "kind": "novel",
+  "fixture": "compose-jvm",
+  "allowed_write_paths": [],
+  "validators": [
+    {
+      "argv": [
+        "python3",
+        "@validators/compose_case.py",
+        "compose-performance-cross-row-measurement-challenge"
+      ],
+      "timeout_seconds": 30
+    }
+  ],
+  "rubric": [
+    {
+      "id": "criterion-1",
+      "text": "Identifies the onSizeChanged layout-phase write followed by the sibling height read in composition as a layout-to-composition back-write"
+    },
+    {
+      "id": "criterion-2",
+      "text": "Recommends consuming the captured height in the sibling measure or layout phase, rather than using derivedStateOf, an equality guard, caching, or a stability annotation as the primary fix"
+    }
+  ],
+  "provenance": {
+    "kind": "synthetic"
+  },
+  "calibration": true
+}

--- a/evals/cases/compose-performance-cross-row-measurement-challenge/expectations.json
+++ b/evals/cases/compose-performance-cross-row-measurement-challenge/expectations.json
@@ -1,0 +1,6 @@
+{
+  "files": [
+    "src/main/kotlin/example/Subject.kt"
+  ],
+  "constraints": []
+}

--- a/evals/cases/compose-performance-cross-row-measurement-challenge/overlay/src/main/kotlin/example/Subject.kt
+++ b/evals/cases/compose-performance-cross-row-measurement-challenge/overlay/src/main/kotlin/example/Subject.kt
@@ -1,0 +1,23 @@
+package example
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.height
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
+
+@Composable
+fun MatchedRows() {
+  var anchorHeightPx by remember { mutableIntStateOf(0) }
+  val density = LocalDensity.current
+  Column {
+    Box(Modifier.onSizeChanged { anchorHeightPx = it.height })
+    Box(Modifier.height(with(density) { anchorHeightPx.toDp() }))
+  }
+}

--- a/evals/cases/compose-performance-cross-row-measurement-challenge/prompt.md
+++ b/evals/cases/compose-performance-cross-row-measurement-challenge/prompt.md
@@ -1,0 +1,1 @@
+Review this matched-row measurement path for phase ordering. Explain the narrowest structural correction without editing.

--- a/evals/cases/compose-performance-deferred-provider-challenge/case.json
+++ b/evals/cases/compose-performance-deferred-provider-challenge/case.json
@@ -1,0 +1,39 @@
+{
+  "id": "compose-performance-deferred-provider-challenge",
+  "title": "Find an eager read behind a provider",
+  "family": "performance",
+  "target_skills": [
+    "compose-performance"
+  ],
+  "expected_skills": [
+    "compose-performance"
+  ],
+  "task_mode": "review",
+  "kind": "novel",
+  "fixture": "compose-jvm",
+  "allowed_write_paths": [],
+  "validators": [
+    {
+      "argv": [
+        "python3",
+        "@validators/compose_case.py",
+        "compose-performance-deferred-provider-challenge"
+      ],
+      "timeout_seconds": 30
+    }
+  ],
+  "rubric": [
+    {
+      "id": "criterion-1",
+      "text": "Identifies that progress.value is still read in composition even though the derived radius is passed through a provider lambda"
+    },
+    {
+      "id": "criterion-2",
+      "text": "Moves both the state read and the dependent radius calculation into the Canvas draw consumer"
+    }
+  ],
+  "provenance": {
+    "kind": "synthetic"
+  },
+  "calibration": true
+}

--- a/evals/cases/compose-performance-deferred-provider-challenge/expectations.json
+++ b/evals/cases/compose-performance-deferred-provider-challenge/expectations.json
@@ -1,0 +1,6 @@
+{
+  "files": [
+    "src/main/kotlin/example/Subject.kt"
+  ],
+  "constraints": []
+}

--- a/evals/cases/compose-performance-deferred-provider-challenge/overlay/src/main/kotlin/example/Subject.kt
+++ b/evals/cases/compose-performance-deferred-provider-challenge/overlay/src/main/kotlin/example/Subject.kt
@@ -1,0 +1,19 @@
+package example
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.ui.Modifier
+
+@Composable
+fun ProgressRing(progress: State<Float>) {
+  val fraction = progress.value
+  RingCanvas(radiusProvider = { fraction * 24f })
+}
+
+@Composable
+private fun RingCanvas(radiusProvider: () -> Float) {
+  Canvas(Modifier) {
+    drawCircle(radius = radiusProvider())
+  }
+}

--- a/evals/cases/compose-performance-deferred-provider-challenge/prompt.md
+++ b/evals/cases/compose-performance-deferred-provider-challenge/prompt.md
@@ -1,0 +1,1 @@
+Review whether this provider actually defers the frame-rate read. Report the concrete issue and smallest phase-local correction without editing.

--- a/evals/cases/compose-performance-strong-skipping-churn-challenge/case.json
+++ b/evals/cases/compose-performance-strong-skipping-churn-challenge/case.json
@@ -1,0 +1,39 @@
+{
+  "id": "compose-performance-strong-skipping-churn-challenge",
+  "title": "Diagnose strong-skipping identity churn",
+  "family": "performance",
+  "target_skills": [
+    "compose-performance"
+  ],
+  "expected_skills": [
+    "compose-performance"
+  ],
+  "task_mode": "review",
+  "kind": "novel",
+  "fixture": "compose-jvm",
+  "allowed_write_paths": [],
+  "validators": [
+    {
+      "argv": [
+        "python3",
+        "@validators/compose_case.py",
+        "compose-performance-strong-skipping-churn-challenge"
+      ],
+      "timeout_seconds": 30
+    }
+  ],
+  "rubric": [
+    {
+      "id": "criterion-1",
+      "text": "Identifies that FeedUiState remains unstable because it contains List and that recreating the state and list gives strong skipping a new identity to compare on every recomposition"
+    },
+    {
+      "id": "criterion-2",
+      "text": "Recommends a truthful immutable collection contract and/or retaining the state instance at its ownership boundary, without adding Stable or Immutable annotations unless the contract is made true"
+    }
+  ],
+  "provenance": {
+    "kind": "synthetic"
+  },
+  "calibration": true
+}

--- a/evals/cases/compose-performance-strong-skipping-churn-challenge/expectations.json
+++ b/evals/cases/compose-performance-strong-skipping-churn-challenge/expectations.json
@@ -1,0 +1,6 @@
+{
+  "files": [
+    "src/main/kotlin/example/Subject.kt"
+  ],
+  "constraints": []
+}

--- a/evals/cases/compose-performance-strong-skipping-churn-challenge/overlay/src/main/kotlin/example/Subject.kt
+++ b/evals/cases/compose-performance-strong-skipping-churn-challenge/overlay/src/main/kotlin/example/Subject.kt
@@ -1,0 +1,15 @@
+package example
+
+import androidx.compose.runtime.Composable
+
+data class FeedUiState(
+  val items: List<String>,
+)
+
+@Composable
+fun FeedRoute(items: List<String>) {
+  FeedContent(FeedUiState(items = items.toList()))
+}
+
+@Composable
+private fun FeedContent(state: FeedUiState) = Unit

--- a/evals/cases/compose-performance-strong-skipping-churn-challenge/prompt.md
+++ b/evals/cases/compose-performance-strong-skipping-churn-challenge/prompt.md
@@ -1,0 +1,1 @@
+Review why an unchanged feed can still fail to skip under current strong-skipping semantics. Recommend the smallest truthful correction. Report findings only.

--- a/evals/cases/compose-stability-diagnostics-direct/expectations.json
+++ b/evals/cases/compose-stability-diagnostics-direct/expectations.json
@@ -4,7 +4,7 @@
   ],
   "must_contain": [],
   "must_contain_any": [
-    ["val items: List<String>", "val items: ImmutableList<String>"]
+    ["val items: ImmutableList<String>", "val items: PersistentList<String>"]
   ],
   "must_not_contain": [
     "MutableList<String>"

--- a/evals/cases/compose-ui-testing-patterns-novel/case.json
+++ b/evals/cases/compose-ui-testing-patterns-novel/case.json
@@ -25,11 +25,11 @@
   "rubric": [
     {
       "id": "criterion-1",
-      "text": "Identifies fixed sleep and production integration as sources of nondeterminism"
+      "text": "Identifies the fixed sleep as nondeterministic and production integration as a broader-than-needed asynchronous seam"
     },
     {
       "id": "criterion-2",
-      "text": "Recommends a controlled UI seam with semantics-based synchronization"
+      "text": "Recommends a controlled UI seam with an observable callback or semantic assertion and does not recommend a fixed delay"
     }
   ],
   "provenance": {

--- a/evals/harness/cases.py
+++ b/evals/harness/cases.py
@@ -60,6 +60,7 @@ class EvalCase:
     provenance: dict[str, str]
     prompt: str
     directory: Path
+    calibration: bool = False
 
 
 @dataclass(frozen=True)
@@ -205,6 +206,10 @@ def load_case(manifest_path: Path, repo_root: Path) -> EvalCase:
     if not prompt.strip():
         raise CaseValidationError("prompt.md cannot be empty")
 
+    calibration = data.get("calibration", False)
+    if not isinstance(calibration, bool):
+        raise CaseValidationError("calibration must be a boolean")
+
     return EvalCase(
         id=case_id,
         title=_require_string(data, "title"),
@@ -218,6 +223,7 @@ def load_case(manifest_path: Path, repo_root: Path) -> EvalCase:
         validators=tuple(validators),
         rubric=tuple(rubric),
         provenance=_validate_provenance(data.get("provenance")),
+        calibration=calibration,
         prompt=prompt,
         directory=manifest_path.parent,
     )
@@ -225,7 +231,8 @@ def load_case(manifest_path: Path, repo_root: Path) -> EvalCase:
 
 def _coverage_gaps(cases: list[EvalCase]) -> list[str]:
     gaps: list[str] = []
-    by_id = {case.id: case for case in cases}
+    benchmark_cases = [case for case in cases if not case.calibration]
+    by_id = {case.id: case for case in benchmark_cases}
     expected_conditions = (
         ("direct", "edit"),
         ("novel", "review"),
@@ -247,11 +254,11 @@ def _coverage_gaps(cases: list[EvalCase]) -> list[str]:
         historical = [case for case in topic_cases if case.provenance["kind"] == "historical"]
         if len(historical) != 1:
             gaps.append(f"{topic}: expected 1 historical case, found {len(historical)}")
-    routing_count = sum(case.kind == "routing" for case in cases)
+    routing_count = sum(case.kind == "routing" for case in benchmark_cases)
     if routing_count != 5:
         gaps.append(f"router: expected 5 cases, found {routing_count}")
-    if len(cases) != 38:
-        gaps.append(f"corpus: expected 38 cases, found {len(cases)}")
+    if len(benchmark_cases) != 38:
+        gaps.append(f"corpus: expected 38 benchmark cases, found {len(benchmark_cases)}")
     return gaps
 
 

--- a/evals/harness/codex.py
+++ b/evals/harness/codex.py
@@ -164,6 +164,8 @@ def build_subject_command(
         "-c",
         "sandbox_workspace_write.network_access=false",
         "-c",
+        'web_search="disabled"',
+        "-c",
         _skill_config(
             case,
             arm,

--- a/evals/harness/experiment.py
+++ b/evals/harness/experiment.py
@@ -58,6 +58,8 @@ def filter_cases(
         missing = requested - {case.id for case in selected}
         if missing:
             raise ValueError(f"unknown cases: {sorted(missing)}")
+    else:
+        selected = [case for case in selected if not case.calibration]
     if skills:
         requested_skills = set(skills)
         selected = [case for case in selected if requested_skills & set(case.target_skills)]
@@ -495,6 +497,90 @@ def regrade_records(
         destination,
         regraded,
         compute_scorecard(regraded),
+        seed=audit_seed,
+    )
+
+
+def write_rejudged_reports(
+    output_dir: Path,
+    records: list[dict[str, Any]],
+    *,
+    audit_seed: int,
+) -> dict[str, Path]:
+    packets: dict[tuple[str, int], tuple[str, dict[str, Any]]] = {}
+    for packet_path in sorted((output_dir / "judge-packets").glob("*.json")):
+        try:
+            candidate_id, fingerprint_prefix, repetition = packet_path.stem.rsplit(
+                "-", 2
+            )
+            key = (fingerprint_prefix, int(repetition))
+        except ValueError as error:
+            raise ValueError(f"invalid judge packet filename: {packet_path}") from error
+        packet = json.loads(packet_path.read_text(encoding="utf-8"))
+        if packet.get("candidate_id") != candidate_id:
+            raise ValueError(f"judge packet candidate mismatch: {packet_path}")
+        if key in packets:
+            raise ValueError(f"duplicate judge packet for fingerprint: {packet_path}")
+        packets[key] = (packet_path.stem, packet)
+
+    judgments: dict[str, tuple[str, dict[str, Any]]] = {}
+    for result_path in sorted((output_dir / "rejudgments").glob("*/*.json")):
+        document = json.loads(result_path.read_text(encoding="utf-8"))
+        fingerprint = document.get("fingerprint")
+        payload = document.get("payload")
+        if not isinstance(fingerprint, str) or not isinstance(payload, dict):
+            raise ValueError(f"invalid rejudgment result: {result_path}")
+        candidate_id = payload.get("candidate_id")
+        if not isinstance(candidate_id, str) or not isinstance(
+            payload.get("judge"), dict
+        ):
+            raise ValueError(f"invalid rejudgment payload: {result_path}")
+        packet_name = result_path.parent.name
+        if packet_name in judgments:
+            raise ValueError(f"ambiguous rejudgments for packet: {packet_name}")
+        judgments[packet_name] = (fingerprint, payload)
+
+    rejudged: list[dict[str, Any]] = []
+    for original in records:
+        fingerprint = original.get("fingerprint")
+        repetition = original.get("repetition")
+        if not isinstance(fingerprint, str) or not isinstance(repetition, int):
+            raise ValueError(
+                f"record lacks fingerprint or repetition: {original.get('id')}"
+            )
+        packet_record = packets.get((fingerprint[:20], repetition))
+        if packet_record is None:
+            raise ValueError(f"missing judge packet for record: {original.get('id')}")
+        packet_name, packet = packet_record
+        candidate_id = packet["candidate_id"]
+        rejudgment = judgments.get(packet_name)
+        if rejudgment is None:
+            raise ValueError(f"missing rejudgment for packet: {packet_name}")
+        rejudgment_fingerprint, judgment = rejudgment
+        if judgment["candidate_id"] != candidate_id:
+            raise ValueError(f"rejudgment candidate mismatch: {packet_name}")
+        judge = judgment["judge"]
+        rubric = tuple(packet.get("rubric", ()))
+        judge_pass = int(judge.get("returncode", 1)) == 0 and judge_passes_rubric(
+            judge.get("output", {}), rubric
+        )
+        record = deepcopy(original)
+        record["original_judge"] = record["judge"]
+        record["judge"] = judge
+        record["judge_model"] = judgment.get("judge_model", record["judge_model"])
+        record["judge_pass"] = judge_pass
+        record["outcome_pass"] = bool(record.get("objective_pass")) and judge_pass
+        record["rejudgment"] = {
+            "candidate_id": candidate_id,
+            "fingerprint": rejudgment_fingerprint,
+        }
+        rejudged.append(record)
+
+    destination = output_dir / "rejudged"
+    return write_reports(
+        destination,
+        rejudged,
+        compute_scorecard(rejudged),
         seed=audit_seed,
     )
 

--- a/evals/harness/judge.py
+++ b/evals/harness/judge.py
@@ -137,6 +137,7 @@ def build_judge_command(
         "--ephemeral",
         "--ignore-user-config",
         "--ignore-rules",
+        "--skip-git-repo-check",
         "--strict-config",
         "--json",
         "--output-schema",
@@ -147,6 +148,8 @@ def build_judge_command(
         f'model_reasoning_effort="{config.reasoning}"',
         "-c",
         "sandbox_workspace_write.network_access=false",
+        "-c",
+        'web_search="disabled"',
         "-c",
         _disabled_skill_config(
             discover_skill_paths(repo_root) if skill_paths is None else skill_paths

--- a/evals/run.py
+++ b/evals/run.py
@@ -19,6 +19,7 @@ from evals.harness.experiment import (
     load_raw_records,
     regrade_records,
     rejudge_packets,
+    write_rejudged_reports,
 )
 from evals.harness.judge import JudgeConfig
 from evals.harness.report import append_audit_decision, write_reports
@@ -60,6 +61,11 @@ def build_parser() -> argparse.ArgumentParser:
     )
     regrade.add_argument("--output-dir", type=Path, required=True)
     regrade.add_argument("--audit-seed", type=int, default=20260816)
+    rejudged_report = subparsers.add_parser(
+        "rejudged-report", help="report valid persisted rejudgments without model calls"
+    )
+    rejudged_report.add_argument("--output-dir", type=Path, required=True)
+    rejudged_report.add_argument("--audit-seed", type=int, default=20260816)
     judge = subparsers.add_parser("judge", help="preview or rejudge persisted packets")
     judge.add_argument("--output-dir", type=Path, required=True)
     judge.add_argument("--judge-model", required=True)
@@ -199,6 +205,23 @@ def main(argv: list[str] | None = None) -> int:
                 audit_seed=args.audit_seed,
             )
         except (CaseValidationError, OSError, ValueError) as error:
+            print(error, file=sys.stderr)
+            return 1
+        print(paths["scorecard"])
+        return 0
+    if args.command == "rejudged-report":
+        output_dir = args.output_dir.resolve()
+        try:
+            records = load_raw_records(output_dir)
+            if not records:
+                print(f"no raw results under {output_dir}", file=sys.stderr)
+                return 1
+            paths = write_rejudged_reports(
+                output_dir,
+                records,
+                audit_seed=args.audit_seed,
+            )
+        except (OSError, ValueError) as error:
             print(error, file=sys.stderr)
             return 1
         print(paths["scorecard"])

--- a/evals/tests/test_cases.py
+++ b/evals/tests/test_cases.py
@@ -58,7 +58,14 @@ class CaseContractTest(unittest.TestCase):
 
         self.assertEqual("compose-state-authoring-direct", case.id)
         self.assertEqual(("compose-state-and-effects",), case.expected_skills)
+        self.assertFalse(case.calibration)
         self.assertEqual("Fix the subject.\n", case.prompt)
+
+    def test_requires_calibration_marker_to_be_boolean(self):
+        case_dir = self.write_case(valid_manifest(calibration="yes"))
+
+        with self.assertRaisesRegex(CaseValidationError, "calibration must be a boolean"):
+            load_case(case_dir / "case.json", self.root)
 
     def test_rejects_validator_paths_that_escape_the_case_contract(self):
         for argv in (["../check.py"], ["/tmp/check.py"]):

--- a/evals/tests/test_codex_runner.py
+++ b/evals/tests/test_codex_runner.py
@@ -87,6 +87,7 @@ class CodexRunnerTest(unittest.TestCase):
             self.assertIn("--json", command)
             self.assertIn('model_reasoning_effort="medium"', rendered)
             self.assertIn("sandbox_workspace_write.network_access=false", rendered)
+            self.assertIn('web_search="disabled"', rendered)
             self.assertIn(str(unrelated.resolve()), rendered)
             self.assertIn("enabled = false", rendered)
             self.assertIn("SKILL.md", rendered)

--- a/evals/tests/test_compose_matrix.py
+++ b/evals/tests/test_compose_matrix.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from evals.harness.cases import EVALUATED_TOPICS, validate_corpus
 from evals.harness.codex import prepare_workspace
 from evals.harness.grade import grade_subject
-from evals.harness.experiment import regrade_records
+from evals.harness.experiment import filter_cases, regrade_records
 from evals.tests.test_grade import make_result
 
 
@@ -17,9 +17,14 @@ class ComposeMatrixTest(unittest.TestCase):
     def test_has_the_exact_concern_slice_and_router_matrix(self):
         report = validate_corpus(REPO_ROOT)
 
-        self.assertEqual(38, report.case_count)
-        standalone = [case for case in report.cases if case.kind != "routing"]
-        routing = [case for case in report.cases if case.kind == "routing"]
+        self.assertEqual(42, report.case_count)
+        benchmark = [case for case in report.cases if not case.calibration]
+        calibration = [case for case in report.cases if case.calibration]
+        self.assertEqual(38, len(benchmark))
+        self.assertEqual(4, len(calibration))
+        self.assertTrue(all(case.family == "performance" for case in calibration))
+        standalone = [case for case in benchmark if case.kind != "routing"]
+        routing = [case for case in benchmark if case.kind == "routing"]
         self.assertEqual(33, len(standalone))
         self.assertEqual(5, len(routing))
         for topic, skill in EVALUATED_TOPICS:
@@ -29,6 +34,22 @@ class ComposeMatrixTest(unittest.TestCase):
             self.assertEqual(1, sum(case.provenance["kind"] == "historical" for case in cases))
             negative = next(case for case in cases if case.kind == "negative")
             self.assertEqual((skill,), negative.expected_skills)
+
+    def test_calibration_cases_require_explicit_selection(self):
+        report = validate_corpus(REPO_ROOT)
+
+        default_cases = filter_cases(report.cases, case_ids=None, skills=None)
+        self.assertEqual(38, len(default_cases))
+        self.assertFalse(any(case.calibration for case in default_cases))
+
+        challenge_id = "compose-performance-strong-skipping-churn-challenge"
+        selected = filter_cases(
+            report.cases,
+            case_ids=[challenge_id],
+            skills=None,
+        )
+        self.assertEqual([challenge_id], [case.id for case in selected])
+        self.assertTrue(selected[0].calibration)
 
     def test_automatic_prompts_do_not_name_or_invoke_expected_skills(self):
         report = validate_corpus(REPO_ROOT)
@@ -56,6 +77,23 @@ class ComposeMatrixTest(unittest.TestCase):
         )
         self.assertIn("recommends first", repair_criterion["text"].lower())
         self.assertIn("then deciding", repair_criterion["text"].lower())
+
+    def test_ui_testing_novel_does_not_require_unnecessary_synchronization(self):
+        report = validate_corpus(REPO_ROOT)
+        case = next(
+            case
+            for case in report.cases
+            if case.id == "compose-ui-testing-patterns-novel"
+        )
+
+        seam_criterion = next(
+            criterion
+            for criterion in case.rubric
+            if criterion["id"] == "criterion-2"
+        )["text"].lower()
+        self.assertIn("callback or semantic assertion", seam_criterion)
+        self.assertIn("does not recommend a fixed delay", seam_criterion)
+        self.assertNotIn("synchronization", seam_criterion)
 
     def test_fixture_declares_pinned_compose_jvm_dependencies_and_offline_wrapper(self):
         fixture = REPO_ROOT / "evals" / "fixtures" / "compose-jvm"
@@ -119,41 +157,45 @@ class Counter {
 
     def test_direct_validators_accept_semantic_equivalents_seen_in_live_runs(self):
         report = validate_corpus(REPO_ROOT)
-        replacements = {
-            "compose-slot-api-pattern-direct": """package example
+        replacements = (
+            ("compose-slot-api-pattern-direct", """package example
 import androidx.compose.runtime.Composable
 @Composable fun ActionRow(
   leadingContent: @Composable () -> Unit,
   titleContent: @Composable () -> Unit,
 ) { leadingContent(); titleContent() }
-""",
-            "compose-stability-diagnostics-direct": """package example
+"""),
+            ("compose-stability-diagnostics-direct", """package example
 import kotlinx.collections.immutable.ImmutableList
 data class FeedState(val items: ImmutableList<String>)
-""",
-            "compose-state-hoisting-direct": """package example
+"""),
+            ("compose-stability-diagnostics-direct", """package example
+import kotlinx.collections.immutable.PersistentList
+data class FeedState(val items: PersistentList<String>)
+"""),
+            ("compose-state-hoisting-direct", """package example
 import androidx.compose.runtime.Composable
 @Composable fun SearchContent(query: String, onQueryChange: (String) -> Unit) = Unit
 @Composable private fun SearchContentPreview() {
   var query by remember { mutableStateOf(\"\") }
   SearchContent(query, onQueryChange = { query = it })
 }
-""",
-            "compose-ui-testing-patterns-direct": """package example
+"""),
+            ("compose-ui-testing-patterns-direct", """package example
 import androidx.compose.ui.test.junit4.createComposeRule
 class SubjectTest {
   val composeTestRule = createComposeRule()
   fun test() { composeTestRule.setContent {} }
 }
-""",
-        }
+"""),
+        )
 
         with tempfile.TemporaryDirectory() as temp_dir:
-            for case_id, source in replacements.items():
+            for index, (case_id, source) in enumerate(replacements):
                 with self.subTest(case=case_id):
                     case = next(case for case in report.cases if case.id == case_id)
                     workspace = prepare_workspace(
-                        case, REPO_ROOT, Path(temp_dir) / case_id
+                        case, REPO_ROOT, Path(temp_dir) / f"{case_id}-{index}"
                     )
                     relative_path = (
                         "src/test/kotlin/example/SubjectTest.kt"

--- a/evals/tests/test_judge.py
+++ b/evals/tests/test_judge.py
@@ -136,8 +136,10 @@ class BlindedJudgeTest(unittest.TestCase):
         self.assertEqual(7, rendered.count("path = "))
         self.assertEqual(0, rendered.count("enabled = true"))
         self.assertEqual("read-only", command[command.index("--sandbox") + 1])
+        self.assertIn("--skip-git-repo-check", command)
         self.assertNotIn("--approve-for-me", command)
         self.assertIn('model_reasoning_effort="high"', rendered)
+        self.assertIn('web_search="disabled"', rendered)
 
     def test_judge_command_treats_subject_controlled_fields_as_untrusted_data(self):
         packet = self.root / "packet.json"

--- a/evals/tests/test_results.py
+++ b/evals/tests/test_results.py
@@ -13,6 +13,7 @@ from evals.harness.experiment import (
     load_raw_records,
     next_attempt_workspace,
     rejudge_packets,
+    write_rejudged_reports,
 )
 from evals.harness.judge import JudgeConfig
 from evals.harness.results import (
@@ -197,6 +198,87 @@ class ResultLifecycleTest(unittest.TestCase):
 
         self.assertNotEqual(first, second)
         self.assertEqual("a" * 64 + ".json", first.name)
+
+    def test_rejudged_report_overlays_a_valid_matching_judgment(self):
+        fingerprint = "a" * 64
+        candidate_id = "candidate"
+        packet_path = _judge_packet_path(self.root, candidate_id, fingerprint, 1)
+        packet_path.parent.mkdir(parents=True)
+        packet_path.write_text(
+            json.dumps(
+                {
+                    "candidate_id": candidate_id,
+                    "rubric": [{"id": "correct", "text": "Correct"}],
+                }
+            ),
+            encoding="utf-8",
+        )
+        rejudgment_path = self.root / "rejudgments" / packet_path.stem / "result.json"
+        write_result(
+            rejudgment_path,
+            "rejudgment-sha",
+            {
+                "candidate_id": candidate_id,
+                "judge_model": {"model": "gpt-5.6-sol", "reasoning": "high"},
+                "judge": {
+                    "returncode": 0,
+                    "events": [],
+                    "output": {
+                        "criteria": [
+                            {"id": "correct", "pass": True, "evidence": "diff"}
+                        ],
+                        "overall_pass": True,
+                        "rationale": "ok",
+                    },
+                    "usage": {},
+                    "stderr": "",
+                    "elapsed_seconds": 1.0,
+                    "retries": 0,
+                },
+            },
+        )
+        original = {
+            "id": "case:none:1",
+            "fingerprint": fingerprint,
+            "repetition": 1,
+            "arm": "none",
+            "kind": "direct",
+            "expected_skills": [],
+            "reported_skills": [],
+            "reported_router": False,
+            "objective_pass": True,
+            "judge_pass": False,
+            "outcome_pass": False,
+            "forbidden_action_failure": False,
+            "judge_model": {"model": "gpt-5.6-sol", "reasoning": "high"},
+            "judge": {"returncode": 1, "output": {}},
+        }
+
+        paths = write_rejudged_reports(self.root, [original], audit_seed=3)
+
+        rejudged = json.loads(paths["results"].read_text(encoding="utf-8"))
+        self.assertTrue(rejudged[0]["judge_pass"])
+        self.assertTrue(rejudged[0]["outcome_pass"])
+        self.assertEqual(1, rejudged[0]["original_judge"]["returncode"])
+        self.assertFalse(original["judge_pass"])
+        self.assertFalse(original["outcome_pass"])
+
+    def test_rejudged_report_refuses_missing_judgments(self):
+        fingerprint = "a" * 64
+        packet_path = _judge_packet_path(self.root, "candidate", fingerprint, 1)
+        packet_path.parent.mkdir(parents=True)
+        packet_path.write_text(
+            json.dumps({"candidate_id": "candidate", "rubric": []}),
+            encoding="utf-8",
+        )
+        original = {
+            "id": "case:none:1",
+            "fingerprint": fingerprint,
+            "repetition": 1,
+        }
+
+        with self.assertRaisesRegex(ValueError, "missing rejudgment"):
+            write_rejudged_reports(self.root, [original], audit_seed=3)
 
     def test_retries_only_once_for_a_retryable_failure(self):
         calls = []

--- a/skills/compose-component-design/SKILL.md
+++ b/skills/compose-component-design/SKILL.md
@@ -13,18 +13,22 @@ policy choices that vary by use.
 
 ## Procedure
 
-1. State the component's invariant visual structure and identify every varying
+1. State the requested API concern and keep the edit within it. A focused slot
+   review does not authorize unrelated modifier, naming, or cleanup changes.
+2. State the component's invariant visual structure and identify every varying
    region, placement concern, and policy choice.
-2. Accept and apply a caller modifier at the component root unless a concrete
-   API boundary makes another placement correct.
-3. Represent caller-controlled, unconstrained visual regions with slots rather
+3. When root placement is part of the requested work or a broad component API
+   design, accept and apply a caller modifier at the component root unless a
+   concrete API boundary makes another placement correct.
+4. Represent caller-controlled, unconstrained visual regions with slots rather
    than proliferating primitive content parameters or Boolean shape flags.
    Keep semantic and design-system constraints as primitive parameters.
-4. Keep simple conditional structure inline; extract only a coherent reusable
+5. Keep simple conditional structure inline; extract only a coherent reusable
    contract.
-5. Read the relevant focused reference below before editing public signatures.
-6. Finish when callers can position the component, supply variable content,
-   and understand ownership without needing hidden layout or content switches.
+6. Read the relevant focused reference below before editing public signatures.
+7. Finish with no edit when the existing API already satisfies the requested
+   concern. Otherwise finish when callers can position the component, supply
+   variable content, and understand ownership without hidden switches.
 
 ## Topic router
 
@@ -43,6 +47,10 @@ policy choices that vary by use.
    the variable regions as named slots.
 2. Novel case: a component needs both a root modifier and caller-supplied
    trailing content. GREEN applies the modifier at the root and supplies a
-   trailing slot without leaking internal layout.
+   trailing slot without leaking the component's `RowScope`; reserve a scope
+   receiver for a region whose child layout is deliberately caller-controlled.
 3. Counterexample: a private screen helper has one fixed child and no callers.
    GREEN keeps it simple instead of inventing slots for hypothetical reuse.
+4. Focused counterexample: a status label intentionally maps a semantic enum to
+   fixed copy, and the task asks only whether it needs slots. GREEN leaves the
+   workspace unchanged instead of adding an unrelated root modifier.

--- a/skills/compose-component-design/references/slot-apis.md
+++ b/skills/compose-component-design/references/slot-apis.md
@@ -6,15 +6,17 @@ A reusable Compose component describes layout structure. Callers provide variabl
 
 ## API review procedure
 
-1. Confirm the component is reusable. For a true single-use composable, do not add slot ceremony.
+1. Confirm the component is reusable and slot semantics are within the requested
+   scope. In a focused slot task, do not add unrelated modifier or cleanup changes.
 2. Mark which regions vary by caller: headline, supporting text, leading visual, trailing visual, actions, body.
 3. Replace caller-controlled, unconstrained primitive content and shape flags
    with slots. Preserve primitive parameters when they intentionally enforce a
    semantic, design-system, constrained-type, or measured fast-path contract.
-4. Add receiver scopes only when the slot is emitted inside a layout whose scope APIs callers should use.
+4. Add a receiver scope only when the public contract deliberately gives callers control over that region's child layout; do not infer it merely because the implementation emits the slot inside a layout.
 5. Make absent optional regions nullable (`null`), so the component can omit their containers and spacing.
 6. Put repeated default content or tokens in `XxxDefaults`.
-7. Pair this with the `modifier` rules in [Modifier and layout](modifier-layout.md).
+7. Pair this with the `modifier` rules in [Modifier and layout](modifier-layout.md)
+   only when root placement is part of the task or a broad API review.
 
 ## 1. Replace primitive content with `@Composable` slots
 
@@ -78,9 +80,9 @@ SettingsRow(
 - Use a singular noun (`title`, `icon`, `actions`) when the slot is semantically constrained and the component name disambiguates (`Scaffold(topBar = { … }, bottomBar = { … }, floatingActionButton = { … })`).
 - Don't use `content` *and* other `xxxContent` slots together — pick one convention per component.
 
-## 2. Scope receivers when the slot emits into a layout
+## 2. Scope receivers only for a public layout contract
 
-If the slot's content will sit inside a `Row`/`Column`/`Box` whose layout features (`Modifier.weight`, `BoxScope.matchParentSize`, alignment) should be available to the caller, declare the slot as a receiver lambda: `@Composable RowScope.() -> Unit`.
+Use a receiver lambda only when callers must intentionally control the layout *inside the named region*, such as an app bar's action region. A component retaining ownership of its internal `Row`, `Column`, or `Box` should keep ordinary `@Composable () -> Unit` slots, even if it happens to emit them in that layout.
 
 ```kotlin
 // ❌ BAD — actions render inside a Row, but callers can't use RowScope.weight()
@@ -100,9 +102,9 @@ fun MyTopBar(
 )
 ```
 
-This is what makes `TopAppBar(actions = { IconButton(…); IconButton(…) })` work — the caller is implicitly inside a `RowScope`.
+This is what makes `TopAppBar(actions = { IconButton(…); IconButton(…) })` work — its documented actions region deliberately gives callers a `RowScope`.
 
-Don't bolt a scope receiver onto every slot reflexively. The receiver should match the actual parent layout the slot emits into. If the slot is rendered inside a `Box`, use `BoxScope`. If it's inside a `Column`, use `ColumnScope`. If the parent is not a standard layout (or none of its scope APIs are useful in slot content), no receiver.
+Don't bolt a scope receiver onto every slot reflexively. First decide whether caller control over region layout is part of the API. Only then match the receiver to that public contract (`RowScope`, `BoxScope`, or `ColumnScope`). A trailing slot in a component-owned row is normally an ordinary slot: callers choose its content while the component owns ordering, spacing, and allocation.
 
 ## 3. Optional slots — nullable with `null` default
 
@@ -160,6 +162,7 @@ This matches Material 3's `ButtonDefaults`, `TopAppBarDefaults`, etc. — defaul
 | A mode parameter enumerating caller-controlled visual variants | Same as flag soup (§1) | Replace the visual variants with a slot |
 | Primitive or mode parameter enforces semantic, design-system, constrained-type, or measured fast-path behavior | Deliberate component contract | Keep the primitive parameter and document the invariant |
 | `actions: @Composable () -> Unit = {}` inside a `Row` body | Missing scope receiver (§2) | `actions: @Composable RowScope.() -> Unit = {}` |
+| A trailing or inline slot merely happens to be emitted in an internal `Row` | Component owns the row's allocation and ordering | Keep `@Composable () -> Unit`; do not leak `RowScope` |
 | `slot: @Composable () -> Unit = {}` for an optional area | Empty-lambda default (§3) | `slot: (@Composable () -> Unit)? = null` and branch on it |
 | Component param `defaultColor: Color = MaterialTheme.colorScheme.surface` | Defaults inlined (§4) | Move to `XxxDefaults.color` and reference it |
 | Common trailing content repeats at every call site | Missing default helper (§4) | Add `XxxDefaults.Chevron()` etc. |

--- a/skills/compose-performance/SKILL.md
+++ b/skills/compose-performance/SKILL.md
@@ -20,8 +20,14 @@ axis begins.
 3. Check for a false lead: a real data change, a correctness defect, or an
    unchanged lazy item that is expected to recompose.
 4. Read the corresponding focused reference before proposing a change.
-5. Change one axis at a time and re-measure the same transition.
-6. Finish when the evidence improves at the observed boundary without hiding
+5. For review work, pair every finding with the smallest evidence-supported
+   repair. For a false stability promise, explicitly say to replace mutable
+   non-snapshot properties with immutable data or snapshot-observable state,
+   verify that contract, and only then decide whether an annotation remains
+   needed. For a phase problem, name the layout or draw consumer where the
+   changing read or calculation should move. Do not stop at diagnosis.
+6. Change one axis at a time and re-measure the same transition.
+7. Finish when the evidence improves at the observed boundary without hiding
    state changes, caching stale values, or moving work to a less correct owner.
 
 ## Topic router
@@ -38,8 +44,9 @@ axis begins.
 
 1. RED blames unstable parameters for unchanged lazy rows that recompose during
    a focus transition. GREEN checks composition and layout back-writing first.
-2. Novel case: an animation value controls only drawing. GREEN reads the State
-   in a draw or layout lambda instead of propagating it through composition.
+2. Novel case: an animation value controls only drawing. RED identifies the
+   composition read but stops at diagnosis. GREEN moves the State read and its
+   geometry calculation into the draw or layout consumer.
 3. Counterexample: a screen visibly recomposes because its displayed model
    actually changed. GREEN does not add stability wrappers or caches merely to
    lower a count.

--- a/skills/compose-state-and-effects/SKILL.md
+++ b/skills/compose-state-and-effects/SKILL.md
@@ -13,21 +13,34 @@ state and effects make rendering change safely.
 
 ## Procedure
 
-1. Inventory mutable UI state, app state, event streams, app dependencies, and
+1. Establish the requested scope and visible behavioral requirements. Treat an
+   ownership change as a finding only when code or task evidence shows a
+   lifecycle, testability, business, or coordination need.
+2. Inventory mutable UI state, app state, event streams, app dependencies, and
    imperative work in the affected screen or component.
-2. Place each state value at its lowest necessary owner: local UI state,
+3. Place each state value at its lowest necessary owner: local UI state,
    hoisted state, a plain UI state holder, or a screen state holder.
-3. Keep app wiring and business state at the screen boundary; expose plain UI
-   state and explicit callbacks to previewable rendering.
-4. Choose an effect API whose lifecycle matches the work, and key it by the
+4. Keep app wiring and business state at the screen boundary. When a screen
+   holder owns Compose runtime objects, explicitly recommend a separate,
+   previewable content composable that takes immutable state and event
+   callbacks; keep runtime objects in composition or a plain UI state holder.
+   Merely recommending immutable state and intents does not establish that
+   rendering boundary.
+5. Choose an effect API whose lifecycle matches the work, and key it by the
    semantic input that should restart or dispose it.
-5. Load the focused reference for every material concern below. Do not use a
+6. Load the focused reference for every material concern below. Do not use a
    reference merely because its topic is adjacent.
-6. Route frame-rate reads, cross-phase back-writing, and
+7. Route frame-rate reads, cross-phase back-writing, and
    `@ReadOnlyComposable` contracts to [Compose performance](../compose-performance/SKILL.md).
-7. Finish when every state value has one owner, every effect has a justified
+8. Before responding to a screen-ownership review, verify that the answer
+   explicitly names all three required seams when the visible code needs them:
+   durable data and intents at the screen boundary, runtime UI objects in
+   composition or a plain UI state holder, and a previewable content composable
+   whose inputs are immutable state and event callbacks.
+9. Finish when every state value has one owner, every effect has a justified
    lifecycle and key, and the UI can be previewed and tested without app
-   dependencies.
+   dependencies. For review-only work, report no change when no evidence-backed
+   issue remains; do not invent product requirements.
 
 ## Topic router
 
@@ -49,3 +62,5 @@ state and effects make rendering change safely.
    the screen state holder, but keeps Compose runtime objects in plain UI state.
 3. Counterexample: a one-off expandable badge has one private Boolean. GREEN
    keeps it local and does not introduce a state holder or an effect.
+4. Counterexample: an accessor reads shared snapshot state with no requirement
+   for per-instance independence. GREEN does not invent an ownership leak.

--- a/skills/compose-state-and-effects/references/state-hoisting.md
+++ b/skills/compose-state-and-effects/references/state-hoisting.md
@@ -9,10 +9,10 @@ Hoist state only as far as the logic needs it. Keep simple UI element state loca
 1. List the state, operations, app dependencies, event streams, and imperative effects involved.
 2. Assign each item to the lowest owner that needs to read or change it using the decision guide below.
 3. Extract a plain state holder only when coordinated UI-only behavior has become a concept.
-4. When a screen mixes app wiring with layout, keep a small state-holder composable and move rendering to a plain state-driven composable.
+4. When a screen state holder owns Compose runtime objects, or a screen mixes app wiring with layout, keep durable data and intents at the screen boundary; move runtime objects into composition or a plain UI state holder; and explicitly recommend a separate, previewable content composable that takes immutable state and event callbacks. Naming immutable state and intents without this content boundary is incomplete.
 5. Pass immutable UI state and explicit event callbacks across that boundary; keep UI mechanics in composition unless business logic needs their values.
 6. Load focused effect, testing, focus, or deferred-read skills when those concerns need deeper treatment.
-7. Finish when the UI can be previewed and tested without app dependencies, business work remains in the screen state holder, and no state has been hoisted farther than its logic requires.
+7. Finish an ownership review by stating that concrete boundary when the visible code requires it. Otherwise allow a no-change conclusion. Do not stop after naming the wrong owner, invent product requirements, or hoist state farther than its logic requires.
 
 ## Decision guide
 

--- a/skills/compose-ui-testing-patterns/SKILL.md
+++ b/skills/compose-ui-testing-patterns/SKILL.md
@@ -9,6 +9,19 @@ description: Use when writing or reviewing Jetpack Compose UI tests, screenshot 
 
 Test the smallest UI contract that proves the behavior. Prefer plain state-driven UI tests with callbacks. Add integration only when lifecycle, navigation, DI, or platform behavior is the thing under test.
 
+## Procedure
+
+1. State the behavior and test concern the task asks you to prove.
+2. Inspect the existing test against that concern and choose the smallest
+   sufficient seam from the table below.
+3. Keep focused edits within the requested test concern. Do not move test-only
+   helpers into production or broaden production APIs unless that production
+   boundary is itself under test.
+4. Drive controlled state or input, synchronize through Compose when needed,
+   and assert an observable semantic, visual, or callback result.
+5. Finish with no edit when the existing test already uses the narrowest valid
+   seam and proves the requested behavior.
+
 ## Test target choice
 
 | What you need to prove | Test shape |
@@ -74,6 +87,12 @@ assertThat(selectedId).isEqualTo("movie-1")
 ```
 
 For plain captured callback values, a direct assertion after the action is usually enough. Use `runOnIdle` when the assertion needs Compose to finish applying snapshot state, recomposition, or queued UI work before reading the result.
+
+## Keep UI tests deterministic
+
+For layout, branch, and callback behavior, render controlled state with `setContent` instead of constructing the production app graph. Production DI, repositories, lifecycle observers, and background effects add asynchronous work that is irrelevant to a plain UI contract and can make the test flaky.
+
+Do not use `Thread.sleep` to wait for Compose. Drive the UI to a known state, then use semantic assertions and Compose synchronization (`waitForIdle`, `runOnIdle`, or a bounded `waitUntil` for a real asynchronous condition). Reserve full-app integration for behavior that actually depends on navigation, lifecycle, DI, or platform wiring.
 
 ## Interaction state with MutableInteractionSource
 
@@ -163,6 +182,8 @@ When image appearance matters, provide a deterministic local painter/bitmap inst
 | Semantics test for padding/color/focus ring | Use screenshot test |
 | Test tags everywhere | Prefer text/content description/role when stable |
 | UI test depends on real image loading/network/time | Fake or freeze the source |
+| Sleeping after an action before asserting UI | Use semantics plus `waitForIdle`, `runOnIdle`, or bounded `waitUntil` |
+| Production DI or app wiring for a state/rendering assertion | Render controlled state with `setContent`; use integration only when that wiring is under test |
 | Simulating hover/press/focus with mouse or touch events | Inject `MutableInteractionSource` and emit the interaction |
 | Relying on the default `InteractionSource` in tests | Pass `MutableInteractionSource` so you can control state |
 | TV/keyboard UI tested with `performClick` only | Use key input and focus assertions; see [compose-focus-navigation](../compose-focus-navigation/SKILL.md) |
@@ -176,3 +197,13 @@ When image appearance matters, provide a deterministic local painter/bitmap inst
 - Focus behavior is visually inspected but not asserted.
 - A test uses `performMouseInput` or touch injection to trigger hover/press states instead of `MutableInteractionSource.emit`.
 - A composable accepts `interactionSource` but tests don't inject `MutableInteractionSource`.
+- A plain rendering test starts the production app or uses `Thread.sleep` before asserting.
+
+## RED/GREEN agent scenarios
+
+1. RED launches a production app, waits with `Thread.sleep`, and only asserts that a node exists. GREEN renders fixed state with `setContent`, drives the action, synchronizes through Compose, and asserts the semantic state or callback result.
+2. Novel case: a screen's repository-backed state holder starts background work, but the test only needs to prove a disabled Save button. GREEN tests the plain UI state directly; a separate integration test covers the state-holder wiring if needed.
+3. Counterexample: navigation behavior depends on a real `NavController` lifecycle. GREEN uses an integration test rather than pretending a plain rendering test proves that contract.
+4. Focused counterexample: a value-only formatter test already uses a plain unit
+   test and the task asks only whether it needs a UI harness. GREEN leaves the
+   test-local helper and workspace unchanged.


### PR DESCRIPTION
## Summary

- publish the certified per-skill Compose evaluation scorecard and its interpretation caveats
- harden subject and judge isolation, validator semantics, and persisted rejudgment reporting
- refine Compose component, performance, state/effects, and UI-testing guidance from audited disagreements
- add four calibration-only Compose performance challenges without changing the 38-case scored benchmark

## Why

The evaluation audit found both genuine skill-guidance gaps and evaluator issues. Some valid answers were rejected by overly narrow validators or rubrics, while a few skills needed more explicit finish gates, repair ordering, scope restraint, and test-seam guidance.

This change repairs those problems and records the resulting advisory evidence. The certification retains unaffected conditions from the previous complete benchmark and uses current three-repetition reruns for every condition affected by the finalized edits; it is not represented as a newly executed all-condition run.

## Results and impact

- aggregate positive outcomes: 82.7% baseline, 100.0% forced, 100.0% automatic
- reported automatic routing: 89.4% precision, 97.7% recall
- forced and automatic negative-control restraint: 100.0%
- the four new performance calibration cases passed in both no-skill and forced arms in a one-repetition probe, so they remain explicitly excluded from default plans and published scores
- the default benchmark remains 38 cases, three arms, and 684 model calls
- plugin and skill versions are unchanged

These scores remain descriptive and do not gate merges or releases.

## Validation

- `npm test`
- `npm run lint`
- `npm run evals:validate` — 42 valid cases, including four calibration-only cases
- default three-repetition plan — 38 scored cases and 684 calls
- `git diff --cached --check`
