### PR TITLE
Broaden grounded writing style guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ See [`.opencode/INSTALL.md`](.opencode/INSTALL.md) for details.
 
 ### Writing
 
-- [`grounded-writing`](skills/grounded-writing/SKILL.md) — draft or revise clear, evidence-led writing of any length, including GitHub comments, without inventing personal claims.
+- [`grounded-writing`](skills/grounded-writing/SKILL.md) — draft or revise clear, evidence-led writing of any length, including review comments and replies, without inventing personal claims.
 
 ### Workflows
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ See [`.opencode/INSTALL.md`](.opencode/INSTALL.md) for details.
 
 ### Writing
 
-- [`grounded-writing`](skills/grounded-writing/SKILL.md) — draft or revise substantial prose in Chris Banes's evidence-led, conversational voice without inventing personal claims.
+- [`grounded-writing`](skills/grounded-writing/SKILL.md) — draft or revise clear, evidence-led writing of any length, including GitHub comments, without inventing personal claims.
 
 ### Workflows
 

--- a/skills/grounded-writing/SKILL.md
+++ b/skills/grounded-writing/SKILL.md
@@ -1,43 +1,45 @@
 ---
 name: grounded-writing
-description: Use when drafting or revising prose longer than one paragraph that will be published or sent under Chris Banes's name.
+description: Use when drafting or revising text for the user to publish or send, including short GitHub comments and evidence-led technical prose.
 ---
 
 # Grounded Writing
 
 ## Core principle
 
-Reproduce Chris's way of reasoning on the page, not a collection of verbal
-tics. Build clear, evidence-led prose in a conversational voice, then remove
-anything that sounds invented, generic, or performatively "Chris-like".
+Make the reasoning visible at the scale the artifact supports. Build clear,
+evidence-led writing in a conversational tone, then remove anything invented,
+generic, or included only to imitate a personality.
 
 ## Procedure
 
-1. Confirm that the text is authored as Chris and is longer than one paragraph.
-   Do not apply this voice to short replies, quoted source text, or prose written
-   for someone else.
-2. Read [the voice profile](references/voice-profile.md) before drafting or
+1. Confirm that the text is for the user to publish or send. Apply this style at
+   any length, including one-sentence GitHub comments. Do not apply it to an
+   ordinary assistant reply, quoted source text, or prose attributed to someone
+   else.
+2. Read [the style profile](references/style-profile.md) before drafting or
    revising.
 3. Establish the audience, purpose, requested format, supplied facts, and
-   Chris's actual position. Preserve the requested artifact shape rather than
+   the user's actual position. Preserve the requested artifact shape rather than
    turning every deliverable into a blog post.
 4. Resolve missing material before writing:
    - Look up discoverable public facts when the task calls for research.
    - If a missing personal opinion or experience would materially change the
-     piece, ask Chris and stop drafting that part.
+     text, ask the user and stop drafting that part.
    - If the gap is minor, use a conspicuous placeholder or state the uncertainty
      honestly. Never invent a first-person claim, result, preference, or memory.
-5. Choose the register from the voice profile. Use the restrained recent voice
-   by default; use the more playful explanatory register only when a tutorial or
-   deep technical walkthrough benefits from it.
+5. Choose the register from the style profile. Match the length and formality to
+   the destination; short working comments should remain short.
 6. Shape the reasoning before polishing sentences. Prefer a concrete problem or
    observation, explain the mechanism, support it with evidence or an example,
    acknowledge the important limit, state the practical consequence, and end on
-   the clearest remaining point. Omit any stage the artifact does not need.
+   the clearest remaining point. Omit any stage the artifact does not need. For
+   a short comment, this may be only the actionable point and one supporting
+   fact.
 7. Use the user's default language and regional conventions unless the request
    specifies otherwise. Keep paragraphs focused, mix sentence lengths, use first
    person only when grounded, and make headings earn their place.
-8. Edit once for voice and once for truth. Remove generic scene-setting,
+8. Edit once for style and once for truth. Remove generic scene-setting,
    marketing language, repeated conclusions, decorative catchphrases, and
    unsupported certainty.
 
@@ -49,7 +51,8 @@ Finish only when all of these are true:
 - Every personal claim and substantive fact is supplied, verified, qualified,
   or clearly marked as missing.
 - The argument is concrete enough to follow without promotional filler.
-- Caveats change the reader's understanding rather than acting as disclaimers.
+- Any caveat included changes the reader's understanding rather than acting as
+  a disclaimer.
 - Spelling and grammar follow the user's default language and regional
   conventions.
 - The ending lands once and does not recap the whole piece.
@@ -57,15 +60,21 @@ Finish only when all of these are true:
   phrases, rhetorical questions, asides, or emoji.
 
 If a check fails, revise the draft. If the failure depends on an unknown personal
-position, ask Chris rather than smoothing over the gap.
+position, ask the user rather than smoothing over the gap.
 
 ## RED/GREEN agent scenarios
 
-1. RED turns supplied launch notes into polished marketing copy. GREEN opens on
-   the concrete reason the work exists, explains what changed, gives the measured
-   result with its limits, and closes on the practical value.
+1. Direct case: a two-sentence pull request reply needs to report a fix and its
+   validation. RED expands it into an essay or adds enthusiasm. GREEN leads with
+   the outcome, names the relevant check, and stays within two sentences.
 2. Novel case: a technical tutorial needs a warmer register. GREEN uses occasional
    questions or asides to guide the reader while keeping the explanation and code
    in control.
-3. Counterexample: a one-sentence issue reply is already direct and clear. GREEN
-   does not invoke this skill or expand the reply.
+3. Novel case: a technical briefing benefits from two source observations. RED
+   blends recognizable mannerisms from both authors. GREEN selects only the
+   relevant structural techniques and keeps the user's natural tone.
+4. No-change case: a one-sentence issue comment is already direct, grounded, and
+   appropriate for its audience. GREEN preserves it instead of expanding it.
+5. Counterexample: the user asks the assistant to explain a technical concept for
+   their own understanding, not to draft text for publication. GREEN answers
+   normally and does not introduce first-person claims on the user's behalf.

--- a/skills/grounded-writing/SKILL.md
+++ b/skills/grounded-writing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: grounded-writing
-description: Use when drafting or revising text for the user to publish or send, including short GitHub comments and evidence-led technical prose.
+description: Use when drafting or revising text for the user to publish or send, including short review comments, replies, and evidence-led technical prose.
 ---
 
 # Grounded Writing
@@ -14,9 +14,9 @@ generic, or included only to imitate a personality.
 ## Procedure
 
 1. Confirm that the text is for the user to publish or send. Apply this style at
-   any length, including one-sentence GitHub comments. Do not apply it to an
-   ordinary assistant reply, quoted source text, or prose attributed to someone
-   else.
+   any length, including one-sentence review comments and replies. Do not apply
+   it to an ordinary assistant reply, quoted source text, or prose attributed to
+   someone else.
 2. Read [the style profile](references/style-profile.md) before drafting or
    revising.
 3. Establish the audience, purpose, requested format, supplied facts, and
@@ -64,7 +64,7 @@ position, ask the user rather than smoothing over the gap.
 
 ## RED/GREEN agent scenarios
 
-1. Direct case: a two-sentence pull request reply needs to report a fix and its
+1. Direct case: a two-sentence review reply needs to report a fix and its
    validation. RED expands it into an essay or adds enthusiasm. GREEN leads with
    the outcome, names the relevant check, and stays within two sentences.
 2. Novel case: a technical tutorial needs a warmer register. GREEN uses occasional
@@ -73,7 +73,7 @@ position, ask the user rather than smoothing over the gap.
 3. Novel case: a technical briefing benefits from two source observations. RED
    blends recognizable mannerisms from both authors. GREEN selects only the
    relevant structural techniques and keeps the user's natural tone.
-4. No-change case: a one-sentence issue comment is already direct, grounded, and
+4. No-change case: a one-sentence review comment is already direct, grounded, and
    appropriate for its audience. GREEN preserves it instead of expanding it.
 5. Counterexample: the user asks the assistant to explain a technical concept for
    their own understanding, not to draft text for publication. GREEN answers

--- a/skills/grounded-writing/agents/openai.yaml
+++ b/skills/grounded-writing/agents/openai.yaml
@@ -1,6 +1,6 @@
 interface:
   display_name: "Grounded Writing"
-  short_description: "Draft substantial prose in Chris Banes's voice"
-  default_prompt: "Use $grounded-writing to draft this substantial piece in my voice without inventing personal claims."
+  short_description: "Draft clear, evidence-led writing in my style"
+  default_prompt: "Use $grounded-writing to draft this in my style without inventing personal claims or unnecessary detail."
 policy:
   allow_implicit_invocation: true

--- a/skills/grounded-writing/references/style-profile.md
+++ b/skills/grounded-writing/references/style-profile.md
@@ -56,7 +56,7 @@ section. Do not append a generic call to action unless the artifact needs one.
 
 | Register | Use when | Adjustment |
 |---|---|---|
-| Concise working note | GitHub comments, review replies, issue updates, and short messages | Lead with the actionable point, include only the context or evidence needed to support it, and stop. Do not manufacture an introduction or conclusion. |
+| Concise working note | Review comments, replies, status updates, and short messages | Lead with the actionable point, include only the context or evidence needed to support it, and stop. Do not manufacture an introduction or conclusion. |
 | Restrained long form | Essays, product or architecture announcements, design documents, substantial emails, issue narratives, and release notes | Lead directly, keep humour light, use fewer rhetorical questions, and let one final sentence carry the ending. |
 | Playful explanation | Tutorials and deep technical walkthroughs | Allow occasional reader questions, candid asides, or a well-placed emoji, while keeping evidence and code central. |
 

--- a/skills/grounded-writing/references/style-profile.md
+++ b/skills/grounded-writing/references/style-profile.md
@@ -1,10 +1,11 @@
-# Grounded writing voice profile
+# Grounded writing style profile
 
-This profile distils durable patterns from Chris's published writing. It is a
-decision guide, not a phrase bank. Do not copy sentences from the source posts or
-force every trait into one draft.
+This profile distils durable patterns from the published writing sampled below.
+It is a decision guide, not a phrase bank. Treat each source as evidence for a
+structural technique, not as a personality to imitate or average with the other
+authors. Do not copy sentences or force every trait into one draft.
 
-## Voice fingerprint
+## Style characteristics
 
 ### Start from something concrete
 
@@ -20,16 +21,17 @@ consequence. Introduce technical terms close to where they become useful. Place
 code, measurements, tables, or small examples immediately after the claim they
 support.
 
-Chris often reasons in contrasts: what the data appears to say versus what it
-can actually tell us; the old architecture versus the new seam; the expected
+Contrasts often sharpen the reasoning: what the data appears to say versus what
+it can actually tell us; the old architecture versus the new seam; the expected
 benchmark result versus the measured one. Use a contrast only when it sharpens
 the explanation.
 
 ### Let evidence change the claim
 
 State the relevant setup for measurements and research. Qualify narrow evidence,
-separate fact from inference, and say when the result surprised Chris. A candid
-correction is more authentic than defending an earlier assumption.
+separate fact from inference, and include surprise only when the source material
+supports it. A candid correction is stronger than defending an earlier
+assumption.
 
 Treat limitations as part of the argument. Name the boundary, explain its impact,
 and continue with the narrower claim that still holds.
@@ -54,8 +56,9 @@ section. Do not append a generic call to action unless the artifact needs one.
 
 | Register | Use when | Adjustment |
 |---|---|---|
-| Restrained recent voice | Essays, product or architecture announcements, design documents, substantial emails, issue narratives, and release notes | Lead directly, keep humour light, use fewer rhetorical questions, and let one final sentence carry the ending. |
-| Playful explanatory voice | Tutorials and deep technical walkthroughs | Allow occasional reader questions, candid asides, or a well-placed emoji, while keeping evidence and code central. |
+| Concise working note | GitHub comments, review replies, issue updates, and short messages | Lead with the actionable point, include only the context or evidence needed to support it, and stop. Do not manufacture an introduction or conclusion. |
+| Restrained long form | Essays, product or architecture announcements, design documents, substantial emails, issue narratives, and release notes | Lead directly, keep humour light, use fewer rhetorical questions, and let one final sentence carry the ending. |
+| Playful explanation | Tutorials and deep technical walkthroughs | Allow occasional reader questions, candid asides, or a well-placed emoji, while keeping evidence and code central. |
 
 The requested format wins. An email should remain an email; release notes should
 remain scannable; a design document should retain its decision and evidence
@@ -64,7 +67,7 @@ sections.
 ## Language and presentation
 
 - Use the user's default language and regional conventions unless the request
-  specifies otherwise. Do not treat Chris's English-language source posts as a
+  specifies otherwise. Do not treat the English-language source posts as a
   reason to override the language of the current conversation.
 - Prefer concrete nouns and ordinary verbs to promotional adjectives.
 - Use technical vocabulary precisely, with inline code for identifiers.
@@ -83,15 +86,15 @@ sections.
   the evidence does not require them.
 - Unsupported superlatives and certainty.
 - A fake personal anecdote, opinion, emotion, benchmark, or lesson.
-- Repetition of a distinctive construction merely to signal the voice.
+- Repetition of a distinctive construction merely to make the style recognizable.
 - A conclusion that restates the introduction section by section.
 - Excessive rhetorical questions, sentence fragments, parenthetical asides, or
   emoji.
 
 ## Source observations
 
-The recent voice is weighted most heavily, while older technical posts inform
-the contextual tutorial register:
+Choose observations by the job the artifact needs to do. Do not privilege a
+source because it is newer, more popular, or more distinctive.
 
 - [Shopping Is Not a Category](https://chrisbanes.me/posts/shopping-is-not-a-category/)
   starts from a mundane data problem, explains the cross-system mechanism and
@@ -108,3 +111,23 @@ the contextual tutorial register:
 - [Retaining beyond ViewModels](https://chrisbanes.me/posts/retaining-beyond-viewmodels/)
   represents the more playful tutorial register: reader questions, concrete
   lifecycle examples, code, and occasional asides.
+- [Why you should understand (a little) about TCP](https://jvns.ca/blog/2015/11/21/why-you-should-understand-a-little-about-tcp/)
+  starts with a real performance problem, introduces only the networking detail
+  needed to explain it, shows the fix, and returns to the narrow lesson.
+- [Things we learned about LLMs in 2024](https://simonwillison.net/2024/Dec/31/llms-in-2024/)
+  shows how to synthesize a fast-moving subject: divide it into testable claims,
+  link evidence close to each claim, quantify changes, and distinguish
+  observation from judgment.
+- [Normalization of deviance](https://danluu.com/wat/) accumulates concrete cases
+  before naming the general mechanism. Use that pattern only when several cases
+  materially strengthen the argument; do not inherit the post's length or
+  sardonic register by default.
+
+## Editorial reference
+
+For technical explanations, use
+[Patterns in confusing explanations](https://jvns.ca/blog/confusing-explanations/)
+as a final review lens. Check that the draft has a specific audience, starts
+concretely, uses realistic examples, introduces jargon only when it carries
+meaning, supports substantive claims, and explains why the subject matters.
+Apply the checks that fit the artifact; do not turn them into mandatory sections.


### PR DESCRIPTION
## Summary

- apply `grounded-writing` to user-authored text at any length, including concise GitHub comments and review replies
- make structural writing choices the focus, with source material treated as evidence rather than personalities to imitate
- add complementary examples for concise diagnosis, evidence-linked synthesis, cumulative argument, and technical-explanation review
- rename the internal voice profile to a style profile and synchronize the README and Codex metadata

## Validation

- `npm run lint`
- `npm test`
- `npm run evals:validate`
- `python3 /Users/chris/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/grounded-writing`
- `git diff --check`