### PR TITLE
Publish recertified Kotlin skill scores

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,8 +146,8 @@ for each skill and metric. These are not merge or release gates. See
 | [`compose-state-and-effects`](skills/compose-state-and-effects/SKILL.md) | 77.8% | 100.0% | 100.0% |
 | [`compose-ui-testing-patterns`](skills/compose-ui-testing-patterns/SKILL.md) | 55.6% | 100.0% | 100.0% |
 | [`gradle-run`](skills/gradle-run/SKILL.md) | 33.3% | 100.0% | 100.0% |
-| [`kotlin-api-design`](skills/kotlin-api-design/SKILL.md) | 66.7% | 91.7% | 100.0% |
-| [`kotlin-concurrency-and-flow`](skills/kotlin-concurrency-and-flow/SKILL.md) | 33.3% | 100.0% | 66.7% |
+| [`kotlin-api-design`](skills/kotlin-api-design/SKILL.md) | 66.7% | 100.0% | 100.0% |
+| [`kotlin-concurrency-and-flow`](skills/kotlin-concurrency-and-flow/SKILL.md) | 33.3% | 100.0% | 100.0% |
 | [`kotlin-control-flow`](skills/kotlin-control-flow/SKILL.md) | 27.8% | 100.0% | 100.0% |
 
 ## License

--- a/evals/README.md
+++ b/evals/README.md
@@ -36,8 +36,8 @@ suite-wide aggregate.
 | `compose-state-and-effects` | 77.8% | 100.0% | 100.0% |
 | `compose-ui-testing-patterns` | 55.6% | 100.0% | 100.0% |
 | `gradle-run` | 33.3% | 100.0% | 100.0% |
-| `kotlin-api-design` | 66.7% | 91.7% | 100.0% |
-| `kotlin-concurrency-and-flow` | 33.3% | 100.0% | 66.7% |
+| `kotlin-api-design` | 66.7% | 100.0% | 100.0% |
+| `kotlin-concurrency-and-flow` | 33.3% | 100.0% | 100.0% |
 | `kotlin-control-flow` | 27.8% | 100.0% | 100.0% |
 
 ## Evaluation setup


### PR DESCRIPTION
## Summary

- publish the current-HEAD 100.0% Automatic result for kotlin-api-design
- publish the current-HEAD 100.0% Restraint result for kotlin-concurrency-and-flow
- keep the result tables in README.md and evals/README.md synchronized

## Evaluation

- kotlin-api-design Automatic: 12/12 outcomes passed across four cases and three repetitions
- kotlin-concurrency-and-flow Restraint: 3/3 forced and 3/3 automatic controls passed
- zero objective failures, violations, forbidden actions, process failures, or retries
- reported API routing precision was 100.0% and recall was 85.7%; both routing gates passed

## Validation

- npm test (247 passed, 1 skipped)
- npm run lint
- npm run evals:validate (61 cases)
- git diff --check