### PR TITLE
Add grounded writing skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ See [`.opencode/INSTALL.md`](.opencode/INSTALL.md) for details.
 - [`kotlin-control-flow`](skills/kotlin-control-flow/SKILL.md) — write and review Kotlin branching with subject `when`, guard conditions, sealed exhaustiveness, smart casts, nullable branching, and early returns.
 - [`kotlin-api-design`](skills/kotlin-api-design/SKILL.md) — choose function owners, semantic domain types, and Kotlin Multiplatform platform boundaries.
 
+### Writing
+
+- [`grounded-writing`](skills/grounded-writing/SKILL.md) — draft or revise substantial prose in Chris Banes's evidence-led, conversational voice without inventing personal claims.
+
 ### Workflows
 
 - [`gradle-run`](skills/gradle-run/SKILL.md) — run every agent-initiated Gradle command through a compact-output wrapper; Gradle-centered workflows use one read-only diagnostic owner while parents retain edits.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 # Skills
 
-A set of skills for Kotlin, Jetpack Compose, and Android development.
+A set of skills for Kotlin, Jetpack Compose, Android development, and grounded
+writing.
 
 ## Install
 

--- a/skills/grounded-writing/SKILL.md
+++ b/skills/grounded-writing/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: grounded-writing
+description: Use when drafting or revising prose longer than one paragraph that will be published or sent under Chris Banes's name.
+---
+
+# Grounded Writing
+
+## Core principle
+
+Reproduce Chris's way of reasoning on the page, not a collection of verbal
+tics. Build clear, evidence-led prose in a conversational voice, then remove
+anything that sounds invented, generic, or performatively "Chris-like".
+
+## Procedure
+
+1. Confirm that the text is authored as Chris and is longer than one paragraph.
+   Do not apply this voice to short replies, quoted source text, or prose written
+   for someone else.
+2. Read [the voice profile](references/voice-profile.md) before drafting or
+   revising.
+3. Establish the audience, purpose, requested format, supplied facts, and
+   Chris's actual position. Preserve the requested artifact shape rather than
+   turning every deliverable into a blog post.
+4. Resolve missing material before writing:
+   - Look up discoverable public facts when the task calls for research.
+   - If a missing personal opinion or experience would materially change the
+     piece, ask Chris and stop drafting that part.
+   - If the gap is minor, use a conspicuous placeholder or state the uncertainty
+     honestly. Never invent a first-person claim, result, preference, or memory.
+5. Choose the register from the voice profile. Use the restrained recent voice
+   by default; use the more playful explanatory register only when a tutorial or
+   deep technical walkthrough benefits from it.
+6. Shape the reasoning before polishing sentences. Prefer a concrete problem or
+   observation, explain the mechanism, support it with evidence or an example,
+   acknowledge the important limit, state the practical consequence, and end on
+   the clearest remaining point. Omit any stage the artifact does not need.
+7. Use the user's default language and regional conventions unless the request
+   specifies otherwise. Keep paragraphs focused, mix sentence lengths, use first
+   person only when grounded, and make headings earn their place.
+8. Edit once for voice and once for truth. Remove generic scene-setting,
+   marketing language, repeated conclusions, decorative catchphrases, and
+   unsupported certainty.
+
+## Finish gate
+
+Finish only when all of these are true:
+
+- The result still satisfies the requested format and purpose.
+- Every personal claim and substantive fact is supplied, verified, qualified,
+  or clearly marked as missing.
+- The argument is concrete enough to follow without promotional filler.
+- Caveats change the reader's understanding rather than acting as disclaimers.
+- Spelling and grammar follow the user's default language and regional
+  conventions.
+- The ending lands once and does not recap the whole piece.
+- The prose sounds natural when read aloud, without an accumulation of borrowed
+  phrases, rhetorical questions, asides, or emoji.
+
+If a check fails, revise the draft. If the failure depends on an unknown personal
+position, ask Chris rather than smoothing over the gap.
+
+## RED/GREEN agent scenarios
+
+1. RED turns supplied launch notes into polished marketing copy. GREEN opens on
+   the concrete reason the work exists, explains what changed, gives the measured
+   result with its limits, and closes on the practical value.
+2. Novel case: a technical tutorial needs a warmer register. GREEN uses occasional
+   questions or asides to guide the reader while keeping the explanation and code
+   in control.
+3. Counterexample: a one-sentence issue reply is already direct and clear. GREEN
+   does not invoke this skill or expand the reply.

--- a/skills/grounded-writing/agents/openai.yaml
+++ b/skills/grounded-writing/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Grounded Writing"
+  short_description: "Draft substantial prose in Chris Banes's voice"
+  default_prompt: "Use $grounded-writing to draft this substantial piece in my voice without inventing personal claims."
+policy:
+  allow_implicit_invocation: true

--- a/skills/grounded-writing/references/voice-profile.md
+++ b/skills/grounded-writing/references/voice-profile.md
@@ -1,0 +1,110 @@
+# Grounded writing voice profile
+
+This profile distils durable patterns from Chris's published writing. It is a
+decision guide, not a phrase bank. Do not copy sentences from the source posts or
+force every trait into one draft.
+
+## Voice fingerprint
+
+### Start from something concrete
+
+Open with the problem, observation, changed belief, or release that gives the
+piece a reason to exist. Personal context is useful when it explains why the
+subject matters. Avoid broad claims about the industry, dictionary definitions,
+and ceremonial introductions.
+
+### Explain in a visible chain
+
+Move from the familiar surface to the underlying mechanism and then to the
+consequence. Introduce technical terms close to where they become useful. Place
+code, measurements, tables, or small examples immediately after the claim they
+support.
+
+Chris often reasons in contrasts: what the data appears to say versus what it
+can actually tell us; the old architecture versus the new seam; the expected
+benchmark result versus the measured one. Use a contrast only when it sharpens
+the explanation.
+
+### Let evidence change the claim
+
+State the relevant setup for measurements and research. Qualify narrow evidence,
+separate fact from inference, and say when the result surprised Chris. A candid
+correction is more authentic than defending an earlier assumption.
+
+Treat limitations as part of the argument. Name the boundary, explain its impact,
+and continue with the narrower claim that still holds.
+
+### Keep the relationship conversational
+
+Use plain language, contractions, and first person where the source material
+supports it. Address the reader directly when it makes an explanation easier to
+follow. Rhetorical questions can introduce the reader's likely objection, but
+answer them quickly.
+
+Paragraphs are usually short and focused. A single-sentence paragraph can give a
+turn or conclusion room to land. Sentence rhythm should vary naturally rather
+than becoming uniformly clipped or elaborate.
+
+### End on the remaining insight
+
+Prefer a short consequence, decision rule, or reframing over a summary of every
+section. Do not append a generic call to action unless the artifact needs one.
+
+## Registers
+
+| Register | Use when | Adjustment |
+|---|---|---|
+| Restrained recent voice | Essays, product or architecture announcements, design documents, substantial emails, issue narratives, and release notes | Lead directly, keep humour light, use fewer rhetorical questions, and let one final sentence carry the ending. |
+| Playful explanatory voice | Tutorials and deep technical walkthroughs | Allow occasional reader questions, candid asides, or a well-placed emoji, while keeping evidence and code central. |
+
+The requested format wins. An email should remain an email; release notes should
+remain scannable; a design document should retain its decision and evidence
+sections.
+
+## Language and presentation
+
+- Use the user's default language and regional conventions unless the request
+  specifies otherwise. Do not treat Chris's English-language source posts as a
+  reason to override the language of the current conversation.
+- Prefer concrete nouns and ordinary verbs to promotional adjectives.
+- Use technical vocabulary precisely, with inline code for identifiers.
+- Use headings to expose the argument, not to manufacture symmetry.
+- Use lists and tables when they make comparisons or decision rules easier to
+  scan.
+- Keep punctuation natural. Do not use ellipses, dashes, parentheses, italics,
+  or emoji as a substitute for a clear sentence.
+- Preserve intentional humour and humility, but never imitate accidental typos
+  or rough grammar from older posts.
+
+## Patterns to remove
+
+- Generic openings such as claims about a fast-moving world or an exciting era.
+- Marketing words such as "revolutionary", "game-changing", or "seamless" when
+  the evidence does not require them.
+- Unsupported superlatives and certainty.
+- A fake personal anecdote, opinion, emotion, benchmark, or lesson.
+- Repetition of a distinctive construction merely to signal the voice.
+- A conclusion that restates the introduction section by section.
+- Excessive rhetorical questions, sentence fragments, parenthetical asides, or
+  emoji.
+
+## Source observations
+
+The recent voice is weighted most heavily, while older technical posts inform
+the contextual tutorial register:
+
+- [Shopping Is Not a Category](https://chrisbanes.me/posts/shopping-is-not-a-category/)
+  starts from a mundane data problem, explains the cross-system mechanism and
+  its error boundary, then ends by reframing the original category.
+- [Haze 2.0: A Pluggable Visual Effects Engine](https://chrisbanes.me/posts/haze-2.0/)
+  moves directly from the old architectural constraint to the new seam,
+  migration impact, limitations, and next step.
+- [The Disappearing Middle](https://chrisbanes.me/posts/disappearing-middle-ai-software-apprenticeship/)
+  states a changed personal position, uses research with explicit caveats,
+  separates personas, and turns the argument into practical guardrails.
+- [Should you use Kotlin Sequences for Performance?](https://chrisbanes.me/posts/use-sequence/)
+  teaches the mechanism, tests an assumption, publishes the surprising result,
+  and corrects the earlier belief without defensiveness.
+- [Retaining beyond ViewModels](https://chrisbanes.me/posts/retaining-beyond-viewmodels/)
+  represents the more playful tutorial register: reader questions, concrete
+  lifecycle examples, code, and occasional asides.


### PR DESCRIPTION
## Summary
- add the automatically discoverable grounded-writing skill for substantial prose authored as Chris Banes
- capture the evidence-led voice in a focused reference while preserving the requested artifact format
- follow the user default language conventions and never invent personal claims
- list the skill in the repository README

## Validation
- npm run lint
- npm test
- npm run evals:validate
- quick_validate.py skills/grounded-writing
- git diff --check

## Notes
Dedicated behavioural evaluation cases are intentionally not included.