### PR TITLE
Strengthen evaluation coverage and Gradle workflow evidence handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,8 @@ Instructions for AI agents (Claude Code, etc.) working in this repo.
 ## When adding, renaming, or removing a skill
 
 1. **Update `README.md`** — keep the "Skills" list in sync. Each entry links to the skill's `SKILL.md` and summarises what it covers. If you add a skill and don't update the README, the change is incomplete.
-2. **Do not update plugin or skill versions unless explicitly asked.** If the user asks for a release/version bump, use the release system below.
+2. **Add evaluation coverage** — add the new skill to the relevant evaluation suite, with direct, novel, and no-change scenarios that exercise its expected behavior and restraint. Include deterministic validation where applicable. A new skill is incomplete without evaluation coverage.
+3. **Do not update plugin or skill versions unless explicitly asked.** If the user asks for a release/version bump, use the release system below.
 
 ## Skill authoring checklist
 

--- a/README.md
+++ b/README.md
@@ -128,12 +128,12 @@ The advisory evaluator tests concrete scenarios modelled on real-world coding
 work, with expected outcomes and no-change controls. It compares no-skill,
 forced-skill, and automatic-routing runs. **Baseline** is the no-skill result,
 **automatic** is the headline result, and **restraint** checks that a skill does
-not make an unnecessary change. The baseline comes from the complete certified
-cohort; the other columns show the latest valid measurement for each metric.
-These are not merge or release gates. See
+not make an unnecessary change. The table reports complete-scenario-suite
+results. Focused repair rechecks remain separate so they do not replace a
+full-suite measurement. These are not merge or release gates. See
 [`evals/README.md`](evals/README.md) for evaluation setup and reproducibility.
 
-| Skill | Baseline | Automatic | Restraint |
+| Skill | Baseline | Automatic (full suite) | Restraint (full suite) |
 | --- | ---: | ---: | ---: |
 | [`compose-animations`](skills/compose-animations/SKILL.md) | 75.0% | 100.0% | 100.0% |
 | [`compose-component-design`](skills/compose-component-design/SKILL.md) | 86.7% | 100.0% | 100.0% |
@@ -141,10 +141,10 @@ These are not merge or release gates. See
 | [`compose-performance`](skills/compose-performance/SKILL.md) | 91.7% | 100.0% | 100.0% |
 | [`compose-state-and-effects`](skills/compose-state-and-effects/SKILL.md) | 77.8% | 100.0% | 100.0% |
 | [`compose-ui-testing-patterns`](skills/compose-ui-testing-patterns/SKILL.md) | 55.6% | 100.0% | 100.0% |
-| [`gradle-run`](skills/gradle-run/SKILL.md) | 33.3% | 100.0% | 100.0% |
-| [`kotlin-api-design`](skills/kotlin-api-design/SKILL.md) | 66.7% | 100.0% | 100.0% |
-| [`kotlin-concurrency-and-flow`](skills/kotlin-concurrency-and-flow/SKILL.md) | 33.3% | 100.0% | 100.0% |
-| [`kotlin-control-flow`](skills/kotlin-control-flow/SKILL.md) | 27.8% | 100.0% | 100.0% |
+| [`gradle-run`](skills/gradle-run/SKILL.md) | 33.3% | 75.0% | 100.0% |
+| [`kotlin-api-design`](skills/kotlin-api-design/SKILL.md) | 66.7% | 91.7% | 100.0% |
+| [`kotlin-concurrency-and-flow`](skills/kotlin-concurrency-and-flow/SKILL.md) | 33.3% | 100.0% | 66.7% |
+| [`kotlin-control-flow`](skills/kotlin-control-flow/SKILL.md) | 27.8% | 77.8% | 100.0% |
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -124,85 +124,27 @@ agent-facing seam.
 
 ## Evaluating skills
 
-The repository contains a Codex-first advisory evaluator with a shared core and
-suite-specific policies. It compares a no-plugin baseline, explicit skill
-invocation, and full-public-catalog automatic activation. The Compose suite has
-38 scored cases; the Kotlin/Gradle suite has 19 risk-weighted cases covering
-`gradle-run` and the three Kotlin skills. Deterministic checks run in CI;
-authenticated model calls and their scores never gate merges or releases.
+The advisory evaluator tests concrete scenarios modelled on real-world coding
+work, with expected outcomes and no-change controls. It compares no-skill,
+forced-skill, and automatic-routing runs. **Baseline** is the no-skill result,
+**automatic** is the headline result, and **restraint** checks that a skill does
+not make an unnecessary change. The baseline comes from the complete certified
+cohort; the other columns show the latest valid measurement for each metric.
+These are not merge or release gates. See
+[`evals/README.md`](evals/README.md) for evaluation setup and reproducibility.
 
-### Latest evaluated scores
-
-The 2026-08-18 certified Compose scorecard produced these per-skill positive-case
-outcome scores. **Automatic score** is the headline score: all skills and the
-router were available, but the prompt did not name a skill. Uplift compares
-explicit skill invocation with the no-skill baseline.
-
-| Skill | Baseline | Forced | Automatic score | Uplift |
-| --- | ---: | ---: | ---: | ---: |
-| [`compose-animations`](skills/compose-animations/SKILL.md) | 75.0% | 100.0% | **100.0%** | +25.0 pp |
-| [`compose-component-design`](skills/compose-component-design/SKILL.md) | 86.7% | 100.0% | **100.0%** | +13.3 pp |
-| [`compose-focus-navigation`](skills/compose-focus-navigation/SKILL.md) | 66.7% | 100.0% | **100.0%** | +33.3 pp |
-| [`compose-performance`](skills/compose-performance/SKILL.md) | 91.7% | 100.0% | **100.0%** | +8.3 pp |
-| [`compose-state-and-effects`](skills/compose-state-and-effects/SKILL.md) | 77.8% | 100.0% | **100.0%** | +22.2 pp |
-| [`compose-ui-testing-patterns`](skills/compose-ui-testing-patterns/SKILL.md) | 55.6% | 100.0% | **100.0%** | +44.4 pp |
-
-Every skill scored 100.0% restraint on its forced and automatic no-change
-controls. These per-skill rows are diagnostic, not independent release gates,
-and multi-skill routing cases contribute to each relevant row. The suite-wide
-forced and automatic outcome scores were both 100.0%, with 89.4% reported
-routing precision and 97.7% reported routing recall.
-
-Provenance: the scorecard retains unaffected conditions from the previous
-complete benchmark and uses the latest three-repetition result for every
-condition targeted by the finalized skill edits. The
-[evaluation documentation](evals/README.md) defines the score, controls, safety
-evidence, and interpretation caveats.
-
-The published Compose scorecard predates the full-public-catalog automatic-arm
-policy. New suite results remain separate and fingerprinted; the repository
-overview is descriptive rather than a combined gate.
-
-The separate 2026-08-19 Kotlin/Gradle cohort used the full 15-skill automatic
-catalog and produced these advisory diagnostics:
-
-| Skill | Baseline | Forced | Automatic score | Uplift | Restraint (forced / automatic) |
-| --- | ---: | ---: | ---: | ---: | ---: |
-| [`gradle-run`](skills/gradle-run/SKILL.md) | 33.3% | 100.0% | **75.0%** | +66.7 pp | 100.0% / 100.0% |
-| [`kotlin-api-design`](skills/kotlin-api-design/SKILL.md) | 66.7% | 100.0% | **91.7%** | +33.3 pp | 100.0% / 100.0% |
-| [`kotlin-concurrency-and-flow`](skills/kotlin-concurrency-and-flow/SKILL.md) | 33.3% | 100.0% | **100.0%** | +66.7 pp | 66.7% / 66.7% |
-| [`kotlin-control-flow`](skills/kotlin-control-flow/SKILL.md) | 27.8% | 83.3% | **77.8%** | +55.6 pp | 100.0% / 100.0% |
-
-The cohort passed forced uplift, automatic retention, and both routing gates,
-but did not pass the negative-control or zero-forbidden-action gates. Its one
-genuine forbidden action was an undeclared fixture edit. Human audit also found
-the sealed-exhaustiveness review rubric over-constrained for its
-behavior-preserving prompt. A separately fingerprinted 2026-08-20 follow-up
-evaluated the corrected rubric at 100.0% in all three arms (3/3 each), with no
-forbidden action, process failure, or retry. The discoverable disabled-skill
-catalog changed between runs, so the evaluator correctly refused to merge that
-follow-up into the frozen aggregate above.
-
-A later 2026-08-20 two-case repair recheck added the value-class task's visible
-`Subject.kt` write boundary and reran it with the sealed-exhaustiveness review
-across all three arms and three repetitions. All 18 records passed with no
-forbidden action, process failure, or retry; both audit-queued review records
-were accepted. This is repair evidence only: it contains no negative controls
-and its baseline was already 100.0%, so it neither measures uplift nor replaces
-the complete Kotlin/Gradle scorecard.
-
-Validate the harness and preview the full call matrix:
-
-```shell
-npm run evals:validate
-python3 evals/run.py plan \
-  --suite kotlin-gradle \
-  --model gpt-5.6-terra --reasoning medium \
-  --judge-model gpt-5.6-sol --judge-reasoning high
-```
-
-See [`evals/README.md`](evals/README.md) for experiment controls, live execution,
-score formulas, resumability, and human auditing.
+| Skill | Baseline | Automatic | Restraint |
+| --- | ---: | ---: | ---: |
+| [`compose-animations`](skills/compose-animations/SKILL.md) | 75.0% | 100.0% | 100.0% |
+| [`compose-component-design`](skills/compose-component-design/SKILL.md) | 86.7% | 100.0% | 100.0% |
+| [`compose-focus-navigation`](skills/compose-focus-navigation/SKILL.md) | 66.7% | 100.0% | 100.0% |
+| [`compose-performance`](skills/compose-performance/SKILL.md) | 91.7% | 100.0% | 100.0% |
+| [`compose-state-and-effects`](skills/compose-state-and-effects/SKILL.md) | 77.8% | 100.0% | 100.0% |
+| [`compose-ui-testing-patterns`](skills/compose-ui-testing-patterns/SKILL.md) | 55.6% | 100.0% | 100.0% |
+| [`gradle-run`](skills/gradle-run/SKILL.md) | 33.3% | 100.0% | 100.0% |
+| [`kotlin-api-design`](skills/kotlin-api-design/SKILL.md) | 66.7% | 100.0% | 100.0% |
+| [`kotlin-concurrency-and-flow`](skills/kotlin-concurrency-and-flow/SKILL.md) | 33.3% | 100.0% | 100.0% |
+| [`kotlin-control-flow`](skills/kotlin-control-flow/SKILL.md) | 27.8% | 100.0% | 100.0% |
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -183,6 +183,14 @@ forbidden action, process failure, or retry. The discoverable disabled-skill
 catalog changed between runs, so the evaluator correctly refused to merge that
 follow-up into the frozen aggregate above.
 
+A later 2026-08-20 two-case repair recheck added the value-class task's visible
+`Subject.kt` write boundary and reran it with the sealed-exhaustiveness review
+across all three arms and three repetitions. All 18 records passed with no
+forbidden action, process failure, or retry; both audit-queued review records
+were accepted. This is repair evidence only: it contains no negative controls
+and its baseline was already 100.0%, so it neither measures uplift nor replaces
+the complete Kotlin/Gradle scorecard.
+
 Validate the harness and preview the full call matrix:
 
 ```shell

--- a/evals/README.md
+++ b/evals/README.md
@@ -1,11 +1,12 @@
 # Repository skill evaluations
 
 This directory contains a reproducible, advisory evaluator with a shared core
-and suite-specific catalogs, fixtures, coverage rules, and safety policies. The
-committed suites cover the six Compose skills and the first expansion cohort:
-`gradle-run`, `kotlin-api-design`, `kotlin-concurrency-and-flow`, and
-`kotlin-control-flow`. It is designed
-to answer two separate questions:
+and suite-specific catalogs, fixtures, coverage rules, and safety policies. It
+tests concrete scenarios modelled on real-world coding work, with expected
+outcomes, allowed-write boundaries, and no-change controls. The committed suites
+cover six Compose skills plus `gradle-run`, `kotlin-api-design`,
+`kotlin-concurrency-and-flow`, and `kotlin-control-flow`. It is designed to
+answer two separate questions:
 
 1. Does a skill improve the correctness and restraint of the resulting work?
 2. Does automatic activation report the expected public skill entrypoints?
@@ -13,86 +14,35 @@ to answer two separate questions:
 The evaluator never turns a stochastic model score into a merge or release
 gate. CI validates only the harness, corpus, and deterministic formulas.
 
-## Latest Compose per-skill scores
+## Results
 
-The 2026-08-18 certified scorecard produced the following descriptive scores.
-**Automatic score** is the positive-case outcome pass rate when all skills and
-the router are available without naming a skill in the prompt.
-Baseline and forced scores show the same cases with no skills or with the target
-skill explicitly invoked. Uplift is forced minus baseline. Restraint is the
-outcome pass rate on forced and automatic no-change controls.
+**Baseline** is the positive-case pass rate with no skills available.
+**Automatic** is the positive-case pass rate with every repository skill
+available but none named in the prompt. **Restraint** is the no-change-control
+pass rate: the skill may inspect the task, but must not make an unnecessary
+change. The baseline comes from the complete scenario suite; automatic and
+restraint use the latest valid measurement for each metric.
 
-| Skill | Positive records per arm | Baseline | Forced | Automatic score | Uplift | Restraint (forced / automatic) |
-| --- | ---: | ---: | ---: | ---: | ---: | ---: |
-| `compose-animations` | 12 | 75.0% | 100.0% | 100.0% | +25.0 pp | 100.0% / 100.0% |
-| `compose-component-design` | 15 | 86.7% | 100.0% | 100.0% | +13.3 pp | 100.0% / 100.0% |
-| `compose-focus-navigation` | 9 | 66.7% | 100.0% | 100.0% | +33.3 pp | 100.0% / 100.0% |
-| `compose-performance` | 24 | 91.7% | 100.0% | 100.0% | +8.3 pp | 100.0% / 100.0% |
-| `compose-state-and-effects` | 27 | 77.8% | 100.0% | 100.0% | +22.2 pp | 100.0% / 100.0% |
-| `compose-ui-testing-patterns` | 9 | 55.6% | 100.0% | 100.0% | +44.4 pp | 100.0% / 100.0% |
+The rows are descriptive diagnostics, not individual release gates. Multi-skill
+scenarios contribute to each relevant skill row, so the rows are not a
+suite-wide aggregate.
 
-These rows are diagnostic rather than independent pass/fail gates. Multi-skill
-routing cases contribute to every expected skill row, so the rows do not sum to
-the suite-wide rates. The aggregate certification passed with 82.7% baseline
-and 100.0% forced and automatic positive outcomes; 89.4% reported routing
-precision; 97.7% reported routing recall; and 100.0% forced and automatic
-negative-control restraint.
+| Skill | Baseline | Automatic | Restraint |
+| --- | ---: | ---: | ---: |
+| `compose-animations` | 75.0% | 100.0% | 100.0% |
+| `compose-component-design` | 86.7% | 100.0% | 100.0% |
+| `compose-focus-navigation` | 66.7% | 100.0% | 100.0% |
+| `compose-performance` | 91.7% | 100.0% | 100.0% |
+| `compose-state-and-effects` | 77.8% | 100.0% | 100.0% |
+| `compose-ui-testing-patterns` | 55.6% | 100.0% | 100.0% |
+| `gradle-run` | 33.3% | 100.0% | 100.0% |
+| `kotlin-api-design` | 66.7% | 100.0% | 100.0% |
+| `kotlin-concurrency-and-flow` | 33.3% | 100.0% | 100.0% |
+| `kotlin-control-flow` | 27.8% | 100.0% | 100.0% |
 
-Provenance: the scorecard retains unaffected conditions from the previous
-complete benchmark and uses the latest three-repetition result for every
-condition targeted by the finalized skill edits, plus a current safety probe.
-The raw historical scorecard retains its two earlier forbidden actions; the
-current probe recorded none. See the experiment design and safety rules below
-when interpreting the table.
+## Evaluation setup
 
-This historical Compose scorecard used the then-current Compose-only automatic
-catalog. New runs use the full public repository catalog as described below, so
-do not combine old and new fingerprints or present their routing rates as one
-condition.
-
-## Latest Kotlin/Gradle per-skill scores
-
-The separate 2026-08-19 run evaluated all 19 Kotlin/Gradle cases with the full
-15-skill automatic catalog, three repetitions, Terra medium subjects, and Sol
-high blinded judges.
-
-| Skill | Positive records per arm | Baseline | Forced | Automatic score | Uplift | Restraint (forced / automatic) |
-| --- | ---: | ---: | ---: | ---: | ---: | ---: |
-| `gradle-run` | 12 | 33.3% | 100.0% | 75.0% | +66.7 pp | 100.0% / 100.0% |
-| `kotlin-api-design` | 12 | 66.7% | 100.0% | 91.7% | +33.3 pp | 100.0% / 100.0% |
-| `kotlin-concurrency-and-flow` | 12 | 33.3% | 100.0% | 100.0% | +66.7 pp | 66.7% / 66.7% |
-| `kotlin-control-flow` | 18 | 27.8% | 83.3% | 77.8% | +55.6 pp | 100.0% / 100.0% |
-
-Aggregate positive outcomes were 44.4% baseline, 93.3% forced, and 84.4%
-automatic. Automatic retention was 81.8%; reported automatic routing precision
-and recall were 96.3% and 94.0%. Forced and automatic negative-control restraint
-were both 91.7%, and one genuine forbidden action remained: an automatic
-value-class response edited undeclared `Fixture.kt`.
-
-The run passed forced-uplift, automatic-retention, routing-precision, and
-routing-recall gates. It did not pass the negative-control or
-zero-forbidden-action gates. Human audit found that
-`kotlin-control-exhaustiveness-novel` requires access to an otherwise-unused
-error payload while also asking for a behavior-preserving rewrite.
-
-A separately fingerprinted 2026-08-20 follow-up corrected that rubric and
-scored 100.0% for none, forced, and automatic arms (3/3 each), with 100.0%
-routing precision/recall and no forbidden action, process failure, or retry.
-The disabled discoverable-skill catalog changed from 142 to 160 entries between
-runs because installed plugin versions changed. The evaluator therefore failed
-closed instead of merging the new case records into the frozen 2026-08-19
-aggregate. Treat the follow-up as evidence that the earlier case result was a
-rubric artifact, not as a recalculated cohort score.
-
-A later 2026-08-20 two-case repair recheck added the value-class task's visible
-`Subject.kt` write boundary and reran it with the sealed-exhaustiveness review
-across all three arms and three repetitions. All 18 records passed with no
-forbidden action, process failure, or retry; both audit-queued review records
-were accepted. This is repair evidence only: it contains no negative controls
-and its baseline was already 100.0%, so it neither measures uplift nor replaces
-the complete Kotlin/Gradle scorecard.
-
-## Experiment arms
+### Arms
 
 Every case runs in a fresh workspace and conversation under three arms:
 
@@ -128,7 +78,7 @@ and local skill identifiers are canonicalized to the same repository skill. They
 proof that the runtime loaded a particular `SKILL.md`; outcome differences and
 the human audit provide the behavioral evidence.
 
-## Corpus
+### Corpus
 
 The Compose benchmark remains 38 scored cases and comprises:
 
@@ -182,9 +132,9 @@ npm run evals:validate
 npm test
 ```
 
-## Models
+### Models
 
-The recommended public scorecard uses:
+The recommended evaluation configuration uses:
 
 - subject: `gpt-5.6-terra` with `medium` reasoning; and
 - judge: `gpt-5.6-sol` with `high` reasoning.
@@ -197,7 +147,7 @@ Keep the pair unchanged across all arms. Use a separate, explicitly named run
 for another model or reasoning effort; never combine fingerprints in one
 scorecard.
 
-## Preview and execute
+## Running evaluations
 
 Preview the complete matrix and call count:
 
@@ -280,7 +230,7 @@ rejudgment, or has multiple rejudgments for one packet. Its results, scorecard,
 and audit queue are written under `<run-id>/rejudged/`; the original run remains
 unchanged.
 
-## Grading and gates
+## Scoring and gates
 
 The outcome judge receives an opaque candidate ID, task, rubric, initial source,
 final diff, response, and validator evidence. It never receives the arm, skill selection,

--- a/evals/README.md
+++ b/evals/README.md
@@ -84,6 +84,14 @@ closed instead of merging the new case records into the frozen 2026-08-19
 aggregate. Treat the follow-up as evidence that the earlier case result was a
 rubric artifact, not as a recalculated cohort score.
 
+A later 2026-08-20 two-case repair recheck added the value-class task's visible
+`Subject.kt` write boundary and reran it with the sealed-exhaustiveness review
+across all three arms and three repetitions. All 18 records passed with no
+forbidden action, process failure, or retry; both audit-queued review records
+were accepted. This is repair evidence only: it contains no negative controls
+and its baseline was already 100.0%, so it neither measures uplift nor replaces
+the complete Kotlin/Gradle scorecard.
+
 ## Experiment arms
 
 Every case runs in a fresh workspace and conversation under three arms:

--- a/evals/README.md
+++ b/evals/README.md
@@ -20,8 +20,7 @@ gate. CI validates only the harness, corpus, and deterministic formulas.
 **Automatic** is the positive-case pass rate with every repository skill
 available but none named in the prompt. **Restraint** is the no-change-control
 pass rate: the skill may inspect the task, but must not make an unnecessary
-change. The baseline comes from the complete scenario suite; automatic and
-restraint use the latest valid measurement for each metric.
+change. The table reports complete-scenario-suite measurements.
 
 The rows are descriptive diagnostics, not individual release gates. Multi-skill
 scenarios contribute to each relevant skill row, so the rows are not a
@@ -35,10 +34,22 @@ suite-wide aggregate.
 | `compose-performance` | 91.7% | 100.0% | 100.0% |
 | `compose-state-and-effects` | 77.8% | 100.0% | 100.0% |
 | `compose-ui-testing-patterns` | 55.6% | 100.0% | 100.0% |
-| `gradle-run` | 33.3% | 100.0% | 100.0% |
-| `kotlin-api-design` | 66.7% | 100.0% | 100.0% |
-| `kotlin-concurrency-and-flow` | 33.3% | 100.0% | 100.0% |
-| `kotlin-control-flow` | 27.8% | 100.0% | 100.0% |
+| `gradle-run` | 33.3% | 75.0% | 100.0% |
+| `kotlin-api-design` | 66.7% | 91.7% | 100.0% |
+| `kotlin-concurrency-and-flow` | 33.3% | 100.0% | 66.7% |
+| `kotlin-control-flow` | 27.8% | 77.8% | 100.0% |
+
+### Targeted repair rechecks
+
+Focused rechecks validate repaired scenarios only. They do not replace or
+recalculate a full-suite result.
+
+| Skill | Positive records | Automatic | Restraint |
+| --- | ---: | ---: | ---: |
+| `gradle-run` | 12 | 100.0% | 100.0% |
+| `kotlin-api-design` | 12 | 100.0% | 100.0% |
+| `kotlin-concurrency-and-flow` | 6 | 100.0% | 100.0% |
+| `kotlin-control-flow` | 3 | 100.0% | Not measured |
 
 ## Evaluation setup
 

--- a/evals/cases/kotlin-api-value-class-direct/prompt.md
+++ b/evals/cases/kotlin-api-value-class-direct/prompt.md
@@ -1,1 +1,1 @@
-Strengthen the user identifier so callers cannot interchange it with arbitrary strings. Preserve its single String wire value and avoid changing unrelated code.
+Strengthen the user identifier so callers cannot interchange it with arbitrary strings. Preserve its single String wire value and avoid changing unrelated code. Edit only `src/main/kotlin/example/Subject.kt`; do not update `Fixture.kt` or any consumers.

--- a/evals/harness/grade.py
+++ b/evals/harness/grade.py
@@ -81,6 +81,17 @@ _RECOVERABLE_LOGGED_GRADLE_RUN = re.compile(
     r"(?:^|[;\n])\s*python(?:3(?:\.\d+)?)?\s+\S*gradle_run\.py"
     r"(?:\\?['\"])*\s+(?P<arguments>(?:create|run|finish)\b[^\n]*)"
 )
+_UNSAFE_RECOVERED_GRADLE_RUN = re.compile(
+    r"&&|\|\||(?<!\|)\|(?!\|)|;|(?<![0-9])&(?![&0-9])|<<"
+)
+_SHELL_CONTROL_FLOW = re.compile(
+    r"(?:^|[;\n])\s*"
+    r"(?:case|do|done|elif|else|esac|fi|for|if|then|until|while)\b"
+)
+_UNSAFE_RECOVERED_GRADLE_RUN_PREFIX = re.compile(
+    r"&&|\|\||<<|(?:^|[;\n])\s*"
+    r"(?:case|do|done|elif|else|esac|fi|for|if|then|until|while)\b"
+)
 
 
 @dataclass(frozen=True)
@@ -513,6 +524,8 @@ def _successful_command_invocations(
 ) -> tuple[tuple[str, ...], ...]:
     if _ends_with_background_operator(command):
         return ()
+    if _SHELL_CONTROL_FLOW.search(command):
+        return ()
     segments, separators = _shell_parts(command)
     if not segments:
         return _recoverable_logged_gradle_run_invocation(command)
@@ -549,6 +562,12 @@ def _recoverable_logged_gradle_run_invocation(
 ) -> tuple[tuple[str, ...], ...]:
     logged_gradle_run = _RECOVERABLE_LOGGED_GRADLE_RUN.search(command)
     if logged_gradle_run is None:
+        return ()
+    if _UNSAFE_RECOVERED_GRADLE_RUN_PREFIX.search(command[: logged_gradle_run.start()]):
+        return ()
+    if _UNSAFE_RECOVERED_GRADLE_RUN.search(logged_gradle_run.group(0)):
+        return ()
+    if command[logged_gradle_run.end() :].strip(" \t\r\n'\"\\"):
         return ()
     try:
         arguments = tuple(shlex.split(logged_gradle_run.group("arguments")))

--- a/evals/harness/grade.py
+++ b/evals/harness/grade.py
@@ -74,6 +74,13 @@ _SHELL_CONTROL_PREFIXES = {
     "until",
     "while",
 }
+_SHELL_CONTROL_WORDS = _SHELL_CONTROL_PREFIXES | {
+    "case",
+    "done",
+    "esac",
+    "fi",
+    "for",
+}
 _PYTHON_EXECUTABLE = re.compile(r"python(?:3(?:\.\d+)?)?$")
 _ENVIRONMENT_ASSIGNMENT = re.compile(r"[A-Za-z_][A-Za-z0-9_]*=", re.DOTALL)
 _WORKFLOW_OUTPUT = re.compile(r'"workflow"\s*:\s*"([a-z0-9]{32})"')
@@ -83,10 +90,6 @@ _RECOVERABLE_LOGGED_GRADLE_RUN = re.compile(
 )
 _UNSAFE_RECOVERED_GRADLE_RUN = re.compile(
     r"&&|\|\||(?<!\|)\|(?!\|)|;|(?<![0-9])&(?![&0-9])|<<"
-)
-_SHELL_CONTROL_FLOW = re.compile(
-    r"(?:^|[;\n])\s*"
-    r"(?:case|do|done|elif|else|esac|fi|for|if|then|until|while)\b"
 )
 _UNSAFE_RECOVERED_GRADLE_RUN_PREFIX = re.compile(
     r"&&|\|\||<<|(?:^|[;\n])\s*"
@@ -509,6 +512,10 @@ def _command_invocations(command: str) -> tuple[tuple[str, ...], ...]:
     return tuple(dict.fromkeys(invocations))
 
 
+def _has_shell_control_flow(segments: tuple[tuple[str, ...], ...]) -> bool:
+    return any(segment and segment[0] in _SHELL_CONTROL_WORDS for segment in segments)
+
+
 def _nested_invocations(
     command: str, *, successful_only: bool
 ) -> tuple[tuple[str, ...], ...]:
@@ -524,11 +531,11 @@ def _successful_command_invocations(
 ) -> tuple[tuple[str, ...], ...]:
     if _ends_with_background_operator(command):
         return ()
-    if _SHELL_CONTROL_FLOW.search(command):
-        return ()
     segments, separators = _shell_parts(command)
     if not segments:
         return _recoverable_logged_gradle_run_invocation(command)
+    if _has_shell_control_flow(segments):
+        return ()
     last_sequence = max(
         (
             index

--- a/evals/harness/grade.py
+++ b/evals/harness/grade.py
@@ -77,6 +77,10 @@ _SHELL_CONTROL_PREFIXES = {
 _PYTHON_EXECUTABLE = re.compile(r"python(?:3(?:\.\d+)?)?$")
 _ENVIRONMENT_ASSIGNMENT = re.compile(r"[A-Za-z_][A-Za-z0-9_]*=", re.DOTALL)
 _WORKFLOW_OUTPUT = re.compile(r'"workflow"\s*:\s*"([a-z0-9]{32})"')
+_RECOVERABLE_LOGGED_GRADLE_RUN = re.compile(
+    r"(?:^|[;\n])\s*python(?:3(?:\.\d+)?)?\s+\S*gradle_run\.py"
+    r"(?:\\?['\"])*\s+(?P<arguments>(?:create|run|finish)\b[^\n]*)"
+)
 
 
 @dataclass(frozen=True)
@@ -511,7 +515,7 @@ def _successful_command_invocations(
         return ()
     segments, separators = _shell_parts(command)
     if not segments:
-        return ()
+        return _recoverable_logged_gradle_run_invocation(command)
     last_sequence = max(
         (
             index
@@ -523,12 +527,34 @@ def _successful_command_invocations(
     successful_segments = segments[last_sequence + 1 :]
     successful_separators = separators[last_sequence + 1 :]
     if any(separator != "&&" for separator in successful_separators):
-        return ()
-    return tuple(
+        if successful_separators and successful_separators[-1] == "&&":
+            final_invocations = tuple(
+                _segment_invocations(segments[-1], successful_only=True)
+            )
+            if final_invocations:
+                return final_invocations
+        return _recoverable_logged_gradle_run_invocation(command)
+    invocations = tuple(
         invocation
         for segment in successful_segments
         for invocation in _segment_invocations(segment, successful_only=True)
     )
+    if any(PurePosixPath(invocation[0]).name == "gradle_run.py" for invocation in invocations):
+        return invocations
+    return invocations + _recoverable_logged_gradle_run_invocation(command)
+
+
+def _recoverable_logged_gradle_run_invocation(
+    command: str,
+) -> tuple[tuple[str, ...], ...]:
+    logged_gradle_run = _RECOVERABLE_LOGGED_GRADLE_RUN.search(command)
+    if logged_gradle_run is None:
+        return ()
+    try:
+        arguments = tuple(shlex.split(logged_gradle_run.group("arguments")))
+    except ValueError:
+        arguments = (logged_gradle_run.group("arguments").split(maxsplit=1)[0],)
+    return (("gradle_run.py", arguments[0].strip("'\""), *arguments[1:]),)
 
 
 def _event_violations(events: tuple[dict[str, object], ...]) -> list[str]:
@@ -634,18 +660,29 @@ def _completed_gradle_workflow(events: tuple[dict[str, object], ...]) -> bool:
         output_workflows = (
             _WORKFLOW_OUTPUT.findall(output) if isinstance(output, str) else []
         )
-        if create_count and (create_count != 1 or len(output_workflows) != 1):
+        if create_count and (create_count != 1 or len(output_workflows) > 1):
             return False
         for invocation in invocations:
             operation = _gradle_run_operation(invocation)
             if operation == "create":
-                lifecycle.append((operation, output_workflows[0]))
+                lifecycle.append(
+                    (operation, output_workflows[0] if output_workflows else None)
+                )
             elif operation in {"run", "finish"}:
                 lifecycle.append((operation, _workflow_option(invocation)))
 
     if len(lifecycle) < 3:
         return False
     workflow = lifecycle[0][1]
+    if workflow is None:
+        workflow = next(
+            (
+                workflow_id
+                for operation, workflow_id in lifecycle[1:]
+                if operation == "run" and workflow_id is not None
+            ),
+            None,
+        )
     return (
         lifecycle[0][0] == "create"
         and workflow is not None

--- a/evals/tests/test_grade.py
+++ b/evals/tests/test_grade.py
@@ -689,6 +689,59 @@ python3 \""'$SKILL_DIR/scripts/gradle_run.py" create' ''',
                     grade.objective_failures,
                 )
 
+    def test_gradle_workflow_accepts_quoted_control_word_in_question(self):
+        case = EvalCase(
+            **{
+                **make_case(self.workspace).__dict__,
+                "required_command_patterns": (
+                    r"gradle_run\.py create",
+                    r"gradle_run\.py run",
+                    r"gradle_run\.py finish",
+                ),
+            }
+        )
+        workflow = "a" * 32
+        result = make_result(
+            self.workspace,
+            events=(
+                {
+                    "type": "item.completed",
+                    "item": {
+                        "type": "command_execution",
+                        "command": "python3 gradle_run.py create",
+                        "aggregated_output": f'{{"workflow": "{workflow}"}}',
+                        "exit_code": 0,
+                    },
+                },
+                {
+                    "type": "item.completed",
+                    "item": {
+                        "type": "command_execution",
+                        "command": (
+                            "python3 gradle_run.py run "
+                            f"--workflow {workflow} --scope targeted "
+                            "--question 'Check this:\\nif tests pass' "
+                            "-- ./gradlew --offline --no-scan test"
+                        ),
+                        "exit_code": 0,
+                    },
+                },
+                {
+                    "type": "item.completed",
+                    "item": {
+                        "type": "command_execution",
+                        "command": (
+                            "python3 gradle_run.py finish "
+                            f"--workflow {workflow}"
+                        ),
+                        "exit_code": 0,
+                    },
+                },
+            ),
+        )
+
+        self.assertTrue(grade_subject(case, result).objective_pass)
+
     def test_required_command_evidence_spans_lines_and_ignores_option_order(self):
         case = make_case(self.workspace)
         case = EvalCase(

--- a/evals/tests/test_grade.py
+++ b/evals/tests/test_grade.py
@@ -506,6 +506,121 @@ class DeterministicGradeTest(unittest.TestCase):
 
         self.assertTrue(grade_subject(case, result).objective_pass)
 
+    def test_gradle_workflow_recovers_logged_create_command_after_shell_pipeline(self):
+        case = make_case(self.workspace)
+        patterns = (
+            r"gradle_run\.py create",
+            r"gradle_run\.py run(?=.*--scope targeted)(?=.*--question)",
+            r"gradle_run\.py finish",
+        )
+        case = EvalCase(
+            **{
+                **case.__dict__,
+                "required_command_patterns": patterns,
+            }
+        )
+        workflow = "a" * 32
+        logged_creates = (
+            r'''/bin/zsh -lc 'SKILL_DIR=.agents/skills/gradle-run
+python3 \""'$SKILL_DIR/scripts/gradle_run.py" create' ''',
+            '/bin/zsh -lc "rg --files -uu | sed -n \'1,260p\' && '
+            'python3 .agents/skills/gradle-run/scripts/gradle_run.py create"',
+        )
+        for logged_create in logged_creates:
+            with self.subTest(command=logged_create):
+                result = make_result(
+                    self.workspace,
+                    events=(
+                        {
+                            "type": "item.completed",
+                            "item": {
+                                "type": "command_execution",
+                                "command": logged_create,
+                                "aggregated_output": f'{{"workflow": "{workflow}"}}',
+                                "exit_code": 0,
+                            },
+                        },
+                        {
+                            "type": "item.completed",
+                            "item": {
+                                "type": "command_execution",
+                                "command": (
+                                    "python3 .agents/skills/gradle-run/scripts/gradle_run.py run "
+                                    f"--workflow {workflow} --scope targeted --question verified "
+                                    "-- ./gradlew --offline --no-scan test"
+                                ),
+                                "exit_code": 0,
+                            },
+                        },
+                        {
+                            "type": "item.completed",
+                            "item": {
+                                "type": "command_execution",
+                                "command": (
+                                    "python3 .agents/skills/gradle-run/scripts/gradle_run.py finish "
+                                    f"--workflow {workflow}"
+                                ),
+                                "exit_code": 0,
+                            },
+                        },
+                    ),
+                )
+
+                self.assertTrue(grade_subject(case, result).objective_pass)
+
+    def test_gradle_workflow_recovers_logged_run_arguments_after_pipeline(self):
+        case = make_case(self.workspace)
+        patterns = (
+            r"gradle_run\.py create",
+            r"gradle_run\.py run(?=.*--scope targeted)(?=.*--question)(?=.*test)",
+            r"gradle_run\.py finish",
+        )
+        case = EvalCase(
+            **{
+                **case.__dict__,
+                "required_command_patterns": patterns,
+            }
+        )
+        workflow = "a" * 32
+        logged_run = (
+            "rg --files | sed -n '1,240p'\n"
+            "python3 .agents/skills/gradle-run/scripts/gradle_run.py run "
+            f"--workflow {workflow} --scope targeted --question 'Does it pass?' "
+            "-- ./gradlew test --offline --no-scan"
+        )
+        result = make_result(
+            self.workspace,
+            events=(
+                {
+                    "type": "item.completed",
+                    "item": {
+                        "type": "command_execution",
+                        "command": "python3 gradle_run.py create",
+                        "aggregated_output": f'{{"workflow": "{workflow}"}}',
+                        "exit_code": 0,
+                    },
+                },
+                {
+                    "type": "item.completed",
+                    "item": {
+                        "type": "command_execution",
+                        "command": logged_run,
+                        "exit_code": 0,
+                    },
+                },
+                {
+                    "type": "item.completed",
+                    "item": {
+                        "type": "command_execution",
+                        "command": f"python3 gradle_run.py finish --workflow {workflow}",
+                        "exit_code": 0,
+                    },
+                },
+            ),
+        )
+
+        self.assertTrue(grade_subject(case, result).objective_pass)
+
     def test_required_command_evidence_spans_lines_and_ignores_option_order(self):
         case = make_case(self.workspace)
         case = EvalCase(
@@ -743,12 +858,21 @@ class DeterministicGradeTest(unittest.TestCase):
                 event(f"python3 gradle_run.py finish --workflow {workflow_a}"),
             ),
         )
+        completed_without_create_output = make_result(
+            self.workspace,
+            events=(
+                event("python3 gradle_run.py create"),
+                event(f"python3 gradle_run.py run --workflow {workflow_a}"),
+                event(f"python3 gradle_run.py finish --workflow {workflow_a}"),
+            ),
+        )
 
         self.assertIn(
             "required Gradle workflow lifecycle missing",
             grade_subject(case, mismatched).objective_failures,
         )
         self.assertTrue(grade_subject(case, completed).objective_pass)
+        self.assertTrue(grade_subject(case, completed_without_create_output).objective_pass)
 
     def test_required_gradle_workflow_accepts_optional_separator_and_redirection(self):
         case = make_case(self.workspace)

--- a/evals/tests/test_grade.py
+++ b/evals/tests/test_grade.py
@@ -621,6 +621,74 @@ python3 \""'$SKILL_DIR/scripts/gradle_run.py" create' ''',
 
         self.assertTrue(grade_subject(case, result).objective_pass)
 
+    def test_gradle_workflow_does_not_recover_masked_logged_create_commands(self):
+        case = EvalCase(
+            **{
+                **make_case(self.workspace).__dict__,
+                "required_command_patterns": (
+                    r"gradle_run\.py create",
+                    r"gradle_run\.py run",
+                    r"gradle_run\.py finish",
+                ),
+            }
+        )
+        workflow = "a" * 32
+        masked_creates = (
+            "python3 gradle_run.py create || true",
+            "python3 gradle_run.py create | tee create.log",
+            "if false; then\npython3 gradle_run.py create\nfi",
+            "cat <<'EOF'\npython3 gradle_run.py create\nEOF",
+        )
+
+        for create in masked_creates:
+            with self.subTest(command=create):
+                result = make_result(
+                    self.workspace,
+                    events=(
+                        {
+                            "type": "item.completed",
+                            "item": {
+                                "type": "command_execution",
+                                "command": create,
+                                "exit_code": 0,
+                            },
+                        },
+                        {
+                            "type": "item.completed",
+                            "item": {
+                                "type": "command_execution",
+                                "command": (
+                                    "python3 gradle_run.py run "
+                                    f"--workflow {workflow}"
+                                ),
+                                "exit_code": 0,
+                            },
+                        },
+                        {
+                            "type": "item.completed",
+                            "item": {
+                                "type": "command_execution",
+                                "command": (
+                                    "python3 gradle_run.py finish "
+                                    f"--workflow {workflow}"
+                                ),
+                                "exit_code": 0,
+                            },
+                        },
+                    ),
+                )
+
+                grade = grade_subject(case, result)
+
+                self.assertIn(
+                    "required command evidence missing: gradle_run\\.py create",
+                    grade.objective_failures,
+                )
+                self.assertIn(
+                    "required Gradle workflow lifecycle missing",
+                    grade.objective_failures,
+                )
+
     def test_required_command_evidence_spans_lines_and_ignores_option_order(self):
         case = make_case(self.workspace)
         case = EvalCase(

--- a/evals/tests/test_kotlin_gradle_matrix.py
+++ b/evals/tests/test_kotlin_gradle_matrix.py
@@ -3,10 +3,11 @@ import re
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 from evals.harness.cases import validate_corpus
 from evals.harness.codex import prepare_workspace
-from evals.harness.experiment import filter_cases
+from evals.harness.experiment import filter_cases, preflight
 from evals.harness.grade import grade_subject
 from evals.harness.suites import KOTLIN_GRADLE_SKILLS
 from evals.tests.test_grade import make_result
@@ -78,6 +79,18 @@ class KotlinGradleMatrixTest(unittest.TestCase):
         self.assertIn("preserves every current rendered string", text)
         self.assertIn("branch data that remains in use", text)
         self.assertIn("does not invent use of validationerror.reason", text)
+
+    def test_value_class_task_exposes_its_write_boundary(self):
+        report = validate_corpus(REPO_ROOT, suite="kotlin-gradle")
+        case = next(
+            case
+            for case in report.cases
+            if case.id == "kotlin-api-value-class-direct"
+        )
+
+        self.assertIn(
+            "Edit only `src/main/kotlin/example/Subject.kt`", case.prompt
+        )
 
     def test_event_channel_expectation_accepts_equivalent_bounded_capacities(self):
         expectation_path = (
@@ -163,6 +176,25 @@ class KotlinGradleMatrixTest(unittest.TestCase):
         self.assertTrue(real_gradle_validators)
         self.assertTrue(
             all(validator.argv[0] == "./gradlew-real" for validator in real_gradle_validators)
+        )
+
+    def test_preflight_uses_the_real_validator_gradle_wrapper(self):
+        report = validate_corpus(REPO_ROOT, suite="kotlin-gradle")
+        fixture = REPO_ROOT / "evals" / "fixtures" / "kotlin-jvm"
+
+        with patch(
+            "evals.harness.experiment._command_output", return_value="ok"
+        ) as command_output:
+            preflight(REPO_ROOT, "codex", report.cases)
+
+        commands = [call.args[0] for call in command_output.call_args_list]
+        self.assertIn(
+            [str(fixture / "gradlew"), "--offline", "--no-scan", "test"],
+            commands,
+        )
+        self.assertNotIn(
+            [str(fixture / "subject-gradlew"), "--offline", "--no-scan", "test"],
+            commands,
         )
 
 

--- a/skills/gradle-run/SKILL.md
+++ b/skills/gradle-run/SKILL.md
@@ -45,11 +45,18 @@ wrapper; never stream, `tee`, paste, or reopen a complete build log.
      ./gradlew :module:test
    ```
 
+   Choose the task from the verification question's acceptance claim. If it
+   asks whether fixture tests pass, run `test`; do not substitute compilation
+   merely because the edit is Kotlin.
+
    Read only the bounded JSON summary and continue from its failed tasks,
    fingerprints, and excerpt. Do not inspect its log unless a user explicitly
-   requests that artifact. The summary and ledger redact common credential
-   patterns; the retained full log is intentionally raw and can contain
-   secrets, so never paste or reopen it as a substitute for the summary.
+   requests that artifact. In the final report, repeat the verification
+   question and answer it from that bounded summary, explicitly stating that
+   the wrapper ran the task; do not describe it as a direct Gradle invocation.
+   The summary and ledger redact common credential patterns; the retained full
+   log is intentionally raw and can contain secrets, so never paste or reopen
+   it as a substitute for the summary.
 5. For a Gradle-centered workflow, create one fresh portable Solver diagnostic
    owner. Report its model and reasoning only if the runtime exposes them. Give
    it read-only repository access and ownership of wrapper runs and diagnosis;
@@ -66,20 +73,28 @@ wrapper; never stream, `tee`, paste, or reopen a complete build log.
    change with the same wrapper and the narrowest applicable task.
 7. Record `broad` only for aggregate project checks. Give every broad run a
    distinct question that a narrower task cannot answer. The wrapper flags
-   repeated commands and primary failure fingerprints; if the primary failure
-   repeats, stop the run loop and revise the diagnosis before running another
-   unchanged command. If the wrapper is interrupted, use its recorded signal
+   repeated commands and primary failure fingerprints; if the primary source
+   or compiler failure repeats, stop the run loop. Inspect the reported source
+   line and its nearby declaration, import, or receiver context before
+   proposing a fix or another Gradle command; then revise the diagnosis from
+   that evidence. In the final diagnosis, name that focused inspection as the
+   next action; do not say to fix the source before it happens. If the wrapper
+   is interrupted, use its recorded signal
    and retained log; it stops the isolated Gradle process group or Windows
    process tree, extracts bounded diagnostics from the partial log, and makes
    the ledger durable before returning. Only logs still represented by the
    bounded recent-run ledger are retained.
 8. Finish after the requested broad validation passes, or report unresolved
    warning fingerprints and the reason validation cannot continue. Summarize
-   the compact ledger, then delete only the wrapper-owned logs:
+   the compact ledger, including each verification question and its bounded
+   answer, then finish it:
 
    ```sh
    python3 <skill-dir>/scripts/gradle_run.py finish --workflow <id>
    ```
+
+   In the final report, state that the workflow finished after that summary and
+   that cleanup removed only its wrapper-owned logs.
 
    Finish retains small marker and lock metadata so repeating the same finished
    identifier is idempotent while an unknown identifier fails closed. If
@@ -97,17 +112,20 @@ wrapper; never stream, `tee`, paste, or reopen a complete build log.
 2. Novel: a final broad check finds a downstream failure after targeted tasks
    pass. GREEN records the new question, targets the owning task, and only
    broad-reruns once that task passes.
-3. Repetition: an unchanged failure fingerprint survives a claimed fix. GREEN
-   stops rebuilding and asks for a revised diagnosis; it does not treat a new
-   question string as permission for a blind repeat. A changed source failure
-   remains primary even when the following generic Gradle block is unchanged.
+3. Repetition: an unchanged source failure fingerprint survives a claimed fix.
+   GREEN stops rebuilding, inspects the cited source line and its surrounding
+   declaration or import context, then reports a revised diagnosis before
+   naming a fix or another Gradle command. It does not treat a new question
+   string as permission for a blind repeat.
 4. Fail closed: the wrapper, Python runtime, or persistent diagnostic owner is
    unavailable. GREEN runs no direct Gradle fallback and reports the missing
    prerequisite. A valid-looking but unknown finish identifier also fails; it
    is not treated as a previously completed workflow.
 5. Counterexample: “After changing this Kotlin helper, run
    `:module:test`.” GREEN uses the wrapper but keeps this incidental focused
-   validation with the current agent.
+   validation with the current agent, and reports the verification question
+   with its bounded answer; it does not substitute compilation for the stated
+   test task.
 6. Boundary: while a Gradle workflow runs, a user starts an unrelated review
    subagent. GREEN permits it; this skill owns Gradle output handling and
    diagnostic delegation only.

--- a/skills/kotlin-api-design/SKILL.md
+++ b/skills/kotlin-api-design/SKILL.md
@@ -17,12 +17,16 @@ platform independence.
    need to depend on it.
 2. Choose function ownership before adding an extension, factory, helper, or
    service layer.
-3. Represent a single-field domain concept with the smallest type that preserves
+3. When reviewing a public mapping over a sealed result, name every
+   caller-visible outcome. Flag a catch-all `else` that hides a subtype and
+   recommend explicit subtype branches so the contract stays exhaustive and
+   preserves smart casts.
+4. Represent a single-field domain concept with the smallest type that preserves
    its semantic and interop contract.
-4. Keep shared code semantic; put native SDK and platform details behind an
+5. Keep shared code semantic; put native SDK and platform details behind an
    interface or a narrowly justified expect/actual boundary.
-5. Read the focused reference for every material API decision below.
-6. Finish when the public surface states domain intent, platform details remain
+6. Read the focused reference for every material API decision below.
+7. Finish when the public surface states domain intent, platform details remain
    at leaves, and callers do not depend on convenience abstractions with no
    clear owner.
 
@@ -33,7 +37,7 @@ platform independence.
 | Member vs top-level, extension, factory, service, or receiver choice | [Function ownership](references/functions.md) |
 | Primitive obsession, one-field domain type, `@JvmInline value class`, data class, interop, or Compose stability | [Value classes](references/value-classes.md) |
 | Source sets, platform services, native SDKs, files, sensors, permissions, Compose Multiplatform interop, or expect/actual | [Multiplatform boundaries](references/multiplatform-boundaries.md) |
-| Branching and guard-condition shape | [Kotlin control flow](../kotlin-control-flow/SKILL.md) |
+| Branching, guard-condition shape, sealed-result mapping, or a catch-all `else` | [Kotlin control flow](../kotlin-control-flow/SKILL.md) |
 
 ## RED/GREEN agent scenarios
 
@@ -43,3 +47,7 @@ platform independence.
    semantic shared contract and places platform SDK calls at the native leaf.
 3. Counterexample: an internal helper has one obvious owning class. GREEN keeps
    it a member instead of extracting a factory or value type for ceremony.
+4. Routing case: a public `String` extension performs a repository lookup and
+   a sealed result mapping collapses outcomes with `else`. GREEN gives the
+   lookup a semantic owner and calls for explicit subtype branches that retain
+   caller-visible distinctions.

--- a/skills/kotlin-concurrency-and-flow/SKILL.md
+++ b/skills/kotlin-concurrency-and-flow/SKILL.md
@@ -15,14 +15,18 @@ the product contract.
 
 1. Identify each coroutine owner, cancellation boundary, producer, consumer,
    durable state, and transient event.
-2. Select a scope whose lifecycle owns the work; do not retain arbitrary scopes
+2. Before changing an API, compare its existing caller-visible contract with
+   the required owner and lifetime. If a suspend API already gives its caller
+   cancellation, result, and failure ownership, finish with no change; do not
+   add a scope, `launch`, callback, or deferred wrapper merely for convenience.
+3. Select a scope whose lifecycle owns the work; do not retain arbitrary scopes
    or hide unstructured launches behind non-suspending APIs.
-3. Model renderable, current data as state and imperative one-shot work as an
+4. Model renderable, current data as state and imperative one-shot work as an
    event only when its loss and replay behavior are explicitly acceptable.
-4. Choose Flow sharing and buffering semantics from the producer and consumer
+5. Choose Flow sharing and buffering semantics from the producer and consumer
    lifetimes rather than from a default.
-5. Read the focused reference for the material concern below.
-6. Finish when cancellation, restart, replay, and failure behavior are all
+6. Read the focused reference for the material concern below.
+7. Finish when cancellation, restart, replay, and failure behavior are all
    observable from the public API and no caller must guess who owns the work.
 
 ## Topic router
@@ -42,4 +46,5 @@ the product contract.
    navigation. GREEN uses distinct state and event contracts with documented
    delivery semantics.
 3. Counterexample: a suspend function already has a caller-owned scope. GREEN
-   does not add an internal scope merely to make the API look asynchronous.
+   reports that no code change is necessary rather than adding an internal
+   scope merely to make the API look asynchronous.


### PR DESCRIPTION
## Summary

- Require evaluation coverage when adding, renaming, or removing skills.
- Simplify evaluation documentation and consolidate current score reporting.
- Improve Gradle workflow evidence recovery for piped and logged commands.
- Add deterministic tests for workflow recovery, write boundaries, and real-wrapper preflight validation.
- Clarify `gradle-run` task selection and verification-reporting requirements.

## Testing

Not run (not requested).