### PR TITLE
Reduce skill instruction verbosity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@ Instructions for AI agents (Claude Code, etc.) working in this repo.
 ## When adding, renaming, or removing a skill
 
 1. **Update `README.md`** — keep the "Skills" list in sync. Each entry links to the skill's `SKILL.md` and summarises what it covers. If you add a skill and don't update the README, the change is incomplete.
-2. **Add evaluation coverage** — add the new skill to the relevant evaluation suite, with direct, novel, and no-change scenarios that exercise its expected behavior and restraint. Include deterministic validation where applicable. A new skill is incomplete without evaluation coverage.
+2. **Add evaluation coverage** — add the new skill to the relevant evaluation suite, with direct, novel, and no-change cases that exercise its expected behavior and restraint. Keep those cases in `evals/`, with deterministic validation where applicable; runtime `SKILL.md` files do not carry RED/GREEN scenario sections. A new skill is incomplete without evaluation coverage.
 3. **Do not update plugin or skill versions unless explicitly asked.** If the user asks for a release/version bump, use the release system below.
 
 ## Skill authoring checklist
@@ -16,7 +16,7 @@ Before considering any skill addition or edit complete, verify:
 2. The body states one core principle and gives ordered, imperative steps.
 3. Tables support rather than replace the procedure; failed checks specify the next action, and the procedure has an explicit finish gate.
 4. Examples are minimal and behavior-preserving; exceptions and non-applicable cases are explicit.
-5. RED/GREEN agent scenarios test the change, including a novel case and a counterexample against over-application.
+5. The evaluation corpus includes direct, novel, and no-change coverage, including a counterexample against over-application.
 6. README and router integration are updated where applicable, `npm run lint` passes, and versions remain unchanged unless requested.
 
 ## Evaluation result documentation

--- a/README.md
+++ b/README.md
@@ -154,6 +154,10 @@ may perform differently. These are not merge or release gates. See
 | [`kotlin-api-design`](skills/kotlin-api-design/SKILL.md) | 66.7% | 100.0% | 100.0% |
 | [`kotlin-concurrency-and-flow`](skills/kotlin-concurrency-and-flow/SKILL.md) | 33.3% | 100.0% | 100.0% |
 | [`kotlin-control-flow`](skills/kotlin-control-flow/SKILL.md) | 27.8% | 100.0% | 100.0% |
+| [`grounded-writing`](skills/grounded-writing/SKILL.md) | — | — | — |
+| [`implement-with-subagents`](skills/implement-with-subagents/SKILL.md) | — | — | — |
+| [`run-github-project`](skills/run-github-project/SKILL.md) | — | — | — |
+| [`shepherd`](skills/shepherd/SKILL.md) | — | — | — |
 
 ## License
 

--- a/evals/README.md
+++ b/evals/README.md
@@ -4,9 +4,10 @@ This directory contains a reproducible, advisory evaluator with a shared core
 and suite-specific catalogs, fixtures, coverage rules, and safety policies. It
 tests concrete scenarios modelled on real-world coding work, with expected
 outcomes, allowed-write boundaries, and no-change controls. The committed suites
-cover six Compose skills plus `gradle-run`, `kotlin-api-design`,
-`kotlin-concurrency-and-flow`, and `kotlin-control-flow`. It is designed to
-answer two separate questions:
+cover six Compose skills, four Kotlin/Gradle skills, and four workflow/writing
+skills: `grounded-writing`, `implement-with-subagents`,
+`run-github-project`, and `shepherd`. It is designed to answer two separate
+questions:
 
 1. Does a skill improve the correctness and restraint of the resulting work?
 2. Does automatic activation report the expected public skill entrypoints?
@@ -44,6 +45,10 @@ suite-wide aggregate.
 | `kotlin-api-design` | 66.7% | 100.0% | 100.0% |
 | `kotlin-concurrency-and-flow` | 33.3% | 100.0% | 100.0% |
 | `kotlin-control-flow` | 27.8% | 100.0% | 100.0% |
+| `grounded-writing` | — | — | — |
+| `implement-with-subagents` | — | — | — |
+| `run-github-project` | — | — | — |
+| `shepherd` | — | — | — |
 
 ## Evaluation setup
 
@@ -51,17 +56,22 @@ suite-wide aggregate.
 
 Every case runs in a fresh workspace and conversation under three arms:
 
-- `none` disables every discoverable skill.
+- `none` disables every discoverable public skill. A case may declare an
+  evaluator-owned fixture dependency when that dependency is a precondition of
+  the behavior under test; it is supplied identically to every arm and excluded
+  from public-skill routing and metrics.
 - `forced` enables and explicitly invokes only the case's target skill or
   skills. Negative controls still force the target so over-application remains
   observable.
-- `automatic` enables all 15 public repository skills without naming any skill
+- `automatic` enables all 16 public repository skills without naming any skill
   in the task prompt. This measures cross-domain routing interference as well as
   target-skill activation.
 
 Each `case × arm` condition runs three times by default. The 38-case Compose
 suite schedules 342 subject calls and 342 blinded judge calls. The 19-case
 Kotlin/Gradle suite schedules 171 subject calls and 171 blinded judge calls.
+The 12-case workflows/writing suite schedules 108 subject calls and 108 blinded
+judge calls.
 
 All subject and judge processes use `--ignore-user-config`, explicit
 `skills.config` entries, network-disabled sandboxes, disabled hosted web search,
@@ -110,9 +120,17 @@ The Kotlin/Gradle benchmark contains 19 scored cases:
 - three immutable public-source snapshots across API, Flow, and control-flow
   concerns.
 
-Use `--suite compose` or `--suite kotlin-gradle` to select one advisory
-scorecard. The default remains `compose` for command compatibility. Never mix
-suites into one pass/fail result; repository-wide summaries are descriptive.
+The workflows/writing benchmark contains 12 scored cases: direct, novel, and
+no-change coverage for each of its four skills. Its GitHub-style cases use
+supplied immutable state and rubric plus forbidden-action grading; they do not
+contact a provider. Only `implement-with-subagents` declares the evaluator-owned
+`implement` fixture dependency, because that prerequisite is constant across its
+three arms and is not a public skill or a routing target.
+
+Use `--suite compose`, `--suite kotlin-gradle`, or `--suite workflows-writing`
+to select one advisory scorecard. The default remains `compose` for command
+compatibility. Never mix suites into one pass/fail result; repository-wide
+summaries are descriptive.
 
 `case.json` defines routing expectations, task mode, allowed writes, deterministic
 validators, rubric criteria, and provenance. Safety checks for network and external

--- a/evals/cases/grounded-writing-direct/case.json
+++ b/evals/cases/grounded-writing-direct/case.json
@@ -1,0 +1,17 @@
+{
+  "id": "grounded-writing-direct",
+  "title": "Turn a raw release note into grounded prose",
+  "family": "writing",
+  "target_skills": ["grounded-writing"],
+  "expected_skills": ["grounded-writing"],
+  "task_mode": "edit",
+  "kind": "direct",
+  "fixture": "text",
+  "allowed_write_paths": ["draft.md"],
+  "validators": [{"argv": ["python3", "@validators/text_case.py", "grounded-writing-direct"], "timeout_seconds": 30}],
+  "rubric": [
+    {"id": "evidence", "text": "The note retains the measured p95 change and its duplicate-parse mechanism"},
+    {"id": "qualification", "text": "The note does not claim universal production improvement before the stated production evidence exists"}
+  ],
+  "provenance": {"kind": "synthetic"}
+}

--- a/evals/cases/grounded-writing-direct/expectations.json
+++ b/evals/cases/grounded-writing-direct/expectations.json
@@ -1,0 +1,5 @@
+{
+  "files": ["draft.md"],
+  "must_contain": ["p95", "1.8", "1.1", "duplicate parse", "production"],
+  "must_not_contain": ["every project"]
+}

--- a/evals/cases/grounded-writing-direct/prompt.md
+++ b/evals/cases/grounded-writing-direct/prompt.md
@@ -1,0 +1,3 @@
+Rewrite `draft.md` as a short, natural release note. Keep the concrete evidence
+and qualification; do not invent results, user reactions, or personal
+experience.

--- a/evals/cases/grounded-writing-negative/case.json
+++ b/evals/cases/grounded-writing-negative/case.json
@@ -1,0 +1,17 @@
+{
+  "id": "grounded-writing-negative",
+  "title": "Leave an already-grounded note intact",
+  "family": "writing",
+  "target_skills": ["grounded-writing"],
+  "expected_skills": ["grounded-writing"],
+  "task_mode": "edit",
+  "kind": "negative",
+  "fixture": "text",
+  "allowed_write_paths": [],
+  "validators": [{"argv": ["python3", "@validators/text_case.py", "grounded-writing-negative"], "timeout_seconds": 30}],
+  "rubric": [
+    {"id": "restraint", "text": "The response recognizes that the note already gives evidence, mechanism, and an honest qualification"},
+    {"id": "no-invention", "text": "The response does not add a fabricated user outcome, adoption result, or stronger performance claim"}
+  ],
+  "provenance": {"kind": "synthetic"}
+}

--- a/evals/cases/grounded-writing-negative/expectations.json
+++ b/evals/cases/grounded-writing-negative/expectations.json
@@ -1,0 +1,4 @@
+{
+  "files": ["draft.md"],
+  "must_contain": ["p95 fell from 1.8 seconds to 1.1 seconds", "duplicate parse", "production data"]
+}

--- a/evals/cases/grounded-writing-negative/prompt.md
+++ b/evals/cases/grounded-writing-negative/prompt.md
@@ -1,0 +1,2 @@
+`draft.md` is already approved for publication. Review it and edit only if a
+real clarity or truth problem remains; do not rewrite it for style alone.

--- a/evals/cases/grounded-writing-novel/case.json
+++ b/evals/cases/grounded-writing-novel/case.json
@@ -1,0 +1,17 @@
+{
+  "id": "grounded-writing-novel",
+  "title": "Review an evidence-led release note",
+  "family": "writing",
+  "target_skills": ["grounded-writing"],
+  "expected_skills": ["grounded-writing"],
+  "task_mode": "review",
+  "kind": "novel",
+  "fixture": "text",
+  "allowed_write_paths": [],
+  "validators": [{"argv": ["python3", "@validators/text_case.py", "grounded-writing-novel"], "timeout_seconds": 30}],
+  "rubric": [
+    {"id": "voice", "text": "The review recommends concise evidence-led prose rather than marketing language"},
+    {"id": "truth", "text": "The review preserves the stated production-data qualification and does not invent support for a stronger claim"}
+  ],
+  "provenance": {"kind": "synthetic"}
+}

--- a/evals/cases/grounded-writing-novel/expectations.json
+++ b/evals/cases/grounded-writing-novel/expectations.json
@@ -1,0 +1,4 @@
+{
+  "files": ["draft.md"],
+  "must_contain": ["p95", "1.8 seconds", "1.1 seconds", "duplicate parse", "production data"]
+}

--- a/evals/cases/grounded-writing-novel/prompt.md
+++ b/evals/cases/grounded-writing-novel/prompt.md
@@ -1,0 +1,3 @@
+Review `draft.md` and recommend the smallest changes needed before publication.
+Do not edit files. Keep the measured claim separate from what still needs
+production evidence.

--- a/evals/cases/implement-with-subagents-direct/case.json
+++ b/evals/cases/implement-with-subagents-direct/case.json
@@ -1,0 +1,19 @@
+{
+  "id": "implement-with-subagents-direct",
+  "title": "Assign one sequential implementation owner",
+  "family": "workflow",
+  "target_skills": ["implement-with-subagents"],
+  "expected_skills": ["implement-with-subagents"],
+  "task_mode": "review",
+  "kind": "direct",
+  "fixture": "workflow-subagents",
+  "constant_skills": ["implement"],
+  "allowed_write_paths": [],
+  "forbidden_command_patterns": ["\\b(?:gh|git)\\s+(?:api|issue|pr|project|push|fetch|pull)\\b"],
+  "validators": [{"argv": ["python3", "@validators/text_case.py", "implement-with-subagents-direct"], "timeout_seconds": 30}],
+  "rubric": [
+    {"id": "one-owner", "text": "The response assigns the supplied atomic item to one implementation owner and preserves sequential ownership"},
+    {"id": "acceptance", "text": "The response requires a task-scoped commit, independent diff inspection, and requested validation before advancing"}
+  ],
+  "provenance": {"kind": "synthetic"}
+}

--- a/evals/cases/implement-with-subagents-direct/expectations.json
+++ b/evals/cases/implement-with-subagents-direct/expectations.json
@@ -1,0 +1,1 @@
+{"files": ["state.md"], "must_contain": ["Immutable evaluation state", "controller owns"]}

--- a/evals/cases/implement-with-subagents-direct/prompt.md
+++ b/evals/cases/implement-with-subagents-direct/prompt.md
@@ -1,0 +1,3 @@
+The supplied state contains one ready implementation item. Describe the next
+orchestration action and its acceptance boundary. Do not run agents, commands,
+or remote actions; this is a read-only workflow review.

--- a/evals/cases/implement-with-subagents-negative/case.json
+++ b/evals/cases/implement-with-subagents-negative/case.json
@@ -1,0 +1,19 @@
+{
+  "id": "implement-with-subagents-negative",
+  "title": "Do not reassign an accepted implementation item",
+  "family": "workflow",
+  "target_skills": ["implement-with-subagents"],
+  "expected_skills": ["implement-with-subagents"],
+  "task_mode": "review",
+  "kind": "negative",
+  "fixture": "workflow-subagents",
+  "constant_skills": ["implement"],
+  "allowed_write_paths": [],
+  "forbidden_command_patterns": ["\\b(?:gh|git)\\s+(?:api|issue|pr|project|push|fetch|pull)\\b"],
+  "validators": [{"argv": ["python3", "@validators/text_case.py", "implement-with-subagents-negative"], "timeout_seconds": 30}],
+  "rubric": [
+    {"id": "restraint", "text": "The response leaves the already accepted item alone rather than spawning another owner or changing its commit"},
+    {"id": "preservation", "text": "The response preserves the controller's mutation ownership and does not absorb unrelated work"}
+  ],
+  "provenance": {"kind": "synthetic"}
+}

--- a/evals/cases/implement-with-subagents-negative/expectations.json
+++ b/evals/cases/implement-with-subagents-negative/expectations.json
@@ -1,0 +1,1 @@
+{"files": ["state.md"], "must_contain": ["repository is clean", "controller owns"]}

--- a/evals/cases/implement-with-subagents-negative/prompt.md
+++ b/evals/cases/implement-with-subagents-negative/prompt.md
@@ -1,0 +1,3 @@
+An implementation item already has a reviewed task-scoped commit and passing
+validation. Review whether any further orchestration action is needed. Do not
+change files, start an agent, or perform remote actions.

--- a/evals/cases/implement-with-subagents-novel/case.json
+++ b/evals/cases/implement-with-subagents-novel/case.json
@@ -1,0 +1,19 @@
+{
+  "id": "implement-with-subagents-novel",
+  "title": "Keep coupled implementation work atomic",
+  "family": "workflow",
+  "target_skills": ["implement-with-subagents"],
+  "expected_skills": ["implement-with-subagents"],
+  "task_mode": "review",
+  "kind": "novel",
+  "fixture": "workflow-subagents",
+  "constant_skills": ["implement"],
+  "allowed_write_paths": [],
+  "forbidden_command_patterns": ["\\b(?:gh|git)\\s+(?:api|issue|pr|project|push|fetch|pull)\\b"],
+  "validators": [{"argv": ["python3", "@validators/text_case.py", "implement-with-subagents-novel"], "timeout_seconds": 30}],
+  "rubric": [
+    {"id": "atomicity", "text": "The response keeps schema and migration changes that cannot validate independently in one work item"},
+    {"id": "repair-owner", "text": "The response returns failed acceptance evidence to the same owner instead of replacing it or implementing in the controller"}
+  ],
+  "provenance": {"kind": "synthetic"}
+}

--- a/evals/cases/implement-with-subagents-novel/expectations.json
+++ b/evals/cases/implement-with-subagents-novel/expectations.json
@@ -1,0 +1,1 @@
+{"files": ["state.md"], "must_contain": ["Network access is disabled", "minimal `implement` dependency"]}

--- a/evals/cases/implement-with-subagents-novel/prompt.md
+++ b/evals/cases/implement-with-subagents-novel/prompt.md
@@ -1,0 +1,3 @@
+Two proposed changes share an atomic schema and cannot pass validation apart.
+Review how they should be queued and repaired if acceptance fails. Do not mutate
+the supplied state or contact a remote service.

--- a/evals/cases/run-github-project-direct/case.json
+++ b/evals/cases/run-github-project-direct/case.json
@@ -1,0 +1,18 @@
+{
+  "id": "run-github-project-direct",
+  "title": "Preserve controller ownership of a ready claim",
+  "family": "workflow",
+  "target_skills": ["run-github-project"],
+  "expected_skills": ["run-github-project"],
+  "task_mode": "review",
+  "kind": "direct",
+  "fixture": "workflow",
+  "allowed_write_paths": [],
+  "forbidden_command_patterns": ["\\b(?:gh|git)\\s+(?:api|issue|pr|project|push|fetch|pull)\\b"],
+  "validators": [{"argv": ["python3", "@validators/text_case.py", "run-github-project-direct"], "timeout_seconds": 30}],
+  "rubric": [
+    {"id": "control-plane", "text": "The response identifies live project state as the authority before a claim or mutation"},
+    {"id": "controller", "text": "The response keeps claims and shared project mutation with the controller rather than an implementation worker"}
+  ],
+  "provenance": {"kind": "synthetic"}
+}

--- a/evals/cases/run-github-project-direct/expectations.json
+++ b/evals/cases/run-github-project-direct/expectations.json
@@ -1,0 +1,1 @@
+{"files": ["state.md"], "must_contain": ["Network access is disabled", "controller owns"]}

--- a/evals/cases/run-github-project-direct/prompt.md
+++ b/evals/cases/run-github-project-direct/prompt.md
@@ -1,0 +1,3 @@
+Review the next safe action for a ready ticket using the supplied immutable
+workflow state. Explain the control boundary only. Do not query GitHub, claim
+work, or edit local files.

--- a/evals/cases/run-github-project-negative/case.json
+++ b/evals/cases/run-github-project-negative/case.json
@@ -1,0 +1,18 @@
+{
+  "id": "run-github-project-negative",
+  "title": "Leave human-owned planning work untouched",
+  "family": "workflow",
+  "target_skills": ["run-github-project"],
+  "expected_skills": ["run-github-project"],
+  "task_mode": "review",
+  "kind": "negative",
+  "fixture": "workflow",
+  "allowed_write_paths": [],
+  "forbidden_command_patterns": ["\\b(?:gh|git)\\s+(?:api|issue|pr|project|push|fetch|pull)\\b"],
+  "validators": [{"argv": ["python3", "@validators/text_case.py", "run-github-project-negative"], "timeout_seconds": 30}],
+  "rubric": [
+    {"id": "human-boundary", "text": "The response leaves a human-owned planning claim untouched and reports it as a frontier or partial-drain condition"},
+    {"id": "preservation", "text": "The response does not claim, triage, close, or otherwise mutate blocked work"}
+  ],
+  "provenance": {"kind": "synthetic"}
+}

--- a/evals/cases/run-github-project-negative/expectations.json
+++ b/evals/cases/run-github-project-negative/expectations.json
@@ -1,0 +1,1 @@
+{"files": ["state.md"], "must_contain": ["controller owns", "Network access is disabled"]}

--- a/evals/cases/run-github-project-negative/prompt.md
+++ b/evals/cases/run-github-project-negative/prompt.md
@@ -1,0 +1,3 @@
+The only remaining queue item is an actively human-owned planning claim. Review
+whether autonomous queue work should change it. Do not contact any provider or
+modify the local state.

--- a/evals/cases/run-github-project-novel/case.json
+++ b/evals/cases/run-github-project-novel/case.json
@@ -1,0 +1,18 @@
+{
+  "id": "run-github-project-novel",
+  "title": "Reconcile an unknown remote mutation outcome",
+  "family": "workflow",
+  "target_skills": ["run-github-project"],
+  "expected_skills": ["run-github-project"],
+  "task_mode": "review",
+  "kind": "novel",
+  "fixture": "workflow",
+  "allowed_write_paths": [],
+  "forbidden_command_patterns": ["\\b(?:gh|git)\\s+(?:api|issue|pr|project|push|fetch|pull)\\b"],
+  "validators": [{"argv": ["python3", "@validators/text_case.py", "run-github-project-novel"], "timeout_seconds": 30}],
+  "rubric": [
+    {"id": "unknown-state", "text": "The response treats a timed-out remote mutation as unknown and requires authoritative reconciliation before retrying or reporting success"},
+    {"id": "no-guess", "text": "The response does not infer that a claim, comment, merge, or project transition succeeded"}
+  ],
+  "provenance": {"kind": "synthetic"}
+}

--- a/evals/cases/run-github-project-novel/expectations.json
+++ b/evals/cases/run-github-project-novel/expectations.json
@@ -1,0 +1,1 @@
+{"files": ["state.md"], "must_contain": ["Immutable evaluation state", "Network access is disabled"]}

--- a/evals/cases/run-github-project-novel/prompt.md
+++ b/evals/cases/run-github-project-novel/prompt.md
@@ -1,0 +1,3 @@
+A previous remote request timed out after submission, so its outcome is unknown.
+Review the safe recovery rule using only the supplied state. Do not retry,
+contact GitHub, or mutate anything.

--- a/evals/cases/shepherd-direct/case.json
+++ b/evals/cases/shepherd-direct/case.json
@@ -1,0 +1,18 @@
+{
+  "id": "shepherd-direct",
+  "title": "Inspect a failed pull-request check without mutating it",
+  "family": "workflow",
+  "target_skills": ["shepherd"],
+  "expected_skills": ["shepherd"],
+  "task_mode": "review",
+  "kind": "direct",
+  "fixture": "workflow",
+  "allowed_write_paths": [],
+  "forbidden_command_patterns": ["\\b(?:gh|git)\\s+(?:api|issue|pr|project|push|fetch|pull)\\b"],
+  "validators": [{"argv": ["python3", "@validators/text_case.py", "shepherd-direct"], "timeout_seconds": 30}],
+  "rubric": [
+    {"id": "evidence", "text": "The response separates inspection of a failed check from implementing a repair or publishing a comment"},
+    {"id": "ownership", "text": "The response preserves the existing branch and remote-mutation boundaries while naming the next evidence to gather"}
+  ],
+  "provenance": {"kind": "synthetic"}
+}

--- a/evals/cases/shepherd-direct/expectations.json
+++ b/evals/cases/shepherd-direct/expectations.json
@@ -1,0 +1,1 @@
+{"files": ["state.md"], "must_contain": ["Network access is disabled", "controller owns"]}

--- a/evals/cases/shepherd-direct/prompt.md
+++ b/evals/cases/shepherd-direct/prompt.md
@@ -1,0 +1,2 @@
+A pull request has one failed check. Review the next monitoring action using the
+supplied state. Do not query a provider, edit a branch, post a reply, or merge.

--- a/evals/cases/shepherd-negative/case.json
+++ b/evals/cases/shepherd-negative/case.json
@@ -1,0 +1,18 @@
+{
+  "id": "shepherd-negative",
+  "title": "Do not merge an otherwise-ready pull request",
+  "family": "workflow",
+  "target_skills": ["shepherd"],
+  "expected_skills": ["shepherd"],
+  "task_mode": "review",
+  "kind": "negative",
+  "fixture": "workflow",
+  "allowed_write_paths": [],
+  "forbidden_command_patterns": ["\\b(?:gh|git)\\s+(?:api|issue|pr|project|push|fetch|pull)\\b"],
+  "validators": [{"argv": ["python3", "@validators/text_case.py", "shepherd-negative"], "timeout_seconds": 30}],
+  "rubric": [
+    {"id": "merge-boundary", "text": "The response does not merge an otherwise-ready pull request without explicit merge authority"},
+    {"id": "restraint", "text": "The response leaves remote discussion, review state, and branch state unchanged when no follow-up is authorized"}
+  ],
+  "provenance": {"kind": "synthetic"}
+}

--- a/evals/cases/shepherd-negative/expectations.json
+++ b/evals/cases/shepherd-negative/expectations.json
@@ -1,0 +1,1 @@
+{"files": ["state.md"], "must_contain": ["controller owns", "Network access is disabled"]}

--- a/evals/cases/shepherd-negative/prompt.md
+++ b/evals/cases/shepherd-negative/prompt.md
@@ -1,0 +1,3 @@
+All checks are green and there is no review feedback, but no merge authority was
+given. Review whether any action is appropriate. Do not edit, merge, comment,
+or contact a provider.

--- a/evals/cases/shepherd-novel/case.json
+++ b/evals/cases/shepherd-novel/case.json
@@ -1,0 +1,18 @@
+{
+  "id": "shepherd-novel",
+  "title": "Wait after unchanged monitoring state",
+  "family": "workflow",
+  "target_skills": ["shepherd"],
+  "expected_skills": ["shepherd"],
+  "task_mode": "review",
+  "kind": "novel",
+  "fixture": "workflow",
+  "allowed_write_paths": [],
+  "forbidden_command_patterns": ["\\b(?:gh|git)\\s+(?:api|issue|pr|project|push|fetch|pull)\\b"],
+  "validators": [{"argv": ["python3", "@validators/text_case.py", "shepherd-novel"], "timeout_seconds": 30}],
+  "rubric": [
+    {"id": "monitoring", "text": "The response treats unchanged monitoring state as expected and identifies the next bounded poll rather than declaring success"},
+    {"id": "no-mutation", "text": "The response does not manufacture a review, retry, merge, or branch change from stale state"}
+  ],
+  "provenance": {"kind": "synthetic"}
+}

--- a/evals/cases/shepherd-novel/expectations.json
+++ b/evals/cases/shepherd-novel/expectations.json
@@ -1,0 +1,1 @@
+{"files": ["state.md"], "must_contain": ["Immutable evaluation state", "repository is clean"]}

--- a/evals/cases/shepherd-novel/prompt.md
+++ b/evals/cases/shepherd-novel/prompt.md
@@ -1,0 +1,3 @@
+Two consecutive monitoring polls show unchanged pending checks. Review the
+correct next action from the immutable state. Do not run a polling command or
+perform any local or remote mutation.

--- a/evals/fixtures/text/draft.md
+++ b/evals/fixtures/text/draft.md
@@ -1,0 +1,5 @@
+We shipped a faster import flow.
+
+The p95 fell from 1.8 seconds to 1.1 seconds in the release benchmark. The
+change removes a duplicate parse, but we still need production data before
+claiming that every project will see the same improvement.

--- a/evals/fixtures/workflow-subagents/.agents/skills/implement/SKILL.md
+++ b/evals/fixtures/workflow-subagents/.agents/skills/implement/SKILL.md
@@ -1,0 +1,9 @@
+---
+name: implement
+description: Use when an implementation owner must deliver one supplied work item.
+---
+
+# Implement
+
+Implement only the supplied work item, validate it, and return the committed
+result or an actionable blocker.

--- a/evals/fixtures/workflow-subagents/state.md
+++ b/evals/fixtures/workflow-subagents/state.md
@@ -1,0 +1,8 @@
+# Immutable evaluation state
+
+Network access is disabled. The user has authorized analysis of this supplied
+state only; no GitHub, GitLab, or local repository mutation is authorized.
+
+The controller owns any shared workflow mutation. The repository is clean at
+the recorded base, and the evaluation fixture provides a minimal `implement`
+dependency to every arm.

--- a/evals/fixtures/workflow/state.md
+++ b/evals/fixtures/workflow/state.md
@@ -1,0 +1,8 @@
+# Immutable evaluation state
+
+Network access is disabled. The user has authorized analysis of this supplied
+state only; no GitHub, GitLab, or local repository mutation is authorized.
+
+The controller owns any shared workflow mutation. The repository is clean at
+the recorded base, and the evaluation fixture provides a minimal `implement`
+dependency to every arm.

--- a/evals/fixtures/workflow/state.md
+++ b/evals/fixtures/workflow/state.md
@@ -4,5 +4,4 @@ Network access is disabled. The user has authorized analysis of this supplied
 state only; no GitHub, GitLab, or local repository mutation is authorized.
 
 The controller owns any shared workflow mutation. The repository is clean at
-the recorded base, and the evaluation fixture provides a minimal `implement`
-dependency to every arm.
+the recorded base.

--- a/evals/harness/cases.py
+++ b/evals/harness/cases.py
@@ -49,6 +49,7 @@ class EvalCase:
     provenance: dict[str, str]
     prompt: str
     directory: Path
+    constant_skills: tuple[str, ...] = ()
     required_command_patterns: tuple[str, ...] = ()
     forbidden_command_patterns: tuple[str, ...] = ()
     calibration: bool = False
@@ -143,8 +144,33 @@ def load_case(manifest_path: Path, repo_root: Path) -> EvalCase:
     fixture = _require_string(data, "fixture")
     if not _safe_relative(fixture):
         raise CaseValidationError("fixture must be a safe relative path")
-    if not (repo_root / "evals" / "fixtures" / fixture).is_dir():
+    fixture_root = repo_root / "evals" / "fixtures" / fixture
+    if not fixture_root.is_dir():
         raise CaseValidationError(f"missing fixture: evals/fixtures/{fixture}")
+
+    constant_skills = (
+        _require_string_list(data, "constant_skills")
+        if "constant_skills" in data
+        else ()
+    )
+    if any(not _ID_PATTERN.fullmatch(skill) for skill in constant_skills):
+        raise CaseValidationError("constant_skills must use lowercase kebab-case")
+    public_constants = set(constant_skills) & set(PUBLIC_SKILLS)
+    if public_constants:
+        raise CaseValidationError(
+            "constant_skills cannot be measured public skills: "
+            f"{sorted(public_constants)}"
+        )
+    fixture_constants = tuple(
+        sorted(
+            path.parent.name
+            for path in (fixture_root / ".agents" / "skills").glob("*/SKILL.md")
+        )
+    )
+    if fixture_constants != tuple(sorted(constant_skills)):
+        raise CaseValidationError(
+            "constant_skills must exactly declare fixture .agents/skills dependencies"
+        )
 
     allowed_write_paths = _require_string_list(data, "allowed_write_paths")
     if task_mode == "review" and allowed_write_paths:
@@ -227,6 +253,7 @@ def load_case(manifest_path: Path, repo_root: Path) -> EvalCase:
         calibration=calibration,
         prompt=prompt,
         directory=manifest_path.parent,
+        constant_skills=constant_skills,
         required_command_patterns=command_patterns["required_command_patterns"],
         forbidden_command_patterns=command_patterns["forbidden_command_patterns"],
     )

--- a/evals/harness/codex.py
+++ b/evals/harness/codex.py
@@ -132,6 +132,9 @@ def _skill_config(
         _workspace_skill_path(workspace, skill)
         for skill in _enabled_skills(case, arm)
     }
+    enabled.update(
+        _workspace_skill_path(workspace, skill) for skill in case.constant_skills
+    )
     entries = []
     configured_paths = set(skill_paths) | enabled
     for skill_path in sorted(configured_paths, key=str):
@@ -145,8 +148,9 @@ def _subject_prompt(case: EvalCase, arm: str) -> str:
     prompt = case.prompt.rstrip()
     prompt += (
         "\n\nIf you run Gradle, use `--offline --no-scan`. In `skills_used`, report "
-        "only skills whose SKILL.md instructions you actually read and followed during "
-        "this run; otherwise return an empty list."
+        "only public repository skill entrypoints whose SKILL.md instructions you "
+        "actually read and followed during this run; otherwise return an empty list. "
+        "Do not report evaluator-owned fixture dependencies."
     )
     if arm == "forced":
         invocations = ", ".join(f"${skill}" for skill in case.target_skills)

--- a/evals/harness/suites.py
+++ b/evals/harness/suites.py
@@ -12,6 +12,7 @@ PUBLIC_SKILLS = (
     "compose-state-and-effects",
     "compose-ui-testing-patterns",
     "gradle-run",
+    "grounded-writing",
     "implement-with-subagents",
     "kotlin-api-design",
     "kotlin-concurrency-and-flow",
@@ -63,6 +64,12 @@ KOTLIN_GRADLE_SKILLS = (
     "kotlin-concurrency-and-flow",
     "kotlin-control-flow",
 )
+WORKFLOWS_WRITING_SKILLS = (
+    "grounded-writing",
+    "implement-with-subagents",
+    "run-github-project",
+    "shepherd",
+)
 
 
 SUITES = {
@@ -83,6 +90,14 @@ SUITES = {
         routing_cases=3,
         require_skill_triads=True,
         historical_minimum=3,
+    ),
+    "workflows-writing": SuitePolicy(
+        id="workflows-writing",
+        title="Workflows and writing",
+        skills=WORKFLOWS_WRITING_SKILLS,
+        benchmark_cases=12,
+        routing_cases=0,
+        require_skill_triads=True,
     ),
 }
 

--- a/evals/schemas/subject-output.schema.json
+++ b/evals/schemas/subject-output.schema.json
@@ -7,7 +7,7 @@
     "summary": { "type": "string" },
     "skills_used": {
       "type": "array",
-      "description": "Only skills whose SKILL.md instructions were actually read and followed during this run.",
+      "description": "Only public repository skills whose SKILL.md instructions were actually read and followed during this run; omit evaluator-owned fixture dependencies.",
       "items": {
         "type": "string"
       }

--- a/evals/tests/test_codex_runner.py
+++ b/evals/tests/test_codex_runner.py
@@ -100,14 +100,18 @@ class CodexRunnerTest(unittest.TestCase):
             self.assertIn("SKILL.md", rendered)
         self.assertEqual(1, " ".join(none).count("path = "))
         self.assertEqual(2, " ".join(forced).count("path = "))
-        self.assertEqual(16, " ".join(automatic).count("path = "))
+        self.assertEqual(17, " ".join(automatic).count("path = "))
         self.assertEqual(0, " ".join(none).count("enabled = true"))
         self.assertEqual(1, " ".join(forced).count("enabled = true"))
-        self.assertEqual(15, " ".join(automatic).count("enabled = true"))
+        self.assertEqual(16, " ".join(automatic).count("enabled = true"))
         self.assertIn("$compose-state-and-effects", forced[-1])
         self.assertNotIn("$compose-state-and-effects", automatic[-1])
         self.assertIn("If you run Gradle, use `--offline --no-scan`.", automatic[-1])
-        self.assertIn("only skills whose SKILL.md instructions you actually read", automatic[-1])
+        self.assertIn(
+            "only public repository skill entrypoints whose SKILL.md instructions you "
+            "actually read",
+            automatic[-1],
+        )
         self.assertNotEqual(case.prompt, automatic[-1])
 
     def test_discovers_repo_and_external_skill_files_without_duplicates(self):

--- a/evals/tests/test_workflows_writing_matrix.py
+++ b/evals/tests/test_workflows_writing_matrix.py
@@ -1,0 +1,87 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from evals.harness.cases import validate_corpus
+from evals.harness.codex import RunConfig, build_subject_command, prepare_workspace
+from evals.harness.experiment import filter_cases
+from evals.harness.suites import PUBLIC_SKILLS, WORKFLOWS_WRITING_SKILLS
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+class WorkflowsWritingMatrixTest(unittest.TestCase):
+    def test_has_exact_skill_triads_without_routing_or_to_plan(self):
+        report = validate_corpus(REPO_ROOT, suite="workflows-writing")
+
+        self.assertEqual(12, report.case_count)
+        self.assertIn("grounded-writing", PUBLIC_SKILLS)
+        self.assertNotIn("implement", PUBLIC_SKILLS)
+        self.assertEqual(12, len(filter_cases(report.cases, case_ids=None, skills=None)))
+        self.assertFalse(any(case.kind == "routing" for case in report.cases))
+        self.assertFalse(any(case.calibration for case in report.cases))
+        self.assertFalse(any("to-plan" in case.target_skills for case in report.cases))
+        for skill in WORKFLOWS_WRITING_SKILLS:
+            kinds = {case.kind for case in report.cases if skill in case.target_skills}
+            with self.subTest(skill=skill):
+                self.assertEqual({"direct", "novel", "negative"}, kinds)
+
+        subagent_cases = [
+            case for case in report.cases if case.fixture == "workflow-subagents"
+        ]
+        self.assertEqual(3, len(subagent_cases))
+        self.assertTrue(
+            all(
+                case.target_skills == ("implement-with-subagents",)
+                and case.constant_skills == ("implement",)
+                for case in subagent_cases
+            )
+        )
+        self.assertTrue(
+            all(
+                not case.constant_skills
+                for case in report.cases
+                if case.fixture == "workflow"
+            )
+        )
+
+    def test_workflow_fixture_supplies_the_implement_dependency_in_every_arm(self):
+        report = validate_corpus(REPO_ROOT, suite="workflows-writing")
+        case = next(
+            case
+            for case in report.cases
+            if case.id == "implement-with-subagents-direct"
+        )
+        config = RunConfig(model="gpt-5.6-terra", reasoning="medium")
+
+        for arm in ("none", "forced", "automatic"):
+            with self.subTest(arm=arm), tempfile.TemporaryDirectory() as temp_dir:
+                workspace = Path(temp_dir) / "workspace"
+                command = build_subject_command(
+                    case, arm, REPO_ROOT, workspace, config, skill_paths=()
+                )
+                rendered = " ".join(command)
+                self.assertIn(
+                    str(workspace / ".agents/skills/implement/SKILL.md"), rendered
+                )
+                self.assertIn("enabled = true", rendered)
+
+                prepare_workspace(case, REPO_ROOT, workspace)
+                self.assertTrue(
+                    (workspace / ".agents/skills/implement/SKILL.md").is_file()
+                )
+
+    def test_workflow_prompts_do_not_disclose_the_target_skill(self):
+        report = validate_corpus(REPO_ROOT, suite="workflows-writing")
+
+        for case in report.cases:
+            with self.subTest(case=case.id):
+                prompt = case.prompt.lower()
+                self.assertNotIn("$", prompt)
+                for skill in case.expected_skills:
+                    self.assertNotIn(skill, prompt)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/compose-animations/SKILL.md
+++ b/skills/compose-animations/SKILL.md
@@ -7,80 +7,40 @@ description: "Use when writing or reviewing Jetpack Compose motion: visibility e
 
 ## Core principle
 
-Pick the **smallest API that matches the problem**: built-in visibility and layout transitions first, then a single animated value, then a shared transition object when several values must move together, then gesture-level or imperative APIs when the framework cannot express the motion.
+Pick the smallest API that expresses the motion and its lifecycle.
 
-## Review procedure
+## Procedure
 
-1. Identify the visual job: show/hide, one value, coordinated values, content swap, size change, or gesture-driven motion.
-2. Choose the smallest API from the table below.
-3. Check lifecycle semantics: should hidden content leave composition, keep focus/state, or only become transparent?
-4. Check identity: render each `AnimatedContent` branch from its content-lambda target, then choose `contentKey` by visual shape rather than payload churn.
-5. Check performance: keep frame-rate animation values as `State` and read them in layout/draw block modifiers when possible.
-6. Escalate to `Animatable` or lower-level APIs only when target-state animation cannot express the motion.
-7. Finish when the chosen API matches the visual and lifecycle needs, any content-swap identity is preserved, no simpler API fits, and the relevant behavior has been verified.
+1. Identify the job: show or hide a subtree, animate one value, coordinate values from one state, resize content, swap content, or handle user-driven motion.
+2. Choose the matching API from the table. Prefer target-state APIs; use `Animatable` only when gestures, interruption, or imperative control require it.
+3. Check lifecycle: an alpha animation keeps content composed; `AnimatedVisibility` removes it after exit. Do not use a fade when unmounting is required.
+4. For `AnimatedContent`, render from the content lambda target and choose a `contentKey` only when visual identity differs from payload equality. Read [AnimatedContent identity](references/animated-content.md) for state-holder details.
+5. Keep animated `State` in layout or draw block modifiers when it changes at frame rate; route deeper diagnosis to [Compose performance](../compose-performance/SKILL.md).
+6. Use Navigation Compose transitions for destination swaps it owns, and dedicated libraries for art-based motion.
+7. Finish when the API, lifecycle, and content identity match the UI, no simpler API fits, and the relevant behavior is verified.
 
-## Pick the smallest animation API
+## API choice
 
-| Need | API |
+| Need | Prefer |
 |---|---|
-| Show or hide a subtree with enter/exit semantics; content is removed after exit completes | [`AnimatedVisibility`](https://developer.android.com/develop/ui/compose/animation/composables-modifiers#animatedvisibility) |
-| Animate one property toward a target derived from state | [`animateFloatAsState`](https://developer.android.com/develop/ui/compose/animation/value-based#animate-as-state) / `animateDpAsState` / `animateColorAsState` / `animateOffsetAsState` / … |
-| Several animated values keyed off one boolean, enum, or sealed state | `rememberTransition` + transition child animations (`animateFloat`, `animateDp`, `animateColor`, `animateValue`, …) |
-| Smooth size when child layout height/width changes (e.g. text wraps) | `Modifier.animateContentSize()` |
-| Swap between different composable trees for the same slot | `AnimatedContent` or `Crossfade` |
-| User-driven motion (drag, fling, interruptible springs) | [`Animatable`](https://developer.android.com/reference/kotlin/androidx/compose/animation/core/Animatable) and related coroutine APIs (see Advanced pointers) |
+| Show/hide a subtree with enter/exit semantics | [`AnimatedVisibility`](https://developer.android.com/develop/ui/compose/animation/composables-modifiers#animatedvisibility) |
+| One value follows state | `animate*AsState` |
+| Several values follow one boolean, enum, or sealed state | `rememberTransition` plus child animations |
+| Child size changes | `Modifier.animateContentSize()` |
+| Different composable trees fill one region | `AnimatedContent`, or `Crossfade` for the simple case |
+| Drag, fling, interruption, or imperative control | [`Animatable`](https://developer.android.com/reference/kotlin/androidx/compose/animation/core/Animatable) |
 
-## Appear and disappear
-
-**Prefer `AnimatedVisibility`** when the UI should leave or join the tree with enter/exit transitions.
-
-```kotlin
-AnimatedVisibility(visible = expanded) {
-    Text("Details…")
-}
-```
-
-**`animateFloatAsState` on alpha** only fades; the composable **stays in composition** and continues to participate in layout unless you gate it yourself. Use that tradeoff when you intentionally keep children mounted (state, focus) but visually hidden. For true remove-from-tree behavior, use `AnimatedVisibility` (or conditional composition with `AnimatedVisibility` / `AnimatedContent` patterns from the [quick guide](https://developer.android.com/develop/ui/compose/animation/quick-guide)).
-
-## Background color
-
-Use `animateColorAsState` for smooth color targets.
-
-For animated fills behind children, the [quick guide](https://developer.android.com/develop/ui/compose/animation/quick-guide) recommends drawing with **`Modifier.drawBehind`** rather than `Modifier.background()` so the animated color is applied in the draw phase appropriately for performance.
-
-```kotlin
-val background = animateColorAsState(
-    targetValue = if (selected) selectedColor else idleColor,
-    label = "background",
-)
-Box(
-    Modifier.drawBehind { drawRect(background.value) },
-) { /* content */ }
-```
-
-## Size changes
-
-`Modifier.animateContentSize()` animates layout size changes—common for expanding/collapsing text or dynamic chips—without hand-rolling width/height animations.
-
-## Value-based animations (`animate*AsState`)
-
-Compose provides `animate*AsState` for `Float`, `Dp`, `Color`, `Size`, `Offset`, `Rect`, `Int`, `IntOffset`, `IntSize`, and more. You supply the **target**; the API owns the animation state.
-
-- Pass an [`AnimationSpec`](https://developer.android.com/reference/kotlin/androidx/compose/animation/core/AnimationSpec) via `animationSpec` (e.g. `spring`, `tween`) when defaults are wrong for the UI.
-- Set a distinct **`label`** for debugging and tooling when multiple animations exist in one composable.
-- For completion or sequencing details, see [Value-based animations](https://developer.android.com/develop/ui/compose/animation/value-based).
+Use an `AnimationSpec` when the default motion is wrong and a distinct `label` when multiple animations need tooling visibility.
 
 ```kotlin
 val width by animateDpAsState(
     targetValue = if (expanded) 200.dp else 56.dp,
-    animationSpec = spring(dampingRatio = 0.7f, stiffness = Spring.StiffnessMedium),
+    animationSpec = spring(dampingRatio = 0.7f),
     label = "fabWidth",
 )
 ```
 
-## Multiple properties: `rememberTransition`
-
-When one piece of state (e.g. `enum class Phase { A, B, C }`) should drive **several** animated values in lockstep, use `rememberTransition` and define child animations on that transition:
+For values that must remain synchronized, define them on one transition rather than several independent `animate*AsState` calls:
 
 ```kotlin
 val transition = rememberTransition(targetState = phase, label = "phase")
@@ -92,123 +52,9 @@ val offset by transition.animateDp(label = "offset") { target ->
 }
 ```
 
-Avoid multiple independent `animate*AsState` calls that should stay visually synchronized but can drift if specs or targets diverge. Older code may use `updateTransition`; prefer `rememberTransition` for new code.
-
-## Choosing between content-level APIs
-
-Use the official [Choose an animation API](https://developer.android.com/develop/ui/compose/animation/choose-api) tree when the table is not enough. Compressed rules:
-
-| Situation | Prefer |
-|---|---|
-| Same composable, different **target values** for layout properties | `animate*AsState` or `rememberTransition` |
-| Different **composable content** for the same region (tabs, steps) | `AnimatedContent` (custom `transitionSpec`, `contentKey`) or simpler `Crossfade` |
-| Pager-like **swipe between pages** | Horizontal pager APIs from the animation docs / Material—follow the choose-api guidance |
-| Transitions **owned by Navigation Compose** | Use navigation’s built-in transitions rather than bolting `AnimatedContent` on top of the same destination swap |
-
-**Art-based motion** (illustrations, Lottie, complex vector timelines) is outside this skill; use dedicated libraries.
-
-## Decision flow (high level)
-
-```mermaid
-flowchart TD
-  start[Animation_need]
-  start --> showHide{Show_or_hide_subtree}
-  showHide -->|yes| av[AnimatedVisibility]
-  showHide -->|no| oneProp{Single_property_to_target}
-  oneProp -->|yes| asState["animate*AsState"]
-  oneProp -->|no| multiProp{Many_props_one_state}
-  multiProp -->|yes| rt[rememberTransition]
-  multiProp -->|no| swapTree{Different_composable_content}
-  swapTree -->|yes| ac[AnimatedContent_or_Crossfade]
-  swapTree -->|no| advanced[Animatable_or_lower_level]
-```
-
-## AnimatedContent keys for state holders
-
-`AnimatedContent` can keep outgoing and incoming content composed at the same time. Render from the content lambda's target value, not a captured outer state value; otherwise both branches can show the latest state and effects inside them can act on the wrong content identity.
-
-```kotlin
-// Wrong: outgoing and incoming branches both read the latest selectedId.
-AnimatedContent(targetState = selectedId) {
-    Destination(selectedId)
-}
-
-// Right: each branch keeps the identity AnimatedContent assigned to it.
-AnimatedContent(targetState = selectedId) { targetId ->
-    Destination(targetId)
-}
-```
-
-When `AnimatedContent` receives a state-holder wrapper such as `AsyncResult<T>`, `Result<T>`, or a sealed `UiState`, decide what should actually trigger the transition. Usually the animation should run when the **content shape** changes (loading → content → error), not when the payload inside the same shape changes.
-
-Use `contentKey` to map rich state to the animation identity:
-
-```kotlin
-AnimatedContent(
-    targetState = result,
-    contentKey = { state ->
-        when (state) {
-            AsyncResult.Loading -> "loading"
-            is AsyncResult.Success -> "content"
-            is AsyncResult.Error -> "error"
-        }
-    },
-    label = "profile-content",
-) { state ->
-    when (state) {
-        AsyncResult.Loading -> Loading()
-        is AsyncResult.Success -> Profile(state.value)
-        is AsyncResult.Error -> ErrorMessage(state.throwable)
-    }
-}
-```
-
-Without `contentKey`, every unequal `Success(value)` can be treated as new content. That is useful if a payload change should animate, but noisy when fresh data updates the same screen shape.
-
-Choose keys by visual shape:
-
-| State change | Typical `contentKey` |
-|---|---|
-| Loading → Success → Error | Branch key: `"loading"`, `"content"`, `"error"` |
-| Success item A → Success item B should crossfade | Stable item id |
-| Success data refresh should update in place | Constant content key for `Success` |
-| Error message text changes but error UI shape stays | Constant content key for `Error` |
-
-## Animated values and composition performance
-
-`animate*AsState` returns `State` that updates frequently. If that value feeds `Modifier.offset`, `Modifier.graphicsLayer`, scroll-adjacent layout, or other **frame-rate** paths, avoid reading it in the composable body with `by` and then passing it into value-form modifiers—use **deferred reads** (block modifiers, draw/ layout lambdas) instead. See [Compose performance](../compose-performance/SKILL.md).
-
-If recomposition counters spike during motion unrelated to bad stability, see [Compose performance](../compose-performance/SKILL.md).
-
-## Escalation points
-
-Load the official docs when one of these applies:
-
-| Need | Start with |
-|---|---|
-| API tree is still ambiguous | [Choose an animation API](https://developer.android.com/develop/ui/compose/animation/choose-api) |
-| Gesture-driven, interruptible, or cancelable motion | [`Animatable`](https://developer.android.com/reference/kotlin/androidx/compose/animation/core/Animatable), pointer input, decay |
-| Infinite or repeating cycles | [`rememberInfiniteTransition`](https://developer.android.com/reference/kotlin/androidx/compose/animation/core/rememberInfiniteTransition) |
-| Seekable or test-controlled progress | [`SeekableTransitionState`](https://developer.android.com/reference/kotlin/androidx/compose/animation/core/SeekableTransitionState) and related APIs |
-
-## Common mistakes
-
-| Mistake | Fix |
-|---|---|
-| Fade with `animateFloatAsState(alpha)` but expect children to unmount | Use `AnimatedVisibility` or remove the subtree from composition when hidden |
-| Three `animateDpAsState` calls that must stay in sync with one enum | One `rememberTransition` + child animations |
-| Animated color on `Modifier.background` causing extra work | Prefer `drawBehind { drawRect(animatedColor) }` per quick guide |
-| Chaining `LaunchedEffect` + manual `Animatable` for simple target animation | Prefer `animate*AsState` or `rememberTransition` unless gestures require `Animatable` |
-| Ignoring Navigation’s own transitions | Use Nav APIs for destination transitions; do not duplicate with `AnimatedContent` for the same swap |
-| Reading outer state inside `AnimatedContent`'s content lambda | Render from the lambda target so outgoing and incoming content retain distinct identities |
-| `AnimatedContent(targetState = asyncResult)` animates on every data refresh | Add `contentKey` based on the visual shape or stable item identity |
-
-## RED/GREEN agent scenarios
-
-1. Novel case: focus moves while `AnimatedContent` swaps between two destinations. RED renders both branches from captured outer state. GREEN renders and keys effects from the lambda target, then tests focus after the transition settles.
-2. Counterexample: a single composable only animates one color value. GREEN keeps `animateColorAsState` and does not introduce `AnimatedContent` or content identity machinery.
+For animated fills, prefer `drawBehind { drawRect(color.value) }` over a value-form background when the color updates every frame. For an API ambiguity, start with the official [Choose an animation API](https://developer.android.com/develop/ui/compose/animation/choose-api) guide; use [`rememberInfiniteTransition`](https://developer.android.com/reference/kotlin/androidx/compose/animation/core/rememberInfiniteTransition) for repeating cycles and [`SeekableTransitionState`](https://developer.android.com/reference/kotlin/androidx/compose/animation/core/SeekableTransitionState) for seekable or test-controlled progress.
 
 ## When not to use this skill
 
-- **Side-effect timing** (`LaunchedEffect`, clicks launching work): use [Compose state and effects](../compose-state-and-effects/SKILL.md).
-- **Deep performance tuning** of where snapshot state is read: use [Compose performance](../compose-performance/SKILL.md) as the primary reference.
+- For side-effect timing or click-launched work, use [Compose state and effects](../compose-state-and-effects/SKILL.md).
+- For deep state-read or recomposition diagnosis, use [Compose performance](../compose-performance/SKILL.md).

--- a/skills/compose-animations/references/animated-content.md
+++ b/skills/compose-animations/references/animated-content.md
@@ -1,0 +1,45 @@
+# AnimatedContent identity
+
+`AnimatedContent` keeps outgoing and incoming content composed together. Render from its content-lambda target rather than captured outer state, so each branch keeps the identity assigned to it.
+
+```kotlin
+// Wrong: both branches can read the newest selectedId.
+AnimatedContent(targetState = selectedId) {
+    Destination(selectedId)
+}
+
+// Right: each branch receives its own target.
+AnimatedContent(targetState = selectedId) { targetId ->
+    Destination(targetId)
+}
+```
+
+For a state holder such as `AsyncResult<T>` or a sealed `UiState`, key the transition by the visual shape when payload refreshes should update in place:
+
+```kotlin
+AnimatedContent(
+    targetState = result,
+    contentKey = { state ->
+        when (state) {
+            AsyncResult.Loading -> "loading"
+            is AsyncResult.Success -> "content"
+            is AsyncResult.Error -> "error"
+        }
+    },
+    label = "profile-content",
+) { state ->
+    when (state) {
+        AsyncResult.Loading -> Loading()
+        is AsyncResult.Success -> Profile(state.value)
+        is AsyncResult.Error -> ErrorMessage(state.throwable)
+    }
+}
+```
+
+| Change | Typical key |
+|---|---|
+| Loading, content, and error have different shapes | A branch key |
+| Different items should crossfade | Stable item id |
+| A data refresh stays in the same shape | One key for that branch |
+
+Without `contentKey`, unequal payloads can animate as new content. Keep that default only when the payload change itself is the desired transition.

--- a/skills/compose-component-design/SKILL.md
+++ b/skills/compose-component-design/SKILL.md
@@ -39,18 +39,3 @@ policy choices that vary by use.
 | Animation belongs to the public component contract | [Compose animations](../compose-animations/SKILL.md) |
 | State ownership changes while designing the component | [Compose state and effects](../compose-state-and-effects/SKILL.md) |
 | Semantics or screenshot coverage is needed | [Compose UI testing patterns](../compose-ui-testing-patterns/SKILL.md) |
-
-## RED/GREEN agent scenarios
-
-1. RED exposes `title: String`, `icon: ImageVector?`, and several display
-   flags for a reusable card. GREEN keeps invariant chrome and gives callers
-   the variable regions as named slots.
-2. Novel case: a component needs both a root modifier and caller-supplied
-   trailing content. GREEN applies the modifier at the root and supplies a
-   trailing slot without leaking the component's `RowScope`; reserve a scope
-   receiver for a region whose child layout is deliberately caller-controlled.
-3. Counterexample: a private screen helper has one fixed child and no callers.
-   GREEN keeps it simple instead of inventing slots for hypothetical reuse.
-4. Focused counterexample: a status label intentionally maps a semantic enum to
-   fixed copy, and the task asks only whether it needs slots. GREEN leaves the
-   workspace unchanged instead of adding an unrelated root modifier.

--- a/skills/compose-component-design/references/modifier-layout.md
+++ b/skills/compose-component-design/references/modifier-layout.md
@@ -2,100 +2,18 @@
 
 ## Core principle
 
-A composable that emits layout is a leaf the *parent* places — the parent decides position, size, alignment, padding. The composable's job is structure (what's inside), not placement (where it goes). Three rules follow:
+The parent owns placement; a reusable composable owns its invariant structure.
 
-- **Declare a `modifier` parameter and apply it to the root**, so the parent can actually do its job. Hardcoding `.fillMaxWidth()` on a composable's root takes that decision away from every future caller.
-- **Construct modifier chains as one fluent expression**, not stepwise reassignments. Both compile to the same thing, but the chain *reads* as intent in one pass.
-- **Conditional rendering belongs where the condition applies.** A layout call whose only content is one `if` exists solely to hold the condition — push the `if` outside instead.
+## Procedure
 
-These travel together because the same composable usually triggers all three: you declare its parameters (rule 1), the caller constructs a chain to position it (rules 2), and the body has a conditional you might be tempted to wrap (rule 3).
-
-## When to use this skill
-
-- You're writing a `@Composable fun` that calls a layout (`Box`, `Column`, `Row`, `LazyColumn`, `Text`, `Image`, `Surface`, `Card`, `Layout { … }`, anything from `compose.foundation.layout` or `compose.material*`) and its signature has no `modifier` parameter, or has one that isn't applied to the root, or has a hardcoded `.fillMaxWidth()`/`.padding(...)` on the root.
-- You see `var m = Modifier` followed by `m = m.padding(…)`, `m = m.background(…)`, etc.
-- A `modifier = …` argument has three or more chained calls on a single line.
-- A composable's body is `Layout { if (cond) Content() }` — one conditional, nothing else.
-
-## 1. Declare a `modifier` parameter
-
-For composables that emit layout, prefer a `modifier` parameter after required parameters and before content/lambda parameters, with a default of `Modifier`. The name is exactly `modifier` — not `mod`, not `m`, not `wrapperModifier`.
+1. For a composable that emits layout, declare `modifier: Modifier = Modifier` after required parameters and apply it to the root layout.
+2. Put the caller modifier first in the root chain, then append intrinsic identity modifiers. Push positioning, padding, and general size decisions to the caller.
+3. Build a modifier as one fluent expression. Keep one or two calls inline; format three or more calls one per line. Use `.then(if (condition) Modifier.x() else Modifier)` for a conditional segment.
+4. Hoist a condition outside a layout only when the layout has no other content or visible container role. Keep it inside when the container has semantics, layout arguments, siblings, or both `if` branches contribute content.
+5. Use `decorateMeasureConstraints` only when a measurement must be consumed during measure; route phase ownership and the cross-row recipe to [Deferred reads](../../compose-performance/references/deferred-reads.md).
+6. Finish when callers can place the component, intrinsic structure remains local, and no refactor changes a container's visible or layout role.
 
 ```kotlin
-// ❌ BAD — no modifier param; caller can't position, size, or constrain this
-@Composable
-fun HomeScreenHeader(title: String, subtitle: String) {
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = 16.dp),
-        verticalArrangement = Arrangement.spacedBy(4.dp),
-    ) {
-        Text(title, style = MaterialTheme.typography.headlineLarge)
-        Text(subtitle, style = MaterialTheme.typography.bodyMedium)
-    }
-}
-```
-
-```kotlin
-// ✅ GOOD — parent decides width and padding; the composable describes structure only
-@Composable
-fun HomeScreenHeader(
-    title: String,
-    subtitle: String,
-    modifier: Modifier = Modifier,
-) {
-    Column(
-        modifier = modifier,
-        verticalArrangement = Arrangement.spacedBy(4.dp),
-    ) {
-        Text(title, style = MaterialTheme.typography.headlineLarge)
-        Text(subtitle, style = MaterialTheme.typography.bodyMedium)
-    }
-}
-```
-
-The caller now writes `HomeScreenHeader(title, subtitle, Modifier.fillMaxWidth().padding(horizontal = 16.dp))` once, at the home screen — the only place that knows the layout actually wants those.
-
-## 2. Apply the caller's modifier to the root, and apply it first
-
-When the root layout already takes other arguments (alignment, arrangement, padding *that's intrinsic to the composable*), the caller-provided modifier still goes on the root layout's `modifier` parameter — and the composable's local chain is appended after.
-
-```kotlin
-// ❌ BAD — modifier accepted but never applied
-@Composable
-fun Avatar(url: String, modifier: Modifier = Modifier) {
-    Image(painter = rememberAsyncImagePainter(url), contentDescription = null)
-}
-
-// ❌ BAD — applied to a child, not the root; caller's size/position changes don't take
-@Composable
-fun Avatar(url: String, modifier: Modifier = Modifier) {
-    Box {
-        Image(
-            painter = rememberAsyncImagePainter(url),
-            contentDescription = null,
-            modifier = modifier,
-        )
-    }
-}
-
-// ❌ BAD — caller's modifier ends up last, so the composable's own size wins
-@Composable
-fun Avatar(url: String, modifier: Modifier = Modifier) {
-    Image(
-        painter = rememberAsyncImagePainter(url),
-        contentDescription = null,
-        modifier = Modifier
-            .clip(CircleShape)
-            .size(48.dp)
-            .then(modifier),
-    )
-}
-```
-
-```kotlin
-// ✅ GOOD — caller's modifier first, then the composable's intrinsic chain
 @Composable
 fun Avatar(url: String, modifier: Modifier = Modifier) {
     Image(
@@ -108,84 +26,9 @@ fun Avatar(url: String, modifier: Modifier = Modifier) {
 }
 ```
 
-Order matters: in a modifier chain, the *earlier* segment is the outer wrapper. The caller's modifier should be the outermost so caller-provided `.size(...)` or `.padding(...)` can override the composable's defaults rather than being overridden by them.
-
-## 3. Don't hardcode layout decisions on the root
-
-If the composable's root has `.fillMaxWidth()`, `.padding(horizontal = 16.dp)`, `.height(56.dp)`, etc., the caller can't *not* have them. Those are layout choices the parent should own.
+`clip(CircleShape)` and a default avatar size can be intrinsic; `fillMaxWidth`, screen padding, alignment, and placement usually are not. A modifier on a child does not make the root caller-placeable.
 
 ```kotlin
-// ❌ BAD — every caller now fills max width whether they want to or not
-@Composable
-fun PrimaryButton(text: String, onClick: () -> Unit, modifier: Modifier = Modifier) {
-    Button(
-        onClick = onClick,
-        modifier = modifier.fillMaxWidth(),   // ← hardcoded
-    ) { Text(text) }
-}
-
-// ✅ GOOD — caller adds .fillMaxWidth() if (and only if) they want it
-@Composable
-fun PrimaryButton(text: String, onClick: () -> Unit, modifier: Modifier = Modifier) {
-    Button(onClick = onClick, modifier = modifier) { Text(text) }
-}
-```
-
-The carve-out is for modifiers that are part of the **identity** of the composable — what makes an `Avatar` an avatar (the `.clip(CircleShape)` and a default `.size(48.dp)`), not where it sits on the screen. Test: can you imagine a caller wanting a version of this composable *without* that modifier? If yes, push it out. If no (an avatar without `clip(CircleShape)` isn't an avatar), keep it — but put it *after* the caller's modifier in the chain (see §2).
-
-## 4. Construct modifier chains as one fluent expression
-
-Recomposition re-runs the composable body — every modifier expression is re-evaluated. Reassigning `var modifier =` step-by-step looks plausible but breaks the visual flow, invites further mutation, and produces nothing a chain doesn't.
-
-```kotlin
-// ❌ BAD — visual flow broken into reassignments; `var` invites more mutation
-@Composable
-fun Demo() {
-    var m = Modifier
-    m = m.padding(16.dp)
-    m = m.fillMaxSize()
-    Box(m) { }
-}
-
-// ❌ ALSO BAD — same shape, dressed up with .then()
-@Composable
-fun Demo() {
-    var m = Modifier
-    m = m.padding(16.dp)
-    m = m.then(Modifier.fillMaxSize())
-    Box(m) { }
-}
-```
-
-```kotlin
-// ✅ GOOD
-@Composable
-fun Demo() {
-    val m = Modifier
-        .padding(16.dp)
-        .fillMaxSize()
-    Box(m) { }
-}
-```
-
-`val`, not `var`: once the chain is built, nothing should re-bind it. The reassignment shape is what makes `var` look necessary; the chain shape doesn't need it.
-
-### Inline at the call site is fine for short chains
-
-For one or two calls, build the modifier inline. The "extract to a `val`" rule only earns its keep when the chain is long enough to be worth naming, or when the same chain repeats.
-
-```kotlin
-// ✅ GOOD — short chain inline
-Box(modifier = Modifier.fillMaxWidth()) { … }
-Box(modifier = Modifier.padding(8.dp).background(Color.Red)) { … }
-```
-
-### Conditional segments stay on the chain
-
-A common reason to reach for `var` is "the modifier depends on a condition." It doesn't — splice the condition inline:
-
-```kotlin
-// ✅ GOOD — conditional inside the chain, still one expression
 Box(
     modifier = Modifier
         .fillMaxWidth()
@@ -193,159 +36,24 @@ Box(
 )
 ```
 
-`Modifier` (the empty modifier) is the identity element for `.then` — it lets you keep the chain shape when one branch contributes nothing.
-
-## 5. Multiline formatting at the call site
-
-When a `modifier` argument's chain has **three or more** calls, format multiline with one call per line. Indent the chain so the dotted calls align beneath the value.
-
-```kotlin
-// ❌ BAD — three+ calls on one line; hard to scan
-Box(
-    modifier = modifier.fillMaxSize().padding(16.dp).weight(1f),
-)
-
-// ✅ GOOD
-Box(
-    modifier = modifier
-        .fillMaxSize()
-        .padding(16.dp)
-        .weight(1f),
-)
-```
-
-One or two calls stay on a single line — the threshold is the call count, not the character count. If a single call has very long arguments, that's a different problem (extract a `val`, or shorten the arguments).
-
-This applies *only* to a parameter named `modifier`. Other fluent-style arguments aren't covered here.
-
-## 6. Hoist single conditionals out of the layout
-
-When a layout's *only* content is one `if`, the layout exists solely to "hold" the conditional. Move the `if` outside — the layout will only exist when it has something to show.
-
-```kotlin
-// ❌ BAD — Column always emitted; only its inner content is conditional
-@Composable
-fun A() {
-    Column {
-        if (showHeader) {
-            Text("Title")
-            Text("Subtitle")
-        }
-    }
-}
-
-// ✅ GOOD — Column only exists when it has content
-@Composable
-fun A() {
-    if (showHeader) {
-        Column {
-            Text("Title")
-            Text("Subtitle")
-        }
-    }
-}
-```
-
-The benefit isn't a performance win — the runtime handles both fine — it's that the second form *reads* as "header section, conditionally." The first reads as "always-on column that may or may not have content."
-
-### The carve-outs (and why)
-
-- **Layout carries visual semantics that aren't conditional.** When the layout call passes `modifier`, `contentAlignment`, `horizontalArrangement`, or `verticalAlignment`, those arguments describe the *container*, not the content. Hoisting the conditional either loses those (the container collapses with the content) or duplicates them into both branches. Leave it.
-
-  ```kotlin
-  // ✅ KEEP AS-IS — modifier on the container is doing visible work
-  @Composable
-  fun A(modifier: Modifier = Modifier) {
-      Box(modifier = modifier) {
-          if (something) {
-              Text("Bleh1")
-              Text("Bleh2")
-          }
-      }
-  }
-  ```
-
-- **There are siblings to the `if`.** The layout has other content; the `if` is just one piece. Hoisting either pulls the siblings out (changing the layout) or leaves a different shape behind. Leave it.
-
-- **`if … else …` with both branches contributing composables.** Both branches do work; nothing to hoist; the layout *is* the shared container.
-
-  ```kotlin
-  // ✅ KEEP AS-IS — both branches contribute to the layout
-  Box {
-      if (something) Text("Hint") else innerTextField()
-  }
-  ```
-
-## 7. Measure-phase constraint helper
-
-When a caller must apply captured constraints during measurement, this small
-layout helper keeps the modifier API reusable:
-
 ```kotlin
 fun Modifier.decorateMeasureConstraints(
     decorate: (Constraints) -> Constraints,
 ): Modifier = layout { measurable, incoming ->
     val constraints = decorate(incoming).constrain(incoming)
     val placeable = measurable.measure(constraints)
-    layout(placeable.width, placeable.height) {
-        placeable.placeRelative(0, 0)
-    }
+    layout(placeable.width, placeable.height) { placeable.placeRelative(0, 0) }
 }
 ```
 
-For the state ownership, phase diagnosis, fallback, and cross-row application
-recipe, use [Deferred reads](../../compose-performance/references/deferred-reads.md)
-as the canonical reference.
+## Exceptions
 
-## Quick reference
-
-| Symptom | Diagnosis | Fix |
-|---|---|---|
-| `@Composable fun Foo(text: String)` with `Column`/`Box`/`Text` in body | No `modifier` param (§1) | Add `modifier: Modifier = Modifier`; pass to root |
-| `modifier: Modifier = Modifier` declared but never referenced | Param ignored (§2) | Apply to root layout's `modifier` arg |
-| `modifier` passed to a child, not the root | Wrong target (§2) | Move to the outermost layout's `modifier` |
-| `modifier = Modifier.x().y().then(modifier)` | Caller's modifier last (§2) | Reorder: `modifier = modifier.x().y()` |
-| `modifier = modifier.fillMaxWidth().padding(...)` on a general-purpose component | Layout hardcoded (§3) | Remove the hardcoded calls; let callers add them |
-| Sibling composables in the file don't have `modifier` either | Spreading anti-pattern | Fix this one; fix siblings opportunistically |
-| `mod: Modifier = Modifier` or `wrapperModifier: Modifier = Modifier` | Wrong name (§1) | Rename to exactly `modifier` |
-| `var m = Modifier` followed by `m = m.xxx()` reassignments | Stepwise modifier construction (§4) | One fluent chain on a `val`, or build inline |
-| `var m = Modifier; m = m.then(Modifier.xxx())` | Same shape via `.then` (§4) | Collapse `.then(Modifier.x())` to `.x()` in the chain |
-| Modifier branch needs a condition | Reaching for `var` (§4) | `.then(if (c) Modifier.x() else Modifier)` inside the chain |
-| `modifier = modifier.a().b().c()` on one line | Long chain not formatted (§5) | One call per line, indented under the value |
-| `Layout { if (cond) X() }` with no other content and no layout-tuning args | Hoist (§6) | Move the `if` outside the layout |
-| `Box(modifier = …) { if (cond) X() }` | Layout carries semantics — leave (§6 carve-out) | Keep as-is |
-| `Box { if (cond) X() else Y() }` | Both branches contribute — leave (§6 carve-out) | Keep as-is |
-| Sibling lazy row reads `height(state)` from another row's measurement | Composition-time size coupling (§7) | Capture on measured row; apply via `decorateMeasureConstraints` on siblings |
-
-## When NOT to apply
-
-- **Composables that don't emit layout.** A `@Composable fun computeColor(): Color` or a `@Composable @ReadOnlyComposable` accessor doesn't emit a layout node. No `modifier` parameter needed (and a `@ReadOnlyComposable` couldn't accept one — see [composition contracts](../../compose-performance/references/composition-contracts.md)).
-- **`@Preview` functions.** Previews are throwaway entry points; the framework calls them with no caller. A `modifier` parameter would be unused dead weight.
-- **Test-only composables** inside `*Test` sources whose only caller is `composeTestRule.setContent { … }`. Same reasoning as previews.
-- **Internal layout primitives that take a `modifier` as their *first required* parameter** (very rare; framework-level). The rule is "first *optional* param"; some private utilities legitimately have `modifier` upfront as required.
-- **Modifier assembled imperatively from animation state.** A modifier built by appending values from `Animatable` or other procedural sources may legitimately need intermediate variables. The chain isn't the goal; readability is. If the chain becomes a worse expression, write the imperative form.
-- **Slot APIs that store modifiers** in a data class or builder (rare; usually framework-level code). The fluent-chain idea is about user-site construction.
-- **Test composables** pinning specific recomposition shapes — usually fine either way; don't refactor test composables purely for style.
-
-The declaration-side rules (§1–§3) should not be skipped merely because "this composable is internal", "only used in one place", "I'd rather not have the extra parameter on the signature", or "we know all the callers already". Those are exactly the rationalisations that produce composables that become single-use the day someone wants to call them twice.
-
-## Red flags during review
-
-| Thought | Reality |
-|---|---|
-| "This composable is internal-only — adding `modifier` is over-engineering" | The parameter is eight characters and a default. It's not over-engineering; it's the convention. Skipping it is the over-engineering — it's a custom decision against the grain of every Compose API. |
-| "It's only used in one place, so I know the layout requirements" | "Only used in one place" describes today. The cost of the parameter is paid once; the cost of refactoring callers when the second use site appears is paid per caller. |
-| "The sibling composables in this file don't have `modifier` either, so I'm matching style" | Spreading an anti-pattern isn't matching style. Fix this one. Fix the siblings opportunistically. |
-| "The parent always wants `.fillMaxWidth()` here" | Then the parent passes `.fillMaxWidth()`. The composable doesn't decide that for callers it hasn't met yet. |
-| "I'll add it when someone needs it" | You're someone. You need it now (for the convention). The next caller won't add it either — they'll work around its absence. |
-| "It's a tiny composable — the modifier param is noise" | The param is eight characters at the declaration and zero characters at any call site that doesn't need it. The "noise" is imagined. |
-| "I added `modifier` but kept `.fillMaxWidth()` on the root so the home screen doesn't have to" | Then the *not*-home-screen caller can't unset it. Move the `.fillMaxWidth()` to the caller. |
-| "I need `var` for the modifier because the chain depends on a condition" | A conditional segment is `.then(if (c) Modifier.x() else Modifier)`, still on one chain. No `var` needed. |
-| "Three lines is too few to make multiline" | Three chained calls *is* the threshold. Below three, one line. At or above three, multiline. |
-| "The Column adds nothing but I'll keep it for symmetry" | Then hoist the conditional and keep the Column inside the consequent — symmetry preserved, no always-on container. |
-| "I'll put the `if` inside because the layout already exists" | "Already exists" is the bug. The layout shouldn't exist when the condition is false. |
+- Do not add a modifier to a non-layout `@ReadOnlyComposable` accessor, preview, or test-only single-use composable.
+- A private/framework primitive may require `modifier` as its first required parameter.
+- Keep an imperative modifier construction when animation/procedural state makes a fluent expression less clear.
+- Do not add a root modifier merely because a focused task asks about slots; follow the task scope.
 
 ## Related
 
-- [Slot APIs](slot-apis.md) — the other half of declaring a reusable composable's public API: take `@Composable () -> Unit` slots for variable content. A reusable component takes both a `modifier` parameter *and* slots — caller owns placement *and* what to place.
-- [Compose performance](../../compose-performance/SKILL.md) — back-writing across phases and deferred measurement reads.
+- [Slot APIs](slot-apis.md) for caller-controlled visual content.
+- [Composition contracts](../../compose-performance/references/composition-contracts.md) for read-only accessors.

--- a/skills/compose-component-design/references/slot-apis.md
+++ b/skills/compose-component-design/references/slot-apis.md
@@ -1,42 +1,20 @@
-# Compose: slot API pattern
+# Compose slot API pattern
 
 ## Core principle
 
-A reusable Compose component describes layout structure. Callers provide variable visual content through slots.
+A reusable component owns layout structure; callers provide unconstrained visual content through slots.
 
-## API review procedure
+## Procedure
 
-1. Confirm the component is reusable and slot semantics are within the requested
-   scope. In a focused slot task, do not add unrelated modifier or cleanup changes.
-2. Mark which regions vary by caller: headline, supporting text, leading visual, trailing visual, actions, body.
-3. Replace caller-controlled, unconstrained primitive content and shape flags
-   with slots. Preserve primitive parameters when they intentionally enforce a
-   semantic, design-system, constrained-type, or measured fast-path contract.
-4. Add a receiver scope only when the public contract deliberately gives callers control over that region's child layout; do not infer it merely because the implementation emits the slot inside a layout.
-5. Make absent optional regions nullable (`null`), so the component can omit their containers and spacing.
-6. Put repeated default content or tokens in `XxxDefaults`.
-7. Pair this with the `modifier` rules in [Modifier and layout](modifier-layout.md)
-   only when root placement is part of the task or a broad API review.
-
-## 1. Replace primitive content with `@Composable` slots
-
-Where the component asks for caller-controlled *content*, prefer a `@Composable () -> Unit` slot. Where the slot is structurally required, leave it non-nullable with no default. Where it's optional, make it nullable with a `null` default.
+1. Confirm the component is reusable and identify the regions that vary by caller.
+2. Replace unconstrained primitive content and shape flags with named `@Composable` slots. Retain parameters that enforce semantic, design-system, constrained-type, or measured fast-path contracts.
+3. Make an optional slot nullable with a `null` default so its container and spacing can disappear.
+4. Add a `RowScope`, `ColumnScope`, or `BoxScope` receiver only when caller control of that region's child layout is a public contract; an internal layout alone is not enough.
+5. Put repeated composable defaults and tokens in `XxxDefaults`.
+6. Pair this with [Modifier and layout](modifier-layout.md) only when root placement is in scope.
+7. Finish when callers can supply variable content without a flag matrix, while the component's own semantic and layout invariants remain explicit.
 
 ```kotlin
-// ❌ BAD — primitive parameters; trailing area is the only slot; everything else is locked
-@Composable
-fun SettingsRow(
-    title: String,
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier,
-    subtitle: String? = null,
-    leadingIcon: ImageVector? = null,
-    trailing: (@Composable () -> Unit)? = null,
-) { … }
-```
-
-```kotlin
-// ✅ GOOD — every visual region is a slot; the row describes structure, not content
 @Composable
 fun SettingsRow(
     headlineContent: @Composable () -> Unit,
@@ -45,147 +23,27 @@ fun SettingsRow(
     supportingContent: (@Composable () -> Unit)? = null,
     leadingContent: (@Composable () -> Unit)? = null,
     trailingContent: (@Composable () -> Unit)? = null,
-) { … }
+) { /* component-owned structure */ }
 ```
 
-Call sites stay short when the typical content is a one-liner:
+Use `xxxContent` for free-form slots, or a semantic noun for a deliberately constrained region. Keep one naming convention within a component. For a public action region whose children deliberately control a row's allocation, use a scope receiver:
 
 ```kotlin
-SettingsRow(
-    headlineContent = { Text("Account") },
-    leadingContent = { Icon(Icons.Default.Person, contentDescription = null) },
-    trailingContent = { SettingsRowDefaults.Chevron() },
-    onClick = { … },
-)
-```
-
-The unusual cases no longer require new component parameters:
-
-```kotlin
-SettingsRow(
-    headlineContent = {
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            Text("Inbox")
-            Spacer(Modifier.width(8.dp))
-            Badge { Text("3") }
-        }
-    },
-    onClick = { … },
-)
-```
-
-### Slot naming
-
-- Use `xxxContent` for free-form `@Composable () -> Unit` slots (`headlineContent`, `supportingContent`, `trailingContent`) — matches Material 3.
-- Use a singular noun (`title`, `icon`, `actions`) when the slot is semantically constrained and the component name disambiguates (`Scaffold(topBar = { … }, bottomBar = { … }, floatingActionButton = { … })`).
-- Don't use `content` *and* other `xxxContent` slots together — pick one convention per component.
-
-## 2. Scope receivers only for a public layout contract
-
-Use a receiver lambda only when callers must intentionally control the layout *inside the named region*, such as an app bar's action region. A component retaining ownership of its internal `Row`, `Column`, or `Box` should keep ordinary `@Composable () -> Unit` slots, even if it happens to emit them in that layout.
-
-```kotlin
-// ❌ BAD — actions render inside a Row, but callers can't use RowScope.weight()
-@Composable
-fun MyTopBar(
-    title: @Composable () -> Unit,
-    actions: @Composable () -> Unit = {},   // ← caller has no Row scope
-)
-```
-
-```kotlin
-// ✅ GOOD — caller gets RowScope; .weight() and alignment-by works inside
-@Composable
 fun MyTopBar(
     title: @Composable () -> Unit,
     actions: @Composable RowScope.() -> Unit = {},
 )
 ```
 
-This is what makes `TopAppBar(actions = { IconButton(…); IconButton(…) })` work — its documented actions region deliberately gives callers a `RowScope`.
+An ordinary trailing slot inside a component-owned `Row` remains `@Composable () -> Unit`: callers choose content, while the component owns order and spacing.
 
-Don't bolt a scope receiver onto every slot reflexively. First decide whether caller control over region layout is part of the API. Only then match the receiver to that public contract (`RowScope`, `BoxScope`, or `ColumnScope`). A trailing slot in a component-owned row is normally an ordinary slot: callers choose its content while the component owns ordering, spacing, and allocation.
+## Exceptions
 
-## 3. Optional slots — nullable with `null` default
-
-For slots that may be absent, prefer `(@Composable () -> Unit)? = null` over `@Composable () -> Unit = {}`:
-
-```kotlin
-// ❌ BAD — empty default; "no leading content" is the empty lambda
-leadingContent: @Composable () -> Unit = {}
-
-// ✅ GOOD — null means "no slot"; the component can omit space/padding when absent
-leadingContent: (@Composable () -> Unit)? = null
-```
-
-With a nullable slot, the component can branch on `leadingContent != null` and skip the slot's container, spacing, and padding entirely. With an empty default, the layout often still allocates space for absent content.
-
-## 4. Defaults live in `XxxDefaults`
-
-When you find yourself documenting "the trailing slot should usually be a chevron" or "pass `MaterialTheme.colorScheme.surface` for the default background", co-locate the helpers in a `XxxDefaults` object next to the component:
-
-```kotlin
-object SettingsRowDefaults {
-    @Composable
-    fun Chevron() = Icon(
-        imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
-        contentDescription = null,
-    )
-
-    @Composable
-    fun TrailingValue(text: String) = Text(
-        text = text,
-        style = MaterialTheme.typography.bodyMedium,
-        color = MaterialTheme.colorScheme.onSurfaceVariant,
-    )
-}
-```
-
-Call sites stay declarative for the common cases and the slot is still fully open for one-offs:
-
-```kotlin
-SettingsRow(
-    headlineContent = { Text("Notifications") },
-    trailingContent = { SettingsRowDefaults.Chevron() },
-    onClick = { … },
-)
-```
-
-This matches Material 3's `ButtonDefaults`, `TopAppBarDefaults`, etc. — defaults that are themselves composable belong here, not as new component parameters with `MaterialTheme.x.y` defaults expanded inline.
-
-## Quick reference
-
-| Symptom | Diagnosis | Fix |
-|---|---|---|
-| Caller-controlled `title: String, subtitle: String?, leadingIcon: ImageVector?` on a reusable component | Unconstrained primitive content (§1) | Convert to `xxxContent: (@Composable () -> Unit)?` slots |
-| Multiple Boolean flags selecting caller-controlled trailing shapes | Enumerating unconstrained shapes (§1) | One `trailingContent: (@Composable () -> Unit)?` slot |
-| A mode parameter enumerating caller-controlled visual variants | Same as flag soup (§1) | Replace the visual variants with a slot |
-| Primitive or mode parameter enforces semantic, design-system, constrained-type, or measured fast-path behavior | Deliberate component contract | Keep the primitive parameter and document the invariant |
-| `actions: @Composable () -> Unit = {}` inside a `Row` body | Missing scope receiver (§2) | `actions: @Composable RowScope.() -> Unit = {}` |
-| A trailing or inline slot merely happens to be emitted in an internal `Row` | Component owns the row's allocation and ordering | Keep `@Composable () -> Unit`; do not leak `RowScope` |
-| `slot: @Composable () -> Unit = {}` for an optional area | Empty-lambda default (§3) | `slot: (@Composable () -> Unit)? = null` and branch on it |
-| Component param `defaultColor: Color = MaterialTheme.colorScheme.surface` | Defaults inlined (§4) | Move to `XxxDefaults.color` and reference it |
-| Common trailing content repeats at every call site | Missing default helper (§4) | Add `XxxDefaults.Chevron()` etc. |
-
-## When NOT to apply
-
-- **Single-use components.** A composable used in exactly one place, with no plan to reuse, doesn't benefit from slot flexibility — and the slot indirection makes the code harder to read for the one reader. Primitive params + inline content is fine. (As soon as a second call site appears, slot it.)
-- **Design-system primitives where every caller must look identical.** A `Heading2(text: String)` exists *because* you want every H2 to look the same; making it `headlineContent: @Composable () -> Unit` invites callers to break the rule. Keep it primitive. (Conversely: if `Heading2` ever needs a badge inline, slot it.)
-- **Semantic parameters the component intentionally owns.** If the component owns typography, iconography, accessibility wording, or product consistency, a primitive parameter may be the constraint you want.
-- **Constrained-type parameters that genuinely are constrained.** A `Switch(checked: Boolean, onCheckedChange: ...)` doesn't need its checked indicator to be a slot. Booleans-with-callbacks are not "content."
-- **Performance-critical fast paths** (rare in app code; common in framework primitives). A slot is an allocated lambda. In the deepest LazyList item layer, sometimes primitives win. If you're not writing the framework, this doesn't apply.
-
-## Red flags during review
-
-| Thought | Reality |
-|---|---|
-| "Title is *always* a String — making it a slot is over-engineering" | "Always today" is the trap. Material's `ListItem.headlineContent` exists because tomorrow someone wants a `Text + Badge`. The slot is `8` characters of extra wrapping at every call site (`{ Text(…) }`); the refactor to add a slot later edits every existing call site. |
-| "Lambdas are heavier than strings" | At the scale of typical Compose UI, this isn't measurable — and the framework's own components (`Button`, `ListItem`, `TopAppBar`, `Scaffold`) all slot. If your component is in the hottest of hot paths, see "When NOT to apply." |
-| "I'll add a slot later if someone asks" | The slot turns one parameter into two parameters (the slot itself + maybe an internal flag) and edits every call site. The shape change isn't a "later" change. |
-| "I'll model the variants with a sealed `Trailing` type instead" | Sealed enumeration is bounded; slots are unbounded. A sealed type works *until* the day someone needs a variant you didn't anticipate — at which point you're back to editing the component. The slot avoids the cycle. |
-| "The leading area is *always* an icon, the trailing area varies — I'll slot only the trailing" | This is the partial-slot trap. The "always-an-icon" assumption breaks the first time a row needs an avatar or a flag emoji or a coloured shape. Slot leading too. |
-| "There's only one call site today" | If there's only one call site, you're probably not designing a reusable component yet. See "When NOT to apply" — primitives are fine for a true single-use. The moment you copy-paste it, slot it. |
+- A true single-use helper, preview, or test fixture can keep primitive parameters and inline content.
+- Keep a primitive when every caller must share a fixed semantic/design-system contract, or when it is a real constrained value such as `checked`.
+- In a measured hot path, retain primitives when a slot allocation is proven to matter.
+- Do not make a scope receiver or slot merely to anticipate hypothetical flexibility.
 
 ## Related
 
-- [Modifier and layout](modifier-layout.md) — the modifier-parameter rule (§1–§3 there) travels with slot APIs. A reusable component takes a `modifier` parameter *and* slots its content; the caller owns both placement and what to place.
+[Modifier and layout](modifier-layout.md) covers caller placement; slots cover caller content.

--- a/skills/compose-focus-navigation/SKILL.md
+++ b/skills/compose-focus-navigation/SKILL.md
@@ -7,21 +7,11 @@ description: Use when writing or reviewing Jetpack Compose UI for TV, keyboard, 
 
 ## Core principle
 
-Focus is stateful UI behavior. Make focus targets explicit, request focus after composition succeeds, and test navigation with the same input model users use: keyboard, D-pad, or remote keys.
+Focus is stateful UI behavior: make targets and exceptional edges explicit, then drive and verify it through the user's keyboard, D-pad, or remote input.
 
-## When to use this skill
+## Procedure
 
-Use this when UI:
-
-- Runs on TV, desktop, ChromeOS, keyboard-first Android, or remote-control devices.
-- Uses `FocusRequester`, `focusRequester`, `focusProperties`, `onFocusChanged`, or key handlers.
-- Needs initial focus, restored focus, directional navigation, or back/escape behavior.
-- Has a carousel, grid, lazy list, menu, dialog, or modal with focus traps.
-- Has tests asserting which item is focused.
-
-## Build focus targets deliberately
-
-Start with components that already participate in focus, then add only the focus hooks the behavior needs:
+1. Start with components that already participate in focus. Add a hook only for a requested behavior:
 
 | Need | Add |
 |---|---|
@@ -30,7 +20,14 @@ Start with components that already participate in focus, then add only the focus
 | Visual or state reaction to focus changes | `Modifier.onFocusChanged { ... }` |
 | Custom interactive surface that is not already focusable | `Modifier.focusable()` plus role/semantics as appropriate |
 
-For example, request and observe focus only when both behaviors are needed:
+2. Request initial or restored focus from `LaunchedEffect`, keyed to the condition that makes the target present. For lazy content, keep requesters by stable item id and request only after the item is composed.
+3. Keep default spatial search unless a concrete edge, jump, or trap is wrong. Encode only those exceptions with `focusProperties`.
+4. Handle keys only for behavior that is not normal click or traversal. Consume exactly the handled event; throttle rapid D-pad work at its expensive owner, not across the screen.
+5. Restore by semantic identity after refresh: retain the focused id when it exists, otherwise choose a deterministic fallback.
+6. Test with key/D-pad input and focused semantics. Use screenshots only for the focus appearance.
+7. Finish when all intentional targets and exceptional edges are encoded, loading/refresh behavior has a stable focus policy, and tests use the same input model as users.
+
+For example, request and observe focus only when both behaviors are required:
 
 ```kotlin
 val requester = remember { FocusRequester() }
@@ -45,11 +42,7 @@ Button(
 }
 ```
 
-Prefer focusable components (`Button`, `TextField`, clickable/selectable surfaces) over manually adding `focusable()` to passive layout. Add manual focus only when the element is truly interactive or participates in navigation.
-
-## Request focus after composition
-
-Call focus requests from an effect, not from the composable body:
+Call focus requests from an effect, not the composable body:
 
 ```kotlin
 val initialFocus = remember { FocusRequester() }
@@ -69,11 +62,7 @@ LaunchedEffect(items.isNotEmpty()) {
 }
 ```
 
-For lazy content, request focus only after the item is actually composed. Keep requesters in stable item state keyed by item id, not by index alone if the list can reorder.
-
-## Directional navigation
-
-Use `focusProperties` when default spatial search is wrong:
+Use `focusProperties` only when default spatial search is wrong:
 
 ```kotlin
 Modifier.focusProperties {
@@ -83,11 +72,7 @@ Modifier.focusProperties {
 }
 ```
 
-Use this sparingly. Too many hard-coded links create stale focus graphs when layouts change. Prefer natural focus order unless the design requires a specific jump or trap.
-
-## Key events
-
-Use key handlers for behavior that is not normal click/focus traversal:
+Too many hard-coded links create stale focus graphs. For special key behavior, consume only the handled event:
 
 ```kotlin
 Modifier.onPreviewKeyEvent { event ->
@@ -100,33 +85,6 @@ Modifier.onPreviewKeyEvent { event ->
 }
 ```
 
-Return `true` only when consumed. Returning `true` too broadly breaks text entry, accessibility shortcuts, and parent navigation.
-
-For rapid D-pad input, throttle at the boundary that owns the expensive behavior (for example row scrolling or paging), not globally across the whole screen.
-
-## Focus restoration
-
-Preserve focus by semantic identity:
-
-- Track selected/focused item id, not just index.
-- Use stable `key` values in lazy lists and grids.
-- When content refreshes, re-request focus for the same id if it still exists.
-- If it no longer exists, choose a deterministic fallback: nearest neighbor, first item, or parent container.
-
-## Common mistakes
-
-| Mistake | Fix |
-|---|---|
-| Adding `focusRequester` and `onFocusChanged` to every button | Add them only when requesting or observing focus |
-| `requestFocus()` in the composable body | Move to `LaunchedEffect` |
-| Initial focus keyed to `Unit` while target appears later | Key to loaded/visible condition |
-| Focus requesters stored by lazy list index | Store by stable item id |
-| Everything gets custom `focusProperties` | Let spatial search work; override only broken edges |
-| Key handler returns `true` for all keys | Consume only handled keys |
-| Tests click nodes in TV/D-pad UI | Send key input and assert focus |
-
-## Testing
-
 Test focus through user input:
 
 ```kotlin
@@ -137,13 +95,4 @@ composeTestRule.onNodeWithTag("screen").performKeyInput {
 composeTestRule.onNodeWithTag("play-button").assertIsFocused()
 ```
 
-Prefer asserting focused semantics over visual styling. Use screenshot tests only for focus appearance, not for deterministic focus ownership.
-
-Broader test-shape choices (plain UI vs integration, semantics-first): [`compose-ui-testing-patterns`](../compose-ui-testing-patterns/SKILL.md).
-
-## Red flags during review
-
-- "It focuses correctly when I tap it" for a keyboard/TV UI.
-- Initial focus works only with fixed data and fails after loading/refresh.
-- Focus state is inferred from selected data state when focus and selection are different concepts.
-- The focus graph is described in comments but not encoded or tested.
+Broader test-shape choices are in [Compose UI testing patterns](../compose-ui-testing-patterns/SKILL.md).

--- a/skills/compose-performance/SKILL.md
+++ b/skills/compose-performance/SKILL.md
@@ -39,14 +39,3 @@ axis begins.
 | Scroll, animation, gesture, layout, or draw State read at frame rate; measured state fed back into composition | [Deferred reads](references/deferred-reads.md) |
 | A composable only reads composition locals or accessor-style values | [Composition contracts](references/composition-contracts.md) |
 | State ownership or effect lifecycle is the root cause | [Compose state and effects](../compose-state-and-effects/SKILL.md) |
-
-## RED/GREEN agent scenarios
-
-1. RED blames unstable parameters for unchanged lazy rows that recompose during
-   a focus transition. GREEN checks composition and layout back-writing first.
-2. Novel case: an animation value controls only drawing. RED identifies the
-   composition read but stops at diagnosis. GREEN moves the State read and its
-   geometry calculation into the draw or layout consumer.
-3. Counterexample: a screen visibly recomposes because its displayed model
-   actually changed. GREEN does not add stability wrappers or caches merely to
-   lower a count.

--- a/skills/compose-performance/references/deferred-reads.md
+++ b/skills/compose-performance/references/deferred-reads.md
@@ -2,200 +2,46 @@
 
 ## Core principle
 
-State reads invalidate the phase that reads them. If a `State<T>` is read in a composable body, changes invalidate composition. If it is read in layout or draw, changes can invalidate only layout or draw. Frame-rate state such as scroll offsets, animations, and drag positions usually belongs in layout/draw, not composition.
+State invalidates the phase that reads it. Read frame-rate state in layout or draw; never write observable state in a phase that invalidates the current or an earlier phase.
 
-**Back-writing** is the symmetric failure mode: writing observable state from a phase that triggers invalidation of an earlier phase. Compose phases run composition → layout → draw. Writing snapshot-backed state from layout or draw to state read in composition invalidates composition; writing during composition to state read earlier in the same composition does the same. Both schedule extra work — often cascading into sibling lazy items.
+## Procedure
 
-The fix is structural: keep the `State<T>` or a provider lambda and read the value inside a layout/draw callback; capture measurements in callbacks and apply them in the measure phase, not by reading measurement state in sibling composable bodies.
-
-## When to use this skill
-
-- `val x by animate*AsState(...)` is passed to `Modifier.offset(x = ...)`, `Modifier.size(...)`, `Modifier.graphicsLayer(...)`, or another value-form modifier.
-- `LazyListState.firstVisibleItemScrollOffset`, `ScrollState.value`, `Animatable.value`, or gesture state is read in a composable body.
-- A composable takes `scrollOffset: Int`, `progress: Float`, `dragOffset: Offset`, or similar frame-rate values.
-- Recomposition counters climb during scroll, animation, or gestures even when data is stable.
-- A composable body calls `stateMap[key] = …`, `list.addAll(…)`, or similar on every recomposition (back-writing composition → composition).
-- One lazy item captures size with `onSizeChanged` / `onGloballyPositioned` and a sibling reads that height in composition (`Modifier.height(state.dp)`) — back-writing layout → composition.
-
-## 0. Back-writing
-
-**Back-writing** = writing observable state in one phase that triggers invalidation of an earlier (or the current) phase. Compose runs composition → layout → draw, so:
-
-- Writing snapshot state during composition that's read in the same composition.
-- Writing snapshot state during layout (e.g. from `Modifier.layout`, `onSizeChanged`, `onGloballyPositioned`) that's read during composition.
-- Writing snapshot state during draw that's read during composition or layout.
-
-In all cases the writer schedules extra invalidation passes — often cascading into sibling lazy items.
-
-Do not write to `mutableStateOf`, `mutableStateListOf`, `mutableStateMapOf`, or other snapshot-backed state from the composable body on every pass:
+1. Confirm that scroll, animation, drag, or measured-size state is changing frequently and identify where it is read.
+2. Keep a `State<T>` or provider lambda across composition, then read it in a block-form layout or draw modifier. Keep the read in composition only when it decides which composables exist.
+3. Do not rebuild snapshot lists or maps from the composable body. Derive immutable values with `remember(keys) { ... }`; mutate snapshot state from events or effects instead.
+4. When one item measures and another consumes the result, capture the measurement in layout and apply it during measure. Do not read that measurement in a sibling composable body.
+5. Re-measure the same transition. Finish when the required phase alone invalidates and derived state cannot become stale.
 
 ```kotlin
-// ❌ BAD — mutates observable map during composition; siblings recompose repeatedly
-@Composable
-fun MergeOverlay(parent: Map<Key, ViewState>, overlay: Map<Key, ViewState>): Map<Key, ViewState> {
-    val merged = remember { mutableStateMapOf<Key, ViewState>() }
-    merged.clear()
-    merged.putAll(parent)
-    merged.putAll(overlay)   // back-writing composition → composition
-    return merged
-}
-
-// ✅ GOOD — read-only merge; no composition-time writes
-@Composable
-fun MergeOverlay(parent: Map<Key, ViewState>, overlay: Map<Key, ViewState>): Map<Key, ViewState> =
-    remember(parent, overlay) {
-        if (overlay.isEmpty()) parent else parent + overlay
-    }
+// The State stays intact; its value is read during layout.
+val offsetX = animateDpAsState(120.dp * selectedIndex)
+Box(Modifier.offset { IntOffset(offsetX.value.roundToPx(), 0) })
 ```
 
-Prefer `remember(keys) { … }` for derived read-only snapshots. Reserve `mutableState*` writes for event callbacks (`onClick`) or effects — not for rebuilding derived data on every composition.
-
-Callbacks like `onSizeChanged` write *during layout*. That is only safe if no earlier phase reads the resulting state — see cross-row measurement below.
-
-### Cross-row measurement (layout → composition back-write)
-
-When row A measures and row B must match A's height, do not read A's captured size in B's composable body. `onSizeChanged` writes during layout; if B reads it in composition, layout has just back-written into composition:
-
-```kotlin
-var anchorHeightPx by remember { mutableIntStateOf(0) }
-
-// ❌ BAD — B reads measurement state in composition; insertion/focus can double-recompose B
-RowA(Modifier.onSizeChanged { anchorHeightPx = it.height })
-RowB(Modifier.height(with(LocalDensity.current) { anchorHeightPx.toDp() }))  // composition read
-
-// ✅ GOOD — capture on A; apply on B in measure phase only
-RowA(Modifier.onSizeChanged { if (it.height != anchorHeightPx) anchorHeightPx = it.height })
-RowB(
-    Modifier.decorateMeasureConstraints { incoming ->
-        if (anchorHeightPx > 0) incoming.copy(minHeight = anchorHeightPx, maxHeight = anchorHeightPx)
-        else incoming
-    },
-)
-```
-
-`decorateMeasureConstraints` is a small layout helper (see [Compose component design](../../compose-component-design/SKILL.md)). While height is unknown, siblings use a fixed fallback in composition; once known, only layout invalidates — not an extra composition cascade.
-
-## 1. Prefer block-form modifiers
-
-Several modifiers have value forms and block forms. The value form receives values already read in composition; the block form can read during layout or draw.
-
-```kotlin
-// Before: animated value read in composition by the `by` delegate
-@Composable
-fun SelectionPill(selectedIndex: Int) {
-    val offsetX by animateDpAsState(120.dp * selectedIndex)
-    Box(Modifier.offset(x = offsetX))
-}
-
-// After: State is kept, value is read in the layout-phase offset block
-@Composable
-fun SelectionPill(selectedIndex: Int) {
-    val offsetX = animateDpAsState(120.dp * selectedIndex)
-    Box(
-        Modifier.offset {
-            IntOffset(offsetX.value.roundToPx(), 0)
-        },
-    )
-}
-```
-
-Common replacements:
-
-| Composition read | Deferred read |
+| Composition-time shape | Deferred shape |
 |---|---|
 | `Modifier.offset(x = animatedX)` | `Modifier.offset { IntOffset(animatedX.value.roundToPx(), 0) }` |
 | `Modifier.graphicsLayer(translationY = y)` | `Modifier.graphicsLayer { translationY = yProvider() }` |
-| `val radius by animateFloatAsState(...); drawBehind { drawCircle(radius = radius) }` | `val radius = animateFloatAsState(...); drawBehind { drawCircle(radius = radius.value) }` |
+| `Child(scrollOffset = listState.firstVisibleItemScrollOffset)` | `Child(scrollOffsetProvider = { listState.firstVisibleItemScrollOffset })` |
 
-The `drawBehind` block is already draw-phase; the important part is that the `State.value` read also happens inside that block.
-
-## 2. Pass providers across composable boundaries
-
-If the fast-changing value would cross a composable boundary, pass a provider lambda instead of a snapshot value:
+Suffix a cross-boundary lambda with `Provider` when that makes its deferred-read contract clear. `drawBehind`, `drawWithContent`, `layout`, `offset {}`, and `graphicsLayer {}` are suitable consumers.
 
 ```kotlin
-// Before: HomeScreen reads scroll offset in composition and passes the value down
-@Composable
-fun HomeScreen() {
-    val listState = rememberLazyListState()
-    LazyColumn(state = listState) {
-        item { HeroImage(scrollOffset = listState.firstVisibleItemScrollOffset) }
-    }
-}
-
-@Composable
-fun HeroImage(scrollOffset: Int, modifier: Modifier = Modifier) {
-    AsyncImage(
-        model = "...",
-        modifier = modifier.graphicsLayer(translationY = -scrollOffset / 2f),
-    )
-}
-
-// After: the only read happens inside graphicsLayer
-@Composable
-fun HomeScreen() {
-    val listState = rememberLazyListState()
-    LazyColumn(state = listState) {
-        item {
-            HeroImage(
-                scrollOffsetProvider = {
-                    if (listState.firstVisibleItemIndex == 0) {
-                        listState.firstVisibleItemScrollOffset
-                    } else {
-                        0
-                    }
-                },
-            )
-        }
-    }
-}
-
-@Composable
-fun HeroImage(scrollOffsetProvider: () -> Int, modifier: Modifier = Modifier) {
-    AsyncImage(
-        model = "...",
-        modifier = modifier.graphicsLayer {
-            translationY = -scrollOffsetProvider() / 2f
-        },
-    )
+// Do not back-write during composition.
+val merged = remember(parent, overlay) {
+    if (overlay.isEmpty()) parent else parent + overlay
 }
 ```
 
-Suffix provider parameters with `Provider` when that clarifies the deferred-read contract.
+For cross-row measurement, use a measure-phase helper such as [`decorateMeasureConstraints`](../../compose-component-design/references/modifier-layout.md), keep a fixed fallback while size is unknown, and compare before writing the captured size. This avoids a layout-to-composition cascade in sibling lazy items.
 
-## 3. Other layout/draw read sites
+## Exceptions
 
-State reads can also be deferred inside:
-
-- `Modifier.layout { measurable, constraints -> ... }`
-- Custom `Alignment.align(...)`
-- `drawWithContent`, `drawBehind`, and other draw modifiers
-- Block-form layer/layout modifiers such as `graphicsLayer { ... }` and `offset { ... }`
-
-Use these when the state changes where something is placed or painted. If the state decides *which composables exist*, it belongs in composition.
-
-## Quick reference
-
-| Symptom | Diagnosis | Fix |
-|---|---|---|
-| `val x by animateFloatAsState(...)` then `Modifier.offset(...)` | `by` reads in composition | Keep `State<Float>` and read `.value` in `offset {}` |
-| `Modifier.graphicsLayer(translationY = animatedY)` | Property-argument form uses composition values | Use `graphicsLayer { translationY = ... }` |
-| `Child(scrollOffset = listState.firstVisibleItemScrollOffset)` | Fast-changing value crosses boundary | `Child(scrollOffsetProvider = { ... })` |
-| Draw block still recomposes every frame | Value was read before draw block | Move the `State.value` read inside the draw block |
-| State chooses between different UI branches | Composition decision | Keep the read in composition |
-| `mergedMap.putAll(overlay)` in composable body | Back-writing composition → composition | `remember(parent, overlay) { parent + overlay }` |
-| Sibling `Modifier.height(measuredPx.toDp())` | Back-writing layout → composition | Measure-phase constraint decoration |
-| Identity cache for read-only merge | Stale overlay risk | `remember(keys)` on immutable result |
-
-## When NOT to apply
-
-- The state controls which composables are emitted.
-- The animation is one-shot, cheap, and clarity wins.
-- You are writing tests where direct value assertions are simpler.
-- Runtime evidence shows recomposition is not the bottleneck.
+- Keep a read in composition when it selects a UI branch.
+- Do not obscure a one-shot, cheap value or a test assertion solely to defer it.
+- If evidence shows recomposition is not the bottleneck, leave the simpler form.
 
 ## Related
 
-- [Compose state and effects](../../compose-state-and-effects/SKILL.md) — when `mutableState*` belongs in composition versus callbacks, and where state-holder versus plain UI splits apply.
-- [Stability](stability.md) — parameter stability and compiler reports.
-- [Compose component design](../../compose-component-design/SKILL.md) — measure-phase constraint decoration helpers.
+- [Stability](stability.md) for parameter comparisons and compiler reports.
+- [Compose state and effects](../../compose-state-and-effects/SKILL.md) for event/effect ownership.

--- a/skills/compose-performance/references/stability.md
+++ b/skills/compose-performance/references/stability.md
@@ -2,44 +2,18 @@
 
 ## Core principle
 
-Compose parameter fixes start from evidence. First identify the compiler mode and the parameter comparison behavior, then change the model or call site that is actually defeating skipping.
+Use compiler evidence and comparison semantics before changing a model or adding a stability promise.
 
-With Kotlin 2.0.20+ strong skipping is enabled by default. Unstable parameters no longer automatically make restartable composables non-skippable, but unstable parameters compare by instance identity (`===`) while stable parameters compare by equality (`equals`). Churny unstable instances can still defeat skipping.
+## Procedure
 
-## Diagnostic procedure
-
-1. Confirm the symptom: recomposition counts, compiler report output, or a suspected churny parameter.
-2. Identify compiler mode: Kotlin/Compose compiler version and whether strong skipping is enabled.
-3. Generate or read the Compose compiler reports for the shipped variant.
-4. For each suspicious parameter, decide whether the problem is stability semantics, instance churn, or a caller-created lambda/derived value.
-5. If an annotation makes a false promise, fix the data contract first; only then decide whether an annotation is still needed.
-6. Apply the lightest fix that makes the type/call site truthful.
-7. Re-measure the same interaction or re-read the same report before claiming the issue is fixed.
-
-## 1. Interpret strong skipping first
-
-On Kotlin 2.0.20+, strong skipping is enabled by default. In that mode:
-
-- Restartable composables are skippable even when parameters are unstable, unless explicitly opted out.
-- Stable parameters compare with `equals`.
-- Unstable parameters compare with instance equality (`===`).
-- Lambdas inside composables are automatically remembered based on captures.
-
-Ask: "will these parameters compare the way I expect, and are callers creating new unstable instances every frame?"
-
-For older compiler setups or strong skipping disabled, the legacy rule still matters: a restartable composable with unstable parameters may be restartable but not skippable.
-
-## 2. Generate compiler reports
-
-With Kotlin 2.0+ the Compose Compiler is configured through the Kotlin Gradle plugin:
+1. Reproduce the transition, record recomposition counts or compiler reports, and confirm the Kotlin/Compose compiler mode.
+2. With Kotlin 2.0.20+ strong skipping is normally enabled: restartable composables can skip with unstable parameters, but stable values compare with `equals` and unstable values compare by identity. Check churny instances and call-site lambdas before changing a type. For older or opted-out builds, account for the legacy non-skippable behavior.
+3. Generate reports for the shipped variant and inspect `classes.txt`, `composables.txt`, `composables.csv`, and module metrics.
+4. Identify the proven cause: false stability promise, mutable collection interface, external immutable type, or caller-created instance/lambda churn.
+5. Apply the smallest truthful fix, then re-read the same report or re-measure the transition.
+6. Finish only when the model's mutability and equality contract remains correct as well as more skippable.
 
 ```kotlin
-plugins {
-    alias(libs.plugins.android.application) // or android.library / jvm
-    alias(libs.plugins.kotlin.android)      // or kotlin.multiplatform / kotlin.jvm
-    alias(libs.plugins.compose.compiler)
-}
-
 if (providers.gradleProperty("composeReports").orNull == "true") {
     composeCompiler {
         reportsDestination = layout.buildDirectory.dir("compose_compiler")
@@ -48,135 +22,30 @@ if (providers.gradleProperty("composeReports").orNull == "true") {
 }
 ```
 
-Then build the variant whose compiler configuration you care about, for example:
-
-```bash
-./gradlew :app:assembleRelease -PcomposeReports=true
-```
-
-Use release/non-debuggable builds for runtime profiling. Compiler reports are build-time outputs, so the important thing is matching the variant and compiler flags you ship.
-
-Key files:
-
-| File | What it tells you |
+| Evidence | Repair |
 |---|---|
-| `<module>-classes.txt` | Stability of classes and properties |
-| `<module>-composables.txt` | Restartable/skippable status and parameter stability |
-| `<module>-composables.csv` | Same data in sortable form |
-| `<module>-module.json` | Aggregate metrics |
+| UI state exposes `List`/`Set` that must be immutable | Use `ImmutableList`/`ImmutableSet`, converting once at the boundary |
+| `@Immutable`/`@Stable` describes mutable non-snapshot state | First make it immutable or snapshot-observable; only then retain/add an annotation if truthful |
+| Third-party type is genuinely immutable | Add only that type to `stabilityConfigurationFiles` |
+| Lazy item gets a new lambda or derived object each parent recomposition | Hoist/remember it for the item's stable inputs |
 
-## 3. Fix only the proven parameter problem
-
-Pick the lightest fix that makes the type's immutability or equality semantics true.
-
-### Immutable collections
-
-If reports show collection interfaces on UI state, prefer `kotlinx.collections.immutable` at UI-state boundaries:
+Never annotate to silence a report: a false promise can show stale UI. If visible evidence cannot distinguish immutable data from observable mutable state, state both valid directions rather than inventing product requirements.
 
 ```kotlin
-// Before: unstable collection interfaces
-data class UiState(val items: List<Item>, val tags: Set<String>)
-
-// After: immutable collection contracts
-import kotlinx.collections.immutable.ImmutableList
-import kotlinx.collections.immutable.ImmutableSet
-
-data class UiState(val items: ImmutableList<Item>, val tags: ImmutableSet<String>)
-```
-
-Producers convert once at the boundary with `.toImmutableList()` / `.toImmutableSet()`.
-
-### `@Immutable` / `@Stable`
-
-- Use `@Immutable` when every property is effectively immutable and equality describes all observable state.
-- Use `@Stable` for types whose mutable state is observable by Compose, typically via `MutableState`.
-
-Do not annotate to silence a report. A false stability promise can produce stale UI.
-
-When an existing annotation is false, order the repair deliberately:
-
-1. Replace mutable non-snapshot properties with immutable data or observable Compose state.
-2. Re-evaluate the now-truthful model under strong-skipping comparison semantics.
-3. Retain or add `@Stable` / `@Immutable` only if the model still needs it and satisfies the full contract.
-
-Removing the annotation without fixing an accidental mutable data contract may avoid an incorrect compiler promise, but it does not make the UI state safe or observable.
-
-Finish gate for a false-promise review: do not stop after saying the annotation is unsupported. State the repair order explicitly—make the affected properties immutable or snapshot-observable first, verify the resulting contract, and only then decide whether an annotation remains truthful and necessary. If visible evidence does not determine whether the model should be immutable or observable, name both valid directions without inventing which one the product requires.
-
-### Third-party immutable types
-
-For types you cannot annotate but can truthfully treat as immutable, use `stabilityConfigurationFiles`:
-
-```kotlin
-composeCompiler {
-    stabilityConfigurationFiles.add(
-        rootProject.layout.projectDirectory.file("compose_stability.conf"),
-    )
-}
-```
-
-```text
-java.math.BigDecimal
-java.math.BigInteger
-java.time.*
-kotlinx.datetime.*
-```
-
-Only list types you are willing to promise are immutable. Do not list mutable types such as `java.util.Date`.
-
-## 4. Stabilize lazy item inputs
-
-When lazy item recomposition comes from call-site churn, stabilize the values passed to each item instead of annotating models blindly.
-
-Hoist and remember per-item inputs that are stable for the item's lifetime:
-
-```kotlin
-// ❌ BAD — new lambda instances when parent recomposes
-items(list, key = { it.id }) { item ->
-    RowCard(
-        onClick = { onItemClick(item.id) },
-        isHighlighted = { item.id == selectedId },
-    )
-}
-
-// ✅ GOOD — stable captures for this item instance
 items(list, key = { it.id }) { item ->
     val onClick = remember(item.id) { { onItemClick(item.id) } }
-    val isHighlighted = remember(item.id, selectedId) { item.id == selectedId }
-    RowCard(onClick = onClick, isHighlighted = isHighlighted)
+    RowCard(onClick = onClick)
 }
 ```
 
-Also hoist row position metadata (`isFirst`, `isLast`, corner radii) with `remember(index) { … }` when the value depends only on index — but do not expect this alone to fix back-writing or cross-row measurement bugs.
+Do not expect call-site stabilization to solve deferred reads or cross-row measurement; route those to [Deferred reads](deferred-reads.md).
 
-Verify focus moves and insertions with recomposition-count assertions after hoisting.
+## Exceptions
 
-## Quick reference
-
-| Symptom | Diagnosis | Fix |
-|---|---|---|
-| Kotlin 2.0.20+ but old docs say unstable means non-skippable | Strong skipping changed the default | Check comparison semantics and instance churn instead |
-| `unstable val items: List<Item>` | Interface collection | Use `ImmutableList<Item>` or another true immutable wrapper |
-| `unstable val price: BigDecimal` | External immutable type | Add to stability config |
-| `@Immutable` on a type with mutable internals | False promise | Fix the model or remove the annotation |
-| Composable skips poorly despite strong skipping | New unstable instance each recomposition | Remember, hoist, or make the type stable/equality-based |
-| Lazy items recompose on parent recompose despite unchanged data | New lambda or derived-value instance per parent recompose (§4) | Hoist per-item with `remember(item.id) { … }` |
-| Reports not generated | Compose compiler plugin missing or flag not set | Apply `org.jetbrains.kotlin.plugin.compose` and enable destinations |
-
-## When NOT to apply
-
-- The issue is back-writing across phases or cross-row measurement reads. Use [Deferred reads](deferred-reads.md).
-- The issue is a fast-changing `State` read in composition, such as scroll or animation. Use [Deferred reads](deferred-reads.md).
-- The recomposition count matches real data changes.
-- The bug is wrong data or stale state, not excess work.
-- The code is test-only and readability is more important than report cleanliness.
-
-## RED/GREEN agent scenarios
-
-1. Novel case: an `@Stable` class exposes a mutable non-snapshot property. RED only removes or defends the annotation. GREEN identifies the false promise and fixes the data contract before reconsidering annotations.
-2. Counterexample: an immutable model is recreated on every frame. GREEN diagnoses instance churn at the call site and does not rewrite the truthful data contract merely to add an annotation.
+- Do not tune a count caused by real displayed-data changes or a correctness defect.
+- Keep test-only code simple when report cleanliness does not serve the test.
+- Do not add third-party types to a stability configuration unless you will uphold their immutability contract.
 
 ## Related
 
-- [Deferred reads](deferred-reads.md) - frame-rate state should often be read in layout/draw rather than composition.
-- [Diagnosis](diagnosis.md) - use this when the recomposition axis is not yet known.
+[Diagnosis](diagnosis.md) identifies the performance axis when it is unknown.

--- a/skills/compose-state-and-effects/SKILL.md
+++ b/skills/compose-state-and-effects/SKILL.md
@@ -20,23 +20,19 @@ state and effects make rendering change safely.
    imperative work in the affected screen or component.
 3. Place each state value at its lowest necessary owner: local UI state,
    hoisted state, a plain UI state holder, or a screen state holder.
-4. Keep app wiring and business state at the screen boundary. When a screen
-   holder owns Compose runtime objects, explicitly recommend a separate,
-   previewable content composable that takes immutable state and event
-   callbacks; keep runtime objects in composition or a plain UI state holder.
-   Merely recommending immutable state and intents does not establish that
-   rendering boundary.
+4. For a screen boundary, keep durable data and intents in the wiring owner,
+   Compose runtime objects in composition or a plain UI state holder, and
+   rendering in a previewable content composable that takes immutable state
+   and callbacks. Read [State hoisting](references/state-hoisting.md) for the
+   implementation shape; naming only state and intents is not that boundary.
 5. Choose an effect API whose lifecycle matches the work, and key it by the
    semantic input that should restart or dispose it.
 6. Load the focused reference for every material concern below. Do not use a
    reference merely because its topic is adjacent.
 7. Route frame-rate reads, cross-phase back-writing, and
    `@ReadOnlyComposable` contracts to [Compose performance](../compose-performance/SKILL.md).
-8. Before responding to a screen-ownership review, verify that the answer
-   explicitly names all three required seams when the visible code needs them:
-   durable data and intents at the screen boundary, runtime UI objects in
-   composition or a plain UI state holder, and a previewable content composable
-   whose inputs are immutable state and event callbacks.
+8. Before responding to a screen-ownership review, verify all three screen
+   seams in step 4 when visible code needs them.
 9. Finish when every state value has one owner, every effect has a justified
    lifecycle and key, and the UI can be previewed and tested without app
    dependencies. For review-only work, report no change when no evidence-backed
@@ -51,16 +47,3 @@ state and effects make rendering change safely.
 | `LaunchedEffect`, `DisposableEffect`, `SideEffect`, `snapshotFlow`, `rememberCoroutineScope`, `rememberUpdatedState`, `produceState`, imperative `requestFocus`, callbacks, event Flow collection, snackbar, navigation, or analytics | [Side effects](references/side-effects.md) |
 | Focus ownership and keyboard/TV/D-pad behavior | [Compose focus navigation](../compose-focus-navigation/SKILL.md) |
 | Tests or previews for the resulting UI contract | [Compose UI testing patterns](../compose-ui-testing-patterns/SKILL.md) |
-
-## RED/GREEN agent scenarios
-
-1. RED keeps a component, collected `StateFlow`, navigation event, and screen
-   layout in one composable. GREEN leaves wiring and effects at the screen
-   boundary and gives plain rendering immutable state plus callbacks.
-2. Novel case: a query drives repository suggestions while a list state and
-   focus requester coordinate UI behavior. GREEN puts query and suggestions in
-   the screen state holder, but keeps Compose runtime objects in plain UI state.
-3. Counterexample: a one-off expandable badge has one private Boolean. GREEN
-   keeps it local and does not introduce a state holder or an effect.
-4. Counterexample: an accessor reads shared snapshot state with no requirement
-   for per-instance independence. GREEN does not invent an ownership leak.

--- a/skills/compose-state-and-effects/references/local-state.md
+++ b/skills/compose-state-and-effects/references/local-state.md
@@ -1,53 +1,18 @@
 # Compose state authoring
 
-Not every `remember { … }` belongs here. This reference covers **local UI
-state** (`remember { mutableStateOf(…) }`, `mutableStateListOf` /
-`mutableStateMapOf`). Other remembered APIs live elsewhere:
-
-- **`rememberCoroutineScope` / `rememberUpdatedState`** → [Side effects](side-effects.md)
-- **`rememberLazyListState` / `rememberScrollState`** used for frame-rate reads → [Compose performance](../../compose-performance/SKILL.md)
-- **Focus navigation, focus state, `FocusRequester` ownership, behavior** → [Compose focus navigation](../../compose-focus-navigation/SKILL.md)
-
 ## Core principle
 
-A `@Composable` is a function the runtime re-runs whenever its inputs change.
-Writing local state correctly asks one question:
+Mutable local UI state must survive recomposition and notify Compose when it changes.
 
-1. **Mutable local state** — does my `var` survive recomposition *and* trigger it? If not, it silently resets on every recompose and writes are invisible.
+## Procedure
 
-Get it wrong and state vanishes or writes become invisible.
-
-## When to use this skill
-
-You're writing or reviewing Compose code and you see any of these:
-
-- `var x = …` inside a `@Composable fun` or any composable lambda (`Column { var x = … }`)
-- A composable whose visible state mysteriously resets on rotation, theme change, or recomposition
-
-## 1. `var` in a composable must be State-backed
-
-Recomposition re-executes the composable from the top. A local `var` is *re-initialized* on every pass — last recompose's value is gone, and writing to it doesn't tell the runtime to recompose.
+1. For a mutable value in a composable scope, use `remember { mutableStateOf(...) }` (or `rememberSaveable` when recreation must preserve it). A bare local `var` resets on recomposition and does not invalidate UI.
+2. Use `mutableStateListOf`/`mutableStateMapOf` for in-place observable collection changes. With `mutableStateOf(List)`, replace the list rather than mutating it.
+3. Do not mutate snapshot state from the composable body to rebuild derived data. Use `remember(keys) { ... }` for a read-only result; events and effects own mutations.
+4. Route layout measurement consumed by sibling composition to [Compose performance](../../compose-performance/SKILL.md), and effect capture/lifecycle to [Side effects](side-effects.md).
+5. Finish when local state has one composable owner, survives the required lifecycle, and changes invalidate the correct UI.
 
 ```kotlin
-// ❌ BAD — counter resets on every recomposition; clicks never update the UI
-@Composable
-fun Counter() {
-    var count = 0
-    Button(onClick = { count++ }) { Text("$count") }
-}
-
-// ❌ ALSO BAD — same rule applies inside composable content lambdas
-@Composable
-fun Wrapper() {
-    Row {
-        var count = 0         // Row's content lambda is @Composable too
-        // …
-    }
-}
-```
-
-```kotlin
-// ✅ GOOD — `remember` survives recomposition, `mutableStateOf` triggers it
 @Composable
 fun Counter() {
     var count by remember { mutableStateOf(0) }
@@ -55,74 +20,19 @@ fun Counter() {
 }
 ```
 
-Two pieces and both matter:
-
-- `remember { … }` — *survives recomposition*. Without it the value is re-created each time.
-- `mutableStateOf(…)` — *triggers recomposition*. Without it, mutations are invisible to the runtime.
-
-For collections, prefer `mutableStateListOf` / `mutableStateMapOf` (also `remember`-ed). They emit Snapshot reads on every read and Snapshot writes on every mutation. A `remember { mutableStateOf(mutableListOf<X>()) }` followed by `list.add(x)` will *not* recompose, because `MutableList.add` doesn't go through the State setter — you'd have to replace the value (`state = state + x`).
-
-### Back-writing snapshot state during composition
-
-**Back-writing** means writing observable state in a phase that triggers invalidation of an earlier (or the current) phase. Mutating `mutableState*` from the composable body back-writes into the same composition pass and schedules another. Do not rebuild derived data this way:
-
 ```kotlin
-// ❌ BAD — clear + putAll on every composition
-val merged = remember { mutableStateMapOf<Key, ViewState>() }
-merged.clear()
-merged.putAll(parent)
-merged.putAll(overlay)
-
-// ✅ GOOD — immutable snapshot remembered from inputs
+// Read-only derived state; no composition-time back-writing.
 val merged = remember(parent, overlay) {
     if (overlay.isEmpty()) parent else parent + overlay
 }
 ```
 
-If the result is read-only for the current inputs, `remember(keys) { … }` is
-enough. See [Compose performance](../../compose-performance/SKILL.md) for
-cross-row measurement and measure-phase fixes.
+## Exceptions
 
-### When this rule does NOT apply
-
-- **Inside `remember { … }`'s producer block.** That runs once per key change, not on every recompose. A local `var` there is fine: `val builder = remember { mutableListOf<X>().apply { var n = 0; … } }`.
-- **In non-`@Composable` lambdas passed *out* of a composable.** `onClick = { var a = 0; … }` is a plain `() -> Unit`. Local vars there are normal Kotlin.
-- **In plain (non-`@Composable`) helper functions.** Only composable scopes are affected.
+- A local `var` inside `remember`'s producer, a non-composable callback, or a plain helper function is ordinary Kotlin state.
+- Tests using `setContent` are composable scopes and follow the same rules.
+- `produceState` has its own coroutine producer; do not add an inner `LaunchedEffect` just to produce it.
 
 ## Related
 
-If a composable needs `LaunchedEffect`, `DisposableEffect`, `SideEffect`,
-`rememberCoroutineScope`, `rememberUpdatedState`, `snapshotFlow`,
-snackbar/navigation handling, analytics, or Flow collection, use [Side
-effects](side-effects.md).
-
-Focus splits by question: **navigation, focus state, `FocusRequester`
-ownership, behavior** → [Compose focus
-navigation](../../compose-focus-navigation/SKILL.md); **when** to call
-imperative `requestFocus` (effect timing, lifecycle, keys, API choice) →
-[Side effects](side-effects.md).
-
-This skill is about authoring Compose state correctly. `rememberUpdatedState` is effect capture state, not a general replacement for `remember { mutableStateOf(...) }`. Side effects have separate lifecycle and keying rules, and keeping them in one focused skill avoids two sources of truth.
-
-## Quick reference
-
-| Symptom | Diagnosis | Fix |
-|---|---|---|
-| `var x = …` inside `@Composable fun` body | Not recomposition-safe (§1) | `var x by remember { mutableStateOf(…) }` |
-| `var x = …` inside `Column { … }` / `Row { … }` content lambda | Same — content lambdas are `@Composable` (§1) | Same fix |
-| `remember { mutableStateOf(list) }` then `.add(x)` not recomposing | Mutation bypasses State setter | Use `mutableStateListOf`, or replace the value: `state = state + x` |
-| `stateMap.clear(); stateMap.putAll(...)` in composable body | Back-writing composition → composition | `remember(keys) { derivedSnapshot }` |
-
-## When NOT to apply
-
-- **Tests** with `composeTestRule.setContent { … }` follow the same rules — they're production composables.
-- **`produceState`** has its own producer block that runs in a coroutine; you don't need `LaunchedEffect` *inside* it.
-- **`derivedStateOf`** has its own concerns around stability and equality — out of scope here; it's about *preventing* recomposition, not authoring state.
-
-## Red flags during review
-
-| Thought | Reality |
-|---|---|
-| "It's a small composable, the bare `var` is fine" | Recomposition can fire at any time. The reset is non-deterministic by design — and a single bug report later. |
-| "I always reach for `LaunchedEffect` because it's the one I know" | Use [Side effects](side-effects.md); effect API choice depends on lifecycle and keys. |
-| "I'll just `.add()` to the remembered list" | A `mutableStateOf(List)` doesn't observe internal mutation — use `mutableStateListOf` or replace the value. |
+Focus behavior belongs in [Compose focus navigation](../../compose-focus-navigation/SKILL.md); `rememberUpdatedState` is effect-capture state, not a replacement for ordinary local UI state.

--- a/skills/compose-state-and-effects/references/side-effects.md
+++ b/skills/compose-state-and-effects/references/side-effects.md
@@ -1,231 +1,46 @@
-# Compose: side effects
+# Compose side effects
 
 ## Core principle
 
-Composable bodies describe UI. They can be recomposed, skipped, or abandoned. Work that changes the outside world belongs in an effect API whose lifecycle matches the work.
+Composable bodies render; external work belongs to the smallest effect whose lifecycle matches that work.
 
-## Pick the smallest effect
+## Procedure
+
+1. Choose the effect from the table and keep network/business work in the appropriate screen holder unless the UI itself owns the keyed lifecycle.
+2. Key an effect by the semantic input that should restart or dispose it. Do not use `Unit` to hide a changing identity, or a broad state object when one property owns the lifecycle.
+3. For a long-lived effect that needs the latest callback without restarting, read a `rememberUpdatedState` value lazily inside the effect or a later callback. If a changed value should recreate work, use it as a key instead.
+4. Collect event/side-effect flows in `LaunchedEffect`; collect render state near the state holder and render it as plain state. A `snapshotFlow` needs a terminal `collect`.
+5. Pair every registration in `DisposableEffect` with `onDispose`; start click/gesture coroutines through `rememberCoroutineScope` rather than an event flag.
+6. Route focus navigation semantics to [Compose focus navigation](../../compose-focus-navigation/SKILL.md) and measurement phase work to [Compose performance](../../compose-performance/SKILL.md).
+7. Finish when work cannot run from composition, its restart/cleanup identity is explicit, and the current lifecycle owns cancellation.
 
 | Need | API |
 |---|---|
-| Publish Compose state to non-Compose code after every successful recomposition | `SideEffect` |
-| Register/unregister a listener, callback, observer, or resource | `DisposableEffect(keys...)` |
-| Run suspending, deferred, or keyed one-shot work | `LaunchedEffect(keys...)` |
-| Launch suspending work from a user event callback | `rememberCoroutineScope()` |
-| Convert Compose snapshot reads into a Flow inside a coroutine | `snapshotFlow { ... }` inside `LaunchedEffect` |
-
-## Effect keys
-
-Keys define restart identity. When any key changes, the old effect is cancelled/disposed and a new one starts.
+| Publish Compose state after successful recomposition | `SideEffect` |
+| Register and unregister a listener/resource | `DisposableEffect(keys...)` |
+| Suspending, deferred, or keyed work | `LaunchedEffect(keys...)` |
+| Suspend work caused by a user event | `rememberCoroutineScope()` |
+| Turn snapshot reads into a Flow | `snapshotFlow { ... }` in `LaunchedEffect` |
 
 ```kotlin
-// ✅ Restart collection when userId changes
-LaunchedEffect(userId) {
-    repository.events(userId).collect { event -> handle(event) }
-}
-
-// ❌ Unit hides a changing input; collection keeps using the first userId
+val latestOnTimeout by rememberUpdatedState(onTimeout)
 LaunchedEffect(Unit) {
-    repository.events(userId).collect { event -> handle(event) }
+    delay(1_000)
+    latestOnTimeout()
 }
 ```
 
-Use stable, semantic keys:
-
-- Use the thing whose lifecycle the effect follows: `userId`, `screenId`, `lifecycleOwner`, `focusRequester`.
-- Do not use broad objects (`state`, `viewModel`) when only one property matters.
-- Do not add changing lambdas as keys unless you really want restarts on every lambda change.
-
-## Avoid stale captures
-
-For long-running effects that should not restart but need the latest callback or value, use `rememberUpdatedState`.
+Do not read `latestOnTimeout` eagerly in `remember { ... }`: that snapshots its initial value. Either key `remember` on the changing value or defer the read in a lambda. Likewise, do not use `rememberUpdatedState(userId)` to avoid restarting a collection that should follow `userId`.
 
 ```kotlin
-@Composable
-fun Timeout(onTimeout: () -> Unit) {
-    val latestOnTimeout by rememberUpdatedState(onTimeout)
-
-    LaunchedEffect(Unit) {
-        delay(1_000)
-        latestOnTimeout()
-    }
+DisposableEffect(owner, observer) {
+    owner.lifecycle.addObserver(observer)
+    onDispose { owner.lifecycle.removeObserver(observer) }
 }
 ```
 
-Use this when the lifecycle is "start once" but the invoked lambda should stay fresh. Common cases:
+## Exceptions
 
-- A timeout or splash effect should not restart when `onTimeout` changes, but it should call the latest callback.
-- A lifecycle observer should stay registered to the same owner, but invoke the latest `onStart` / `onStop` lambdas.
-- A long-running collector should keep its collection lifecycle, but call the latest event handler.
-
-Do not use `rememberUpdatedState` to avoid choosing proper keys. If the changed value should restart the work, make it a key instead:
-
-```kotlin
-// BAD: userId changes should restart the collection, not update a captured value.
-val latestUserId by rememberUpdatedState(userId)
-LaunchedEffect(Unit) {
-    repository.events(latestUserId).collect { event -> handle(event) }
-}
-
-// GOOD: the collection lifecycle follows userId.
-LaunchedEffect(userId) {
-    repository.events(userId).collect { event -> handle(event) }
-}
-```
-
-### `rememberUpdatedState` values are stale inside `remember {}` blocks
-
-`rememberUpdatedState` returns a `State` object whose `.value` is updated on every recomposition. The "latest" behavior only helps when the State is **read lazily** — inside an effect body or a lambda that runs later — not when the value is captured eagerly.
-
-Inside a `remember {}` block the producer lambda runs once. Reading the delegate there snapshots the current `.value` into the remembered object — future State updates never reach it:
-
-```kotlin
-val latestChannelId by rememberUpdatedState(channelId)
-
-// ❌ BAD — channelId is read once when remember's lambda executes;
-// the destination holds the initial value forever
-val destination = remember {
-    Destination(channelId = latestChannelId)
-}
-
-// ✅ GOOD — skip rememberUpdatedState; key remember on the changing value
-val destination = remember(channelId) {
-    Destination(channelId = channelId)
-}
-
-// ✅ ALSO GOOD — wrapping lambda defers the read to each invocation
-val destination = remember {
-    Destination(channelId = { latestChannelId })
-}
-```
-
-The same trap applies anywhere a `rememberUpdatedState` delegate is **read eagerly** rather than deferred behind a lambda or effect body: data classes constructed in `remember`, objects built once in `DisposableEffect`'s setup block, or any expression evaluated at creation time.
-
-When the captured value should trigger recreation of the remembered object, make it a `remember` key and skip `rememberUpdatedState` entirely. Reserve `rememberUpdatedState` for values that must stay fresh inside a long-lived scope (effect coroutine, event callback) **without** restarting that scope.
-
-`rememberUpdatedState` also does not make render state "non-recomposing." If the UI needs to display a changing value, read normal `State` in composition or use [Compose performance](../../compose-performance/SKILL.md) for frame-rate values.
-
-## Collecting Flow
-
-Use `LaunchedEffect` for **side-effect/event flows**: snackbars, navigation events, analytics events, focus commands, or other streams where each emission triggers imperative work.
-
-```kotlin
-LaunchedEffect(events) {
-    events.collect { event ->
-        snackbarHostState.showSnackbar(event.message)
-    }
-}
-```
-
-Do not collect render state imperatively just to mutate local state. For UI state, collect near the state holder and pass plain values into the UI composable—the **state-holder vs UI split**, `collectAsStateWithLifecycle()` / `collectAsState()`, and preview-friendly wiring are covered in [State hoisting](state-hoisting.md). Do not duplicate that architecture here.
-
-On Android, prefer lifecycle-aware collection where available; use `collectAsState()` on targets without lifecycle-aware APIs.
-
-For Compose state reads, use `snapshotFlow`:
-
-```kotlin
-LaunchedEffect(listState) {
-    snapshotFlow { listState.firstVisibleItemIndex }
-        .distinctUntilChanged()
-        .collect { index -> analytics.visibleIndex(index) }
-}
-```
-
-`snapshotFlow { ... }.map { ... }` without a terminal `collect` does nothing.
-
-## User events
-
-Use `rememberCoroutineScope()` when a click or gesture starts suspending work:
-
-```kotlin
-@Composable
-fun SaveButton(snackbarHostState: SnackbarHostState) {
-    val scope = rememberCoroutineScope()
-
-    Button(
-        onClick = {
-            scope.launch {
-                snackbarHostState.showSnackbar("Saved")
-            }
-        },
-    ) {
-        Text("Save")
-    }
-}
-```
-
-Avoid "event flag" state just to trigger a `LaunchedEffect`. The click already is the event.
-
-## Registration and cleanup
-
-Use `DisposableEffect` for paired setup/teardown:
-
-```kotlin
-@Composable
-fun ObserveLifecycle(owner: LifecycleOwner, observer: LifecycleObserver) {
-    DisposableEffect(owner, observer) {
-        owner.lifecycle.addObserver(observer)
-        onDispose {
-            owner.lifecycle.removeObserver(observer)
-        }
-    }
-}
-```
-
-Every registration path should have a matching `onDispose` cleanup path.
-
-## Common mistakes
-
-| Mistake | Diagnosis | Fix |
-|---|---|---|
-| Network request directly in the composable body | Side work in composition | Usually move to a ViewModel/state holder; use `LaunchedEffect` only for UI-owned keyed work |
-| Analytics property written from the composable body | Side work in composition | Use `SideEffect` when it should publish after every successful recomposition |
-| Impression/event logged from the composable body | Side work in composition | Use `LaunchedEffect(key)` when it should run once for that key |
-| `LaunchedEffect(Unit)` captures changing `id` | Missing key | Key by `id`, or use `rememberUpdatedState` if it must not restart |
-| `rememberUpdatedState(id)` used so `LaunchedEffect(Unit)` keeps running after `id` changes | Hidden lifecycle bug | Key the effect by `id` |
-| Long-lived effect invokes an old callback after recomposition | Stale capture | Wrap the callback with `rememberUpdatedState` and call the wrapper inside the effect |
-| `rememberUpdatedState` delegate read directly in `remember {}` (e.g. `Destination(id = latestId)`) | Value captured once, never refreshed | Make the value a `remember` key: `remember(id) { Destination(id = id) }` |
-| `LaunchedEffect(state) { ... }` restarts too often | Overly broad key | Key by the specific property |
-| `LaunchedEffect(...) { nonSuspendSetter() }` | Wrong effect type | Usually `SideEffect`; keep `LaunchedEffect` only for keyed one-shot/deferred work |
-| Listener added in `LaunchedEffect` with no cleanup | Missing disposal | Use `DisposableEffect` |
-| Launching from click by setting `shouldShowSnackbar = true` | Event flag anti-pattern | Use `rememberCoroutineScope()` in the click callback |
-| `if (isFocused) { … }` or focus read in composable body for side work | Side work during composition | `LaunchedEffect(focused) { … }` or `snapshotFlow` |
-| `onSizeChanged { heightState = it.height }` on measured composable | Layout → composition back-write if a sibling reads `heightState` in composition | Siblings must consume height in measure phase, not `Modifier.height(state.dp)` in composition |
-
-## Focus and measurement
-
-**Focus:** Reading focus in the composable body to drive **side work** (preloading, analytics, toasts) runs that work during composition. Observe focus in an effect instead:
-
-```kotlin
-// ❌ BAD — side work runs during composition every time `focused` is true,
-// including transient focus passes; `SideEffect` re-runs after every successful recomposition
-@Composable
-fun Preloader(interactionSource: MutableInteractionSource) {
-    val focused by interactionSource.collectIsFocusedAsState()
-    if (focused) {
-        preloadImages()
-    }
-}
-
-// ✅ GOOD — side work in a keyed effect
-@Composable
-fun Preloader(interactionSource: MutableInteractionSource) {
-    val focused by interactionSource.collectIsFocusedAsState()
-    LaunchedEffect(focused) {
-        if (focused) preloadImages()
-    }
-}
-```
-
-Use `snapshotFlow { … }` inside `LaunchedEffect` when you need to sample multiple snapshot reads or debounce rapid changes without keying the effect on every derived value. For TV/D-pad focus navigation semantics, see [Compose focus navigation](../../compose-focus-navigation/SKILL.md).
-
-**Measurement:** `onSizeChanged` / `onGloballyPositioned` are valid **callbacks**, but they fire during the layout phase. Writing snapshot state there is only safe if no earlier phase reads it. If a sibling reads that state in composition, layout is back-writing into composition and the sibling will recompose every measure pass. Apply captured dimensions in `Modifier.layout` (see [Compose component design](../../compose-component-design/SKILL.md) and [Compose performance](../../compose-performance/SKILL.md)).
-
-## Red flags during review
-
-- "This only runs once" about code in a composable body.
-- `LaunchedEffect(Unit)` in a function with changing parameters.
-- A flow chain inside an effect with no terminal collection.
-- Effects whose keys are chosen to silence lint instead of model lifecycle.
-- Callback lambdas used from long-lived effects without either a key or `rememberUpdatedState`.
-- `rememberUpdatedState` delegate read eagerly inside a `remember {}` block or object constructor — the value is captured once and never refreshes.
+- `SideEffect` publishes after every successful recomposition; use a keyed `LaunchedEffect` for one-shot work.
+- Use lifecycle-aware state collection on Android where available; use `collectAsState()` where it is not.
+- For focus-derived side work, use a keyed effect or `snapshotFlow`, never an `if` in the composable body.

--- a/skills/compose-state-and-effects/references/state-hoisting.md
+++ b/skills/compose-state-and-effects/references/state-hoisting.md
@@ -2,135 +2,31 @@
 
 ## Core principle
 
-Hoist state only as far as the logic needs it. Keep simple UI element state local, move shared UI element state to the lowest common composable owner, extract a plain state holder when UI-only behavior becomes a concept, and use a screen state holder when business logic or app data is involved. At the screen boundary, keep state-holder wiring separate from plain state-driven UI rendering.
+Hoist state only as far as its logic needs it; screen wiring and plain rendering are separate owners.
 
-## Review procedure
+## Procedure
 
-1. List the state, operations, app dependencies, event streams, and imperative effects involved.
-2. Assign each item to the lowest owner that needs to read or change it using the decision guide below.
-3. Extract a plain state holder only when coordinated UI-only behavior has become a concept.
-4. When a screen state holder owns Compose runtime objects, or a screen mixes app wiring with layout, keep durable data and intents at the screen boundary; move runtime objects into composition or a plain UI state holder; and explicitly recommend a separate, previewable content composable that takes immutable state and event callbacks. Naming immutable state and intents without this content boundary is incomplete.
-5. Pass immutable UI state and explicit event callbacks across that boundary; keep UI mechanics in composition unless business logic needs their values.
-6. Load focused effect, testing, focus, or deferred-read skills when those concerns need deeper treatment.
-7. Finish an ownership review by stating that concrete boundary when the visible code requires it. Otherwise allow a no-change conclusion. Do not stop after naming the wrong owner, invent product requirements, or hoist state farther than its logic requires.
-
-## Decision guide
+1. List the state, operations, app dependencies, event streams, and effects that need coordination.
+2. Choose the lowest owner from the table.
+3. Extract a plain state holder only when coordinated UI behavior is a concept; keep a lone boolean or trivial text field local.
+4. At a screen boundary, implement the three seams defined in the parent skill: small wiring owns app dependencies, durable data, and effects; composition or a plain UI state holder owns runtime UI objects; a plain composable receives immutable UI state and event callbacks.
+5. Keep frame-clock operations such as scrolling or drawer animation in a composition-scoped coroutine, not `viewModelScope`.
+6. Save serializable values with `rememberSaveable`/a `Saver`, never runtime objects or callbacks.
+7. Finish by stating the concrete boundary for an ownership review, or make no change when the existing owner already matches the evidence.
 
 | Situation | Owner |
 |---|---|
-| One composable reads/writes simple state | Keep local with `remember` / `rememberSaveable` |
-| Sibling or parent composables need to read/write it | Hoist state and events to their lowest common composable ancestor |
-| Related UI element state plus UI logic is making a composable hard to read, preview, or test | Extract a plain state holder class remembered in composition |
-| Repository calls, persistence, business rules, or screen UI state production are involved | Use a screen-level state holder such as a `ViewModel` or component |
-| A screen composable collects app state/effects and also owns most layout | Keep a small wiring composable and extract a plain UI composable that takes immutable state and callbacks |
-
-UI element state includes things like expansion, sheet visibility, scroll position, focus, text field editing state, selection, and animation/interaction state. Screen UI state is app data prepared for display.
-
-If UI element state is an input to business logic, it may need to live in the screen state holder too. For example, text used to query repository-backed suggestions belongs with the state holder that produces those suggestions.
-
-## Plain state holder trigger
-
-Extract a plain state holder when several of these are true:
-
-- Multiple related `remember` values are coordinated by the same callbacks.
-- Scroll, focus, text, selection, or sheet state needs named operations such as `clear`, `submit`, `jumpToTop`, or `openFilters`.
-- Derived UI flags are scattered through the composable.
-- Child composables receive mechanics they do not conceptually own.
-- Previews or tests must drive a long sequence of UI details to check one behavior.
-- Helper functions need many state parameters just to keep the composable readable.
-
-Do not extract for one boolean, one text field, or trivial show/hide logic. Ceremony is not separation of concerns.
-
-## Pattern
-
-Use a plain class for UI element state and UI logic, plus a `remember...State` function for composition-owned objects:
-
-```kotlin
-@Stable
-class ProductSearchState(
-    query: String,
-    private val listState: LazyListState,
-    private val focusRequester: FocusRequester,
-) {
-    var query by mutableStateOf(query)
-        private set
-
-    var filtersOpen by mutableStateOf(false)
-        private set
-
-    val canClear: Boolean
-        get() = query.isNotEmpty()
-
-    fun updateQuery(value: String) {
-        query = value
-    }
-
-    fun clear() {
-        query = ""
-        focusRequester.requestFocus()
-    }
-
-    suspend fun jumpToTop() {
-        listState.animateScrollToItem(0)
-    }
-}
-
-@Composable
-fun rememberProductSearchState(
-    initialQuery: String = "",
-    listState: LazyListState = rememberLazyListState(),
-    focusRequester: FocusRequester = remember { FocusRequester() },
-): ProductSearchState {
-    return remember(listState, focusRequester) {
-        ProductSearchState(initialQuery, listState, focusRequester)
-    }
-}
-```
-
-The composable renders from the state holder and calls intent-style methods. If a parent needs to coordinate the same UI behavior, accept the state holder as a parameter with a default:
-
-```kotlin
-@Composable
-fun ProductSearchPanel(
-    state: ProductSearchState = rememberProductSearchState(),
-    modifier: Modifier = Modifier,
-) {
-    val scope = rememberCoroutineScope()
-
-    SearchField(
-        query = state.query,
-        onQueryChange = state::updateQuery,
-        onClear = state::clear,
-    )
-
-    JumpToTopButton(onClick = {
-        scope.launch { state.jumpToTop() }
-    })
-}
-```
-
-## Composition ownership
-
-Plain state holders created with `remember` follow the composable lifecycle. This makes them a good home for Compose UI objects such as `LazyListState`, `FocusRequester`, `PagerState`, `DrawerState`, and `TextFieldState`.
-
-Keep suspend UI operations that require a frame clock, such as scroll or drawer animations, in a composition-scoped coroutine (`rememberCoroutineScope`, `LaunchedEffect`, or another composition-owned scope). Do not move those calls to `viewModelScope`.
-
-## Saving state
-
-Use `rememberSaveable` or a custom `Saver` only for values that should survive Activity or process recreation, such as a query string, selected filter IDs, or a current tab key.
-
-Do not try to save runtime objects like `LazyListState`, `FocusRequester`, coroutine scopes, or callbacks directly. Save the minimal serializable values needed to rebuild behavior.
-
-## Split screen wiring from UI rendering
-
-When a screen takes a `ViewModel`, component, controller, navigator, repository, or service, keep that dependency in a small state-holder composable. Collect app state and effects there, then pass immutable UI state and explicit event callbacks to a plain UI composable.
+| One composable owns simple UI state | Local `remember` / `rememberSaveable` |
+| Siblings or a parent share it | Lowest common composable owner |
+| Related UI mechanics need named operations or coordinated state | Plain state holder remembered in composition |
+| Repository calls, persistence, business rules, or screen state production | Screen-level holder such as `ViewModel` or component |
+| App wiring and layout are mixed | Small wiring composable plus plain UI composable |
 
 ```kotlin
 @Composable
 fun ProfileScreen(component: ProfileComponent, modifier: Modifier = Modifier) {
     val state by component.state.collectAsStateWithLifecycle()
-
-    ProfileScreen(
+    ProfileContent(
         state = state,
         onNameChange = component::onNameChange,
         onSaveClick = component::save,
@@ -138,72 +34,18 @@ fun ProfileScreen(component: ProfileComponent, modifier: Modifier = Modifier) {
         modifier = modifier,
     )
 }
-
-@Composable
-fun ProfileScreen(
-    state: ProfileUiState,
-    onNameChange: (String) -> Unit,
-    onSaveClick: () -> Unit,
-    onBackClick: () -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    // Layout only.
-}
 ```
 
-Use the boundary deliberately:
+A plain state holder can retain `LazyListState`, `FocusRequester`, `PagerState`, drawer state, and other UI mechanics created in composition. Pass business-relevant derived values across the screen boundary, but do not expose those runtime objects to the screen holder. When a child must coordinate the holder, accept it deliberately; otherwise pass plain values and callbacks.
 
-| Concern | State-holder composable | Plain UI composable |
-|---|---|---|
-| Collect app/business state and one-shot effects | Yes | No |
-| Hold dependency-injected objects | Yes | No |
-| Accept immutable UI state and event callbacks | Usually passes them through | Yes |
-| Own layout, modifiers, semantics, and test tags | No or minimal | Yes |
-| Own Compose runtime objects such as `LazyListState` or `FocusRequester` | No | Yes, directly or in a plain UI state holder |
-| Receive business-relevant values or intents derived from UI mechanics | Yes | Supplies them without exposing runtime objects |
+## Exceptions
 
-Pass the smallest useful UI contract:
-
-- Prefer a dedicated immutable `UiState` when the screen has cohesive state.
-- Prefer explicit event callbacks over passing the whole state holder through the tree.
-- Keep navigation as callbacks that describe user intent.
-- Map domain models to UI models when direct use would pull business rules into rendering.
-- Pass provider lambdas for frame-rate values that should be read in layout or draw, per [Compose performance](../../compose-performance/SKILL.md).
-
-Handle navigation, snackbar, analytics, or event collection near the state holder, where the source and imperative target are available. If effect handling grows, extract a small sibling effect handler rather than passing the state holder into the UI composable. Use [Side effects](side-effects.md) for effect APIs, keys, cleanup, and stale captures.
-
-Do not create a state-holder/UI overload for every small composable. Split at a screen or cohesive section boundary when doing so removes app dependencies from meaningful UI that should be previewed, tested, or reused.
-
-Do not apply the split to tiny one-off composables that already take plain values and callbacks, design-system primitives that should expose slots and modifiers, or wrappers that would only forward one primitive without isolating an app dependency.
-
-## RED/GREEN agent scenarios
-
-For each scenario, establish RED by omitting or reverting the relevant rule, then restore the skill and require the GREEN outcome.
-
-1. A screen takes a component, collects `StateFlow`, handles a navigation event, and owns most layout. GREEN keeps the component, collection, and effect handling in a small wiring composable, then extracts a plain UI composable with immutable state and callbacks.
-2. Novel case: a search query drives repository-backed suggestions while a `LazyListState` and `FocusRequester` coordinate the UI. GREEN moves the query and suggestion logic to the screen state holder, but keeps the Compose runtime objects in the plain UI or a plain UI state holder.
-3. Over-application counterexample: a stateless design-system badge takes plain values, slots, and a modifier. GREEN does not create a state-holder/UI overload or introduce a `ViewModel` merely for structural symmetry.
-
-## Common mistakes
-
-| Mistake | Fix |
-|---|---|
-| Hoisting every local state value to a parent "just in case" | Hoist to the lowest owner that actually reads or writes it |
-| Extracting a plain state holder for one boolean | Keep simple private UI state local |
-| Putting repository calls or product rules in a Compose state holder | Move that logic to a screen state holder such as a `ViewModel` or component |
-| Keeping text or selection local when it drives repository-backed screen state | Move that input to the screen state holder with the business logic |
-| Passing a state holder deep into unrelated children | Pass plain values and callbacks unless the child truly coordinates the holder's behavior |
-| Treating the holder as a dumping ground for a whole screen | Split by cohesive UI behavior, such as search input, sheet coordination, or list controls |
-| Calling animation suspend functions from `viewModelScope` | Use a composition-scoped coroutine |
-| A screen composable takes a component and renders all layout | Extract a plain UI overload that takes state and callbacks |
-| Child composables take a `ViewModel` or component | Pass only the values and callbacks each child needs |
-| UI rendering performs navigation or collects app event flows | Handle effects beside the screen state holder |
-| Every small composable gets a state-holder overload | Split only at screen or cohesive section boundaries |
+- Do not split a tiny one-off composable that already receives plain values and callbacks.
+- Do not create a state-holder/UI overload for structural symmetry or a design-system primitive; use slots and modifiers for those APIs.
+- If UI input drives repository-backed data, keep that input with the screen holder that produces the data.
 
 ## Related
 
-- [Local state](local-state.md) — correct local `remember` and mutable state authoring.
-- [Side effects](side-effects.md) — choose effect APIs and composition-scoped coroutine boundaries.
-- [Compose focus navigation](../../compose-focus-navigation/SKILL.md) — focus state, requesters, and keyboard/D-pad behavior.
-- [Compose UI testing patterns](../../compose-ui-testing-patterns/SKILL.md) — test plain state-driven UI without constructing the full app graph.
-- [Kotlin API design](../../kotlin-api-design/SKILL.md) — keep shared UI plain while platform services stay behind semantic boundaries.
+- [Local state](local-state.md) for correct `remember` and snapshot-state authoring.
+- [Side effects](side-effects.md) for effect APIs, keys, and cleanup.
+- [Compose UI testing patterns](../../compose-ui-testing-patterns/SKILL.md) for testing plain UI without the app graph.

--- a/skills/compose-ui-testing-patterns/SKILL.md
+++ b/skills/compose-ui-testing-patterns/SKILL.md
@@ -171,39 +171,3 @@ setContentWithFakeImageLoader { request ->
 ```
 
 When image appearance matters, provide a deterministic local painter/bitmap instead of network data.
-
-## Common mistakes
-
-| Mistake | Fix |
-|---|---|
-| Constructing full app graph to test an error row | Test plain UI with `state = Error` |
-| Testing click behavior through a ViewModel mock | Pass a callback and assert it was invoked |
-| Screenshot test for simple text presence | Use semantics assertion |
-| Semantics test for padding/color/focus ring | Use screenshot test |
-| Test tags everywhere | Prefer text/content description/role when stable |
-| UI test depends on real image loading/network/time | Fake or freeze the source |
-| Sleeping after an action before asserting UI | Use semantics plus `waitForIdle`, `runOnIdle`, or bounded `waitUntil` |
-| Production DI or app wiring for a state/rendering assertion | Render controlled state with `setContent`; use integration only when that wiring is under test |
-| Simulating hover/press/focus with mouse or touch events | Inject `MutableInteractionSource` and emit the interaction |
-| Relying on the default `InteractionSource` in tests | Pass `MutableInteractionSource` so you can control state |
-| TV/keyboard UI tested with `performClick` only | Use key input and focus assertions; see [compose-focus-navigation](../compose-focus-navigation/SKILL.md) |
-
-## Red flags during review
-
-- "This UI test is flaky because images load slowly."
-- A test uses production DI for simple rendering.
-- A screenshot has random dates, clocks, remote images, or live data.
-- Assertions only check that a node exists after performing an action, not that the callback/state change happened.
-- Focus behavior is visually inspected but not asserted.
-- A test uses `performMouseInput` or touch injection to trigger hover/press states instead of `MutableInteractionSource.emit`.
-- A composable accepts `interactionSource` but tests don't inject `MutableInteractionSource`.
-- A plain rendering test starts the production app or uses `Thread.sleep` before asserting.
-
-## RED/GREEN agent scenarios
-
-1. RED launches a production app, waits with `Thread.sleep`, and only asserts that a node exists. GREEN renders fixed state with `setContent`, drives the action, synchronizes through Compose, and asserts the semantic state or callback result.
-2. Novel case: a screen's repository-backed state holder starts background work, but the test only needs to prove a disabled Save button. GREEN tests the plain UI state directly; a separate integration test covers the state-holder wiring if needed.
-3. Counterexample: navigation behavior depends on a real `NavController` lifecycle. GREEN uses an integration test rather than pretending a plain rendering test proves that contract.
-4. Focused counterexample: a value-only formatter test already uses a plain unit
-   test and the task asks only whether it needs a UI harness. GREEN leaves the
-   test-local helper and workspace unchanged.

--- a/skills/gradle-run/SKILL.md
+++ b/skills/gradle-run/SKILL.md
@@ -7,38 +7,33 @@ description: Use when planning to execute Gradle through `gradle`, `./gradlew`, 
 
 ## Core principle
 
-Treat complete Gradle output as a temporary artifact, never conversation
-context. Every agent-initiated Gradle command goes through the compact-output
-wrapper; never stream, `tee`, paste, or reopen a complete build log.
+Treat complete Gradle output as a temporary, sensitive artifact. Every
+agent-initiated Gradle command runs through the compact-output wrapper; never
+stream, `tee`, paste, or reopen a full build log.
 
 ## Procedure
 
-1. Classify the request. A focused Gradle command that only validates another
-   implementation change is incidental validation. A build, check,
-   warning-cleanup, or failure-investigation loop is a Gradle-centered
-   workflow.
-2. Resolve this installed skill's directory and confirm `python3` and
-   `<skill-dir>/scripts/gradle_run.py` are available. If either is
-   unavailable, stop before running Gradle directly and report the failed
-   prerequisite.
-3. Create one wrapper workflow before the first command:
+1. Classify the request. Reuse a current successful result when unchanged
+   source and inputs already answer the question. A focused task that validates
+   another change is incidental; build/check/warning/failure work is a
+   Gradle-centered workflow.
+2. Resolve this skill directory and confirm `python3` plus
+   `scripts/gradle_run.py`. If either is unavailable, stop and report that
+   prerequisite; never run Gradle directly as a fallback.
+3. Create one workflow before its first command and retain its opaque ID:
 
    ```sh
    python3 <skill-dir>/scripts/gradle_run.py create
    ```
 
-   Run `create`, every `run`, and `finish` as standalone shell commands; do
-   not chain a lifecycle operation with discovery, status, or cleanup commands.
-   Retain the returned opaque workflow identifier. Use only this wrapper to
-   run Gradle. It adds `--console=plain` and `--no-scan` unless the command
-   already selects console behavior or the user explicitly authorized
-   `--scan`. For warning discovery, include `--warning-mode all` in the Gradle
-   command; otherwise include it only when the user asks for it. Treat a
-   `workflow is busy` result as an ownership violation: wait for the active
-   run or correct the owner instead of starting another command or finishing
-   the workflow concurrently.
-4. For incidental validation, stay in the current agent and run the smallest
-   owning task with a non-empty verification question:
+   Run `create`, each `run`, and `finish` as standalone shell commands. Use the
+   wrapper exclusively; it supplies `--console=plain` and `--no-scan` unless
+   console behavior was selected or the user authorized `--scan`. Add
+   `--warning-mode all` only for warning discovery or an explicit request. A
+   `workflow is busy` result is an ownership violation: wait for the owner or
+   correct ownership; do not start or finish concurrently.
+4. For incidental validation, stay in the current agent and run the narrowest
+   task that answers a non-empty verification question:
 
    ```sh
    python3 <skill-dir>/scripts/gradle_run.py run \
@@ -47,107 +42,38 @@ wrapper; never stream, `tee`, paste, or reopen a complete build log.
      ./gradlew :module:test
    ```
 
-   Choose the task from the verification question's acceptance claim. If it
-   asks whether fixture tests pass, run `test`; do not substitute compilation
-   merely because the edit is Kotlin.
-
-   Read only the bounded JSON summary and continue from its failed tasks,
-   fingerprints, and excerpt. Do not inspect its log unless a user explicitly
-   requests that artifact. In the final report, repeat the verification
-   question and answer it from that bounded summary. Name the managed
-   `gradle_run.py run` wrapper as the executor and the nested Gradle task
-   separately; do not present only the nested Gradle command or describe it as
-   a direct Gradle invocation.
-   The summary and ledger redact common credential patterns; the retained full
-   log is intentionally raw and can contain secrets, so never paste or reopen
-   it as a substitute for the summary.
-5. For a Gradle-centered workflow, create one fresh portable Solver diagnostic
-   owner. Report its model and reasoning only if the runtime exposes them. Give
-   it read-only repository access and ownership of wrapper runs and diagnosis;
-   it must not edit source, tests, configuration, or generated project files,
-   and it must not delegate Gradle ownership. The parent owns every repository
-   edit. If a fresh persistent owner cannot be created, stop rather than make
-   the parent run the workflow loop.
-6. Have that owner reuse prior actionable summaries, group warnings and
-   failures by fingerprint, and return exact file or line evidence plus the
-   narrowest next command. Prefer source or compiler failure fingerprints over
-   a following generic Gradle failure block. Run an initial broad command only
-   when existing targeted evidence cannot answer the recorded question. The
-   owner stays available for the whole workflow and verifies each parent
-   change with the same wrapper and the narrowest applicable task.
-7. Record `broad` only for aggregate project checks. Give every broad run a
-   distinct question that a narrower task cannot answer. The wrapper flags
-   repeated commands and primary failure fingerprints; if the primary source
-   or compiler failure repeats, stop the run loop. Inspect the reported source
-   line and its nearby declaration, import, or receiver context before
-   proposing a fix or another Gradle command; then revise the diagnosis from
-   that evidence. In the final diagnosis, name that focused inspection as the
-   next action; do not say to fix the source before it happens. If the wrapper
-   is interrupted, use its recorded signal
-   and retained log; it stops the isolated Gradle process group or Windows
-   process tree, extracts bounded diagnostics from the partial log, and makes
-   the ledger durable before returning. Only logs still represented by the
-   bounded recent-run ledger are retained.
-8. Finish after the requested broad validation passes, or report unresolved
-   warning fingerprints and the reason validation cannot continue. Summarize
-   the compact ledger, including each verification question and its bounded
-   answer, then finish it:
+   Do not substitute compilation for requested fixture tests. Read only the
+   bounded JSON summary; report both the managed wrapper and nested Gradle task,
+   the question, and its bounded answer.
+5. For Gradle-centered work, create one fresh persistent Solver diagnostic
+   owner with read-only repository access. It owns wrapper runs and diagnosis,
+   may not edit or delegate Gradle ownership, and remains available for the
+   workflow. Report its model and reasoning only when exposed. The parent owns
+   repository edits. If that owner cannot exist, stop rather than running the
+   loop in the parent.
+6. Have the owner reuse actionable summaries, group warnings/failures by
+   fingerprint, and return source/line evidence plus the narrowest next command.
+   Run broad only for an aggregate question that targeted evidence cannot
+   answer. On a repeated primary source/compiler fingerprint, stop rebuilding;
+   inspect the cited source line and nearby declaration, import, or receiver
+   context before revising the diagnosis. Verify each parent change with the
+   same wrapper and narrowest applicable task. In the final diagnosis, name the
+   focused inspection as the next action; do not claim a source fix before it.
+   A new question does not permit a blind repeat.
+7. Treat the full log as raw sensitive material even though summaries and
+   ledgers redact common credentials. Never expose it in model-visible context.
+   On interruption, use the wrapper's recorded signal and bounded partial
+   diagnostics; it owns process-group/process-tree cleanup and durable ledger
+   updates. Only logs still represented by the bounded recent-run ledger remain.
+8. Finish after the last requested validation (targeted or broad) passes, or
+   report unresolved fingerprints and why validation cannot continue. Summarize
+   each question and bounded answer, then run:
 
    ```sh
    python3 <skill-dir>/scripts/gradle_run.py finish --workflow <id>
    ```
 
-   In the final report, state that the workflow finished after that summary and
-   that cleanup removed only its wrapper-owned logs.
-
-   Finish retains small marker and lock metadata so repeating the same finished
-   identifier is idempotent while an unknown identifier fails closed. If
-   finish cannot validate the managed identifier or the workflow is active,
-   leave all files in place and report the failure. This skill does not
-   constrain unrelated review, exploration, implementation, or other
+   Report that finish removed only wrapper-owned logs. A finished known ID is
+   idempotent; an unknown ID or active workflow fails closed and leaves files in
+   place. This skill does not constrain unrelated review, implementation, or
    subagents.
-
-## RED/GREEN agent scenarios
-
-1. Direct: “Run `check` and fix every warning.” RED runs repeated full
-   builds with their logs in context. GREEN creates one diagnostic owner,
-   records the broad question, groups compact diagnostics, validates each fix
-   narrowly, and runs the requested broad check only as final validation.
-2. Novel: a final broad check finds a downstream failure after targeted tasks
-   pass. GREEN records the new question, targets the owning task, and only
-   broad-reruns once that task passes.
-3. Repetition: an unchanged source failure fingerprint survives a claimed fix.
-   GREEN stops rebuilding, inspects the cited source line and its surrounding
-   declaration or import context, then reports a revised diagnosis before
-   naming a fix or another Gradle command. It does not treat a new question
-   string as permission for a blind repeat.
-4. Fail closed: the wrapper, Python runtime, or persistent diagnostic owner is
-   unavailable. GREEN runs no direct Gradle fallback and reports the missing
-   prerequisite. A valid-looking but unknown finish identifier also fails; it
-   is not treated as a previously completed workflow.
-5. Counterexample: “After changing this Kotlin helper, run
-   `:module:test`.” GREEN uses the wrapper but keeps this incidental focused
-   validation with the current agent, runs each lifecycle operation as a
-   standalone command, and reports the managed wrapper plus the verification
-   question and bounded answer; it does not substitute compilation for the
-   stated test task.
-6. Boundary: while a Gradle workflow runs, a user starts an unrelated review
-   subagent. GREEN permits it; this skill owns Gradle output handling and
-   diagnostic delegation only.
-7. Interruption: Ctrl-C arrives twice after Gradle emits a diagnostic and enters
-   a signal-resistant worker process. GREEN tolerates the second signal, stops
-   the isolated process group, extracts the partial diagnostic, retains the
-   log, and records SIGINT in the compact ledger before returning. RED re-enters
-   cleanup, leaves either process running, or loses the diagnostic or
-   interruption record.
-8. Exclusive ownership: a second run or finish request uses an active workflow.
-   GREEN fails closed before launching or deleting anything. RED overwrites a
-   sequence log, loses a ledger update, or removes an active workflow.
-9. Sensitive output: a Gradle property and warning contain credentials. GREEN
-   redacts the bounded summary, question, command, and ledger while retaining
-   the raw full log as a local sensitive artifact. RED sends or persists the
-   credential in model-visible metadata.
-10. Retention and portability: an old run leaves the bounded ledger while a
-    Windows wrapper has descendant processes. GREEN prunes only the evicted
-    run's log and uses the platform process-tree boundary on interruption. RED
-    leaks unbounded logs or terminates only the Windows launcher.

--- a/skills/grounded-writing/SKILL.md
+++ b/skills/grounded-writing/SKILL.md
@@ -61,20 +61,3 @@ Finish only when all of these are true:
 
 If a check fails, revise the draft. If the failure depends on an unknown personal
 position, ask the user rather than smoothing over the gap.
-
-## RED/GREEN agent scenarios
-
-1. Direct case: a two-sentence review reply needs to report a fix and its
-   validation. RED expands it into an essay or adds enthusiasm. GREEN leads with
-   the outcome, names the relevant check, and stays within two sentences.
-2. Novel case: a technical tutorial needs a warmer register. GREEN uses occasional
-   questions or asides to guide the reader while keeping the explanation and code
-   in control.
-3. Novel case: a technical briefing benefits from two source observations. RED
-   blends recognizable mannerisms from both authors. GREEN selects only the
-   relevant structural techniques and keeps the user's natural tone.
-4. No-change case: a one-sentence review comment is already direct, grounded, and
-   appropriate for its audience. GREEN preserves it instead of expanding it.
-5. Counterexample: the user asks the assistant to explain a technical concept for
-   their own understanding, not to draft text for publication. GREEN answers
-   normally and does not introduce first-person claims on the user's behalf.

--- a/skills/implement-with-subagents/SKILL.md
+++ b/skills/implement-with-subagents/SKILL.md
@@ -17,23 +17,19 @@ through completion.
 2. Resolve and read the installed `implement` skill. Treat it as a required
    dependency. If it is unavailable, stop before making changes and report the
    missing dependency; never reproduce its procedure from memory.
-3. Build the work queue from the supplied tickets or plan tasks:
-   - preserve explicit boundaries and dependency order;
-   - treat an unsplit implementation request as one work item;
-   - keep checklist steps inside their containing work item; and
-   - group supplied items only when they cannot safely produce separate,
-     behavior-preserving commits.
-4. Process the queue sequentially on the current branch. Before each item,
-   record `HEAD` and require the preceding item to be committed with a clean
-   task-owned diff relative to the recorded pre-existing worktree state.
-5. Select the portable **Solver** role for the next item and map it to the
+3. Build a dependency-ordered queue. Keep an unsplit request and its checklist
+   in one work item; group supplied items only when they cannot validate in
+   separate behavior-preserving commits.
+4. Process one item at a time. Record `HEAD` and the pre-existing worktree state
+   before each item; accept the preceding item before starting the next.
+5. Select the portable **Solver** role and map it to the
    runtime's implementation-capable subagent type. Record the portable role and
    actual runtime selection when the environment exposes it. Spawn one owner.
    Do not implement any part of the item in the controller. If an implementation
    slot is temporarily unavailable, wait for capacity. If subagents cannot be
    started, stop and report the blocker rather than falling back to controller
    implementation.
-6. Give the owner a decision-complete packet containing:
+6. Give that owner a decision-complete packet containing:
    - the exact ticket or plan task and its acceptance criteria;
    - the relevant specification and repository instructions;
    - exclusive ownership of that work item on the current branch;
@@ -41,13 +37,12 @@ through completion.
    - an instruction to invoke the installed `implement` skill; and
    - an instruction to return the commit, the evidence required by the installed
      `implement` skill's current finish contract, and any unresolved blocker.
-7. Wait for that owner to finish before starting another. Do not split its
-   implementation across additional agents. When its result is incomplete,
-   dirty, uncommitted, or fails a required check, send the evidence back to the
-   same owner and let it repair its item. Stop on a material blocker the owner
-   cannot resolve within the supplied contract.
-8. Independently accept the item before advancing. Treat the owner's report as
-   claims rather than acceptance evidence:
+7. Wait for that owner before starting another. Do not split its implementation
+   across agents. If the result is incomplete, dirty, uncommitted, or fails a
+   required check, return the evidence to the same owner. Stop on a material
+   blocker it cannot resolve within the supplied contract.
+8. Independently accept the item before advancing; an owner's report is not
+   acceptance evidence. Verify:
    - verify `HEAD` advanced by at least one task-scoped commit;
    - inspect the complete commit range and diff from the recorded `HEAD` to the
      current `HEAD` for the work item's acceptance criteria and scope;
@@ -56,11 +51,9 @@ through completion.
      current finish contract; and
    - verify the task-owned diff is empty relative to the recorded pre-existing
      state.
-9. Send every failed acceptance check back to the same owner, then repeat step 8.
-   Start the next item only after acceptance passes. After the last item, run any
-   final verification required by the user or repository that the item-level
-   acceptance passes did not cover. If a later action changes files, return the
-   changes to their owning subagent for validation and commit.
+9. Repeat step 8 after every repair. After the last accepted item, run any final
+   user- or repository-required verification. If a later action changes files,
+   return them to their owner for validation and commit.
 
 ## Ownership boundaries
 
@@ -79,27 +72,3 @@ Finish only when every queued item has a task-scoped, reviewed, verified commit,
 the final worktree matches the recorded pre-existing state, and no
 owner-reported blocker remains. Report the item-to-commit mapping and the final
 validation result. Otherwise finish blocked and name the first incomplete gate.
-
-## RED/GREEN agent scenarios
-
-For each scenario, establish RED by omitting the relevant rule, then restore the
-skill and require the GREEN outcome.
-
-1. Two supplied tickets touch different modules and the second depends on the
-   first. RED implements in the controller or starts both agents concurrently.
-   GREEN sends the first ticket to one Solver owner using `implement`, accepts
-   its commit independently, then sends the second ticket to a fresh owner on
-   the updated branch.
-2. Novel case: the first owner reports success, but controller inspection finds
-   a required assertion missing from the committed diff. RED trusts the report
-   or starts the next work item. GREEN returns the failed acceptance evidence to
-   the same owner, then reinspects the repair and reruns verification.
-3. Missing-dependency case: `implement` is not installed. RED copies its
-   remembered behavior or lets the controller implement. GREEN stops before
-   mutation and reports the required dependency.
-4. Over-application counterexample: one ticket contains four TDD checklist
-   steps that share a seam. GREEN assigns the whole ticket to one owner and
-   does not create four agents.
-5. Coupling counterexample: two plan tasks must change the same atomic schema
-   and cannot pass validation independently. GREEN groups them into one work
-   item for one owner and records why separate commits would be unsafe.

--- a/skills/kotlin-api-design/SKILL.md
+++ b/skills/kotlin-api-design/SKILL.md
@@ -25,7 +25,7 @@ platform independence.
    its semantic and interop contract.
 5. Keep shared code semantic; put native SDK and platform details behind an
    interface or a narrowly justified expect/actual boundary.
-6. Read the focused reference for every material API decision below.
+6. Read the focused reference for the selected decision below.
 7. Finish when the public surface states domain intent, platform details remain
    at leaves, and callers do not depend on convenience abstractions with no
    clear owner.
@@ -38,16 +38,3 @@ platform independence.
 | Primitive obsession, one-field domain type, `@JvmInline value class`, data class, interop, or Compose stability | [Value classes](references/value-classes.md) |
 | Source sets, platform services, native SDKs, files, sensors, permissions, Compose Multiplatform interop, or expect/actual | [Multiplatform boundaries](references/multiplatform-boundaries.md) |
 | Branching, guard-condition shape, sealed-result mapping, or a catch-all `else` | [Kotlin control flow](../kotlin-control-flow/SKILL.md) |
-
-## RED/GREEN agent scenarios
-
-1. RED adds an extension on `String` to hide repository behavior. GREEN gives
-   the behavior a domain owner or service with a meaningful dependency boundary.
-2. Novel case: shared UI needs a platform permission service. GREEN preserves a
-   semantic shared contract and places platform SDK calls at the native leaf.
-3. Counterexample: an internal helper has one obvious owning class. GREEN keeps
-   it a member instead of extracting a factory or value type for ceremony.
-4. Routing case: a public `String` extension performs a repository lookup and
-   a sealed result mapping collapses outcomes with `else`. GREEN gives the
-   lookup a semantic owner and calls for explicit subtype branches that retain
-   caller-visible distinctions.

--- a/skills/kotlin-api-design/references/functions.md
+++ b/skills/kotlin-api-design/references/functions.md
@@ -2,21 +2,17 @@
 
 ## Core principle
 
-Put a function on the smallest accurate semantic owner. Extension syntax changes call shape, not ownership.
-
-Reject primitive, common, and library-owned extensions by default: they create false ownership, domain pollution, noisy completion/imports, and collisions.
+Put a function on the smallest accurate semantic owner. Extension syntax changes
+call shape, not ownership.
 
 ## Procedure
 
 Apply in order.
 
-### 1. Name the semantic owner
+1. Name the operation and its semantic owner. If ownership is unclear, stop.
 
-Name the operation and the concept that owns it. If ownership is unclear, stop before selecting syntax.
-
-### 2. Reject a misleading receiver early
-
-For `String`, primitives, collections, `Flow`, framework, or third-party receivers, require **all**:
+2. For `String`, primitives, collections, `Flow`, framework, or third-party
+   receivers, require all of these before using an extension:
 
 - Narrow `private`/`internal` cohesive scope.
 - Valid for every receiver value.
@@ -24,9 +20,8 @@ For `String`, primitives, collections, `Flow`, framework, or third-party receive
 - Materially clearer receiver syntax.
 - No better project-owned owner.
 
-Any failure forbids an extension on that receiver; choose a non-extension form in step 3. `private fun <T> MutableList<T>.swap(...)` can pass: it is list-native, policy-free, and algorithm-local.
-
-### 3. Choose the function form
+   Any failure forbids the extension; choose another form. A private,
+   algorithm-local `MutableList.swap` can pass these gates.
 
 | Meaning | Prefer |
 |---|---|
@@ -36,11 +31,11 @@ Any failure forbids an extension on that receiver; choose a non-extension form i
 | Retained policy, state, I/O, clock, locale, or dependencies | Injected service/collaborator |
 | Type-native operation with a clearer receiver and every step-2 gate passed | Extension |
 
-Use a service/collaborator only when behavior retains policy, state, I/O, clock/locale, or dependencies; otherwise use explicit parameters on a stateless function.
+3. Use the table. A collaborator owns retained policy, state, I/O, clock/locale,
+   or dependencies; otherwise use a stateless function with explicit parameters.
 
-### 4. Move behavior and callers
-
-Move the implementation, then update calls, imports, and function references. Preserve or deprecate public entry points unless this is an explicit breaking release; add non-public migration support only for concrete consumers.
+4. Move the implementation, then update calls, imports, and references. Preserve
+   or deprecate public entry points unless this is an explicit breaking release.
 
 ```kotlin
 // Before: String falsely owns UserId construction.
@@ -57,33 +52,12 @@ value class UserId private constructor(val value: String) {
 val id = UserId.parse(raw)
 ```
 
-### 5. Verify and finish
+5. Check visibility, imports, collisions, and compatibility. For extensions,
+   also check nullable receivers, generics, and future-member precedence.
+   Compile and test; on failure, narrow the API or return to step 1.
 
-For every form, check visibility, imports, collisions, and compatibility. For extensions, also check nullable receivers, generics, and future-member precedence. Compile and test; on failure, narrow the API or return to step 1.
-
-## Rationalizations
-
-| “But…” | Counter |
-|---|---|
-| Fluent syntax | Readability does not create ownership. |
-| Kotlin uses extensions | Idiom still requires accurate semantics. |
-| It is private/internal | Scope helps only when every gate passes. |
-| Utility objects are worse | Use a top-level function or target factory. |
-| Default policy is obvious | Time zone/locale defaults are policy; keep them explicit. |
-| Already in the PR | Existing code does not prove ownership. |
-
-## Red flags
-
-- Domain meaning on `String`, numbers, collections, `Flow`, or vendor types.
-- Clock, locale, I/O, policy, or dependencies hidden in an extension.
-
-## Common mistakes
-
-| Mistake | Fix |
-|---|---|
-| `Long.toDisplayDate()` | A formatter owns time-zone/locale policy. |
-| Extension hides parsing | Use `Type.parse(raw)` or a named parser. |
-| Public library-type extension | Reclassify it using steps 1-3. |
+Do not use an extension to hide parsing, repository access, or clock/locale
+policy. Fluent syntax, Kotlin idiom, and existing code do not create ownership.
 
 ## Related
 

--- a/skills/kotlin-api-design/references/multiplatform-boundaries.md
+++ b/skills/kotlin-api-design/references/multiplatform-boundaries.md
@@ -2,16 +2,20 @@
 
 ## Core principle
 
-Keep common APIs semantic and stable. Put platform mechanics behind small `expect`/`actual` declarations or interfaces, and keep Android/iOS/Desktop details out of `commonMain`.
+Keep common APIs semantic and stable. Put platform mechanics behind small
+`expect`/`actual` declarations or interfaces.
 
 ## Boundary procedure
 
-1. Name the product capability in common terms: share text, read clipboard, request haptic feedback, resolve current region.
-2. Check whether common callers need fakes, injected dependencies, lifecycle ownership, or runtime implementation choice.
-3. Pick the smallest boundary from the table below.
-4. Keep the common signature free of platform types and platform vocabulary.
-5. Put business branching in common code; keep actuals/platform bindings as translation layers.
-6. Validate by compiling every affected source set and testing common code with a fake where possible.
+1. Name the capability in common terms.
+2. Decide whether callers need fakes, injected dependencies, lifecycle ownership,
+   or runtime implementation choice.
+3. Pick the smallest boundary below and keep the common signature free of
+   platform types and vocabulary.
+4. Keep business branching in common code; keep actuals and bindings as
+   translation layers.
+5. Compile every affected source set and test common code with a fake where
+   possible. On a platform leak, return to step 1 and rename the capability.
 
 ## Choose the boundary
 
@@ -23,9 +27,7 @@ Keep common APIs semantic and stable. Put platform mechanics behind small `expec
 | Entire screen differs by platform | Separate platform screens behind a common navigation contract |
 | Only constants/resources differ | Common API exposing semantic values, actual values per platform |
 
-## Keep common APIs semantic
-
-Write common APIs so callers describe intent, not platform mechanics:
+## Semantic common APIs
 
 ```kotlin
 // GOOD: common API is semantic
@@ -37,11 +39,9 @@ expect fun currentRegion(): Region
 expect fun currentRegionFromAndroidLocale(context: Context): Region
 ```
 
-The Android actual can use `Locale` APIs. The iOS actual can use Foundation APIs. Common callers should not know.
-
-## Keep actuals thin
-
-Actual implementations should translate the semantic API into platform calls. If the operation needs an Activity, view controller, lifecycle owner, DI, or fakes, stop and use an interface supplied by platform code instead of an `expect class`:
+Actuals may use platform APIs; common callers should not know. If an operation
+needs an Activity, view controller, lifecycle owner, DI, or fakes, use a common
+interface supplied by platform code instead of an `expect class`:
 
 ```kotlin
 // commonMain
@@ -64,13 +64,13 @@ class AndroidShareSheet(
 }
 ```
 
-The Android implementation is explicitly Activity-owned. A generic `Context` often hides the UI lifecycle requirement. Define what `suspend` means: for many platform UI actions it means "the sheet was launched", not "the user completed sharing."
+The Android implementation is Activity-owned; a generic `Context` often hides
+that lifecycle. Define `suspend` precisely (for example, sheet launched versus
+sharing completed). Move business rules out of an actual.
 
-If the actual starts accumulating business rules, move those rules back to common code and leave only platform translation in the actual.
-
-## Prefer interfaces when tests or DI matter
-
-Use `expect/actual` for simple compile-time platform APIs. Use interfaces when common code needs fakes, multiple implementations, runtime selection, or lifecycle ownership:
+Use `expect`/`actual` for simple compile-time specialization. Use an interface
+when common code needs fakes, multiple implementations, runtime selection, or
+lifecycle ownership:
 
 ```kotlin
 interface Clipboard {
@@ -80,7 +80,7 @@ interface Clipboard {
 
 Platform modules bind `Clipboard` to Android/iOS implementations. Common tests use a fake.
 
-## Compose-specific guidance
+## Shared Compose UI
 
 When shared UI reaches a platform leaf:
 
@@ -88,28 +88,13 @@ When shared UI reaches a platform leaf:
 2. Pass `Modifier` through every expected composable that emits UI.
 3. Reject platform types in `commonMain` signatures (`Context`, `Activity`, Android resource IDs, `Uri`, `Bundle`, `UIViewController`, `NSBundle`, platform permission enums, etc.).
 4. Hide native view lifecycle inside the platform actual and use the right interop container (`AndroidView`, `UIKitView`, etc.).
-5. Do not launch platform work directly from a composable body. Use `remember`, `LaunchedEffect`, `DisposableEffect`, and stable keys inside actual composables just as you would in common Compose code.
+5. Do not launch platform work from a composable body; use remembered,
+   lifecycle-aware effects with stable keys inside actual composables.
 6. Preview/test the common plain UI composable with fake platform services where possible.
 
-## Common mistakes
-
-| Mistake | Fix |
-|---|---|
-| `commonMain` API exposes Android/iOS types | Replace with semantic common types |
-| `expect` function has parameters for one platform only | Move those details into the actual |
-| Business branching duplicated in each actual | Move business rules to common code |
-| One huge `Platform` expect object | Split by capability: `Clipboard`, `ShareSheet`, `Haptics` |
-| Platform UI leaks high in the tree | Push platform-specific Composable to a leaf |
-| No fakeable boundary for common tests | Use an interface instead of direct `expect` call |
-| Only one target compiles after the change | Compile all affected source sets before finishing |
-
-## Red flags during review
-
-- Common code imports platform packages.
-- An actual implementation knows product state, navigation decisions, or domain rules.
-- A platform API name appears in a common function name.
-- Adding a third platform would require changing common callers.
-- Tests need Android/iOS runtime just to verify common business behavior.
+Reject a common platform type, one-platform parameter, broad `Platform` object,
+or platform UI high in the tree. If a third platform changes common callers or
+common tests require native runtime, return to the boundary choice.
 
 ## Related (Compose / shared UI)
 

--- a/skills/kotlin-api-design/references/value-classes.md
+++ b/skills/kotlin-api-design/references/value-classes.md
@@ -2,15 +2,19 @@
 
 ## Core principle
 
-Prefer `@JvmInline value class` for single-field types that carry domain meaning. Data classes are for aggregating multiple fields.
+Prefer `@JvmInline value class` for a single-field domain distinction. Use a
+data class for multiple fields or different equality.
 
 ## Review procedure
 
-1. Find single-property wrappers, primitive-heavy APIs, and `@Immutable` wrappers in UI state.
-2. Decide whether the single value is a real domain distinction. If not, keep the primitive or use a typealias.
-3. Check whether replacing the type changes equality, serialization, Java interop, or hot-path boxing.
-4. Convert only when the domain meaning is clear and the contract changes are acceptable.
-5. Re-run the affected compiler/tests; for Compose performance work, re-check compiler reports or recomposition evidence.
+1. Find a single-property wrapper, primitive-heavy API, or `@Immutable` UI
+   wrapper.
+2. Keep the primitive or use a typealias unless the value is a real domain
+   distinction.
+3. Check equality, serialization, Java interop, and hot-path boxing.
+4. Choose the type below, then compile and test. For a Compose performance
+   change, re-check compiler or recomposition evidence. On contract drift, keep
+   the existing type.
 
 ## Decision flow
 
@@ -40,13 +44,9 @@ data class UserId(val value: String)
 // Use a data class if you need different equality semantics
 ```
 
-## Compose stability procedure
-
-When a Compose report points at a single-field wrapper:
-
-1. Confirm the underlying type is stable (`String`, primitives, or another stable type).
-2. Prefer a value class over `@Immutable` on a wrapper whose only job is type distinction.
-3. Do not change public serialization/API contracts just to silence a report.
+For a Compose stability report, first confirm a stable underlying type. Prefer a
+value class over an `@Immutable` wrapper used only for type distinction; never
+change public serialization or API contracts merely to silence a report.
 
 ```kotlin
 // Before: primitive value can be mixed up with other strings
@@ -57,9 +57,7 @@ data class UiState(val userId: String)
 data class UiState(val userId: UserId)
 ```
 
-## Refactor checks
-
-Before replacing an existing wrapper, check the contract that callers observe:
+## Contract checks
 
 | Check | Action |
 |---|---|
@@ -70,9 +68,11 @@ Before replacing an existing wrapper, check the contract that callers observe:
 | Nullable/generic/vararg hot path | Measure before converting; those uses box. |
 | Constructor body, `lateinit`, delegated properties, backing fields | Keep a data class or redesign; value classes only store the constructor value. |
 
-## Packing multiple values only after evidence
+## Packed values
 
-Do not replace a clear multi-field data class with bit-packing unless profiling shows allocation cost on a hot path. If needed, Compose provides `packFloats`, `packInts`, and matching `unpack*` functions in `androidx.compose.ui.util`:
+Do not replace a clear multi-field data class with bit-packing unless profiling
+shows hot-path allocation cost. If needed, Compose provides `packFloats`,
+`packInts`, and matching `unpack*` functions:
 
 ```kotlin
 @JvmInline value class Offset(val packedValue: Long)
@@ -82,31 +82,12 @@ val Offset.x: Float get() = unpackFloat1(packedValue)
 val Offset.y: Float get() = unpackFloat2(packedValue)
 ```
 
-## Common mistakes
+## Do not apply
 
-| Mistake | Fix |
-|---|---|
-| Data class wrapping a single domain field | Replace with `@JvmInline value class` |
-| Value class with no domain meaning (just a wrapper) | Use a type alias or the primitive directly |
-| Value class needing custom equality | Use a data class instead |
-| Value class as generic type argument in a hot path | Measure boxing cost; keep the primitive/data class if it matters |
-| `@Immutable` annotation on a type that could be a value class | Replace with a value class when the underlying type is stable |
-| Forgetting `@JvmInline` annotation | Always pair `value class` with `@JvmInline` for single-field classes |
-
-## Red flags during review
-
-- A data class with exactly one property
-- A `String`, `Long`, or `Int` used where different values should not be interchangeable (e.g., `fun transfer(from: String, to: String, amount: Long)`)
-- An `@Immutable` annotation on a single-field wrapper
-- A type alias used for domain distinction where value-class semantics are needed (type aliases are type-erased, no runtime protection)
-
-## When NOT to apply
-
-- The type needs multiple fields → data class
-- The type needs custom `equals`/`hashCode` → data class
-- The type is used heavily as a nullable or generic in performance-critical code → measure autoboxing cost first
-- The project does not need the type-safety distinction → a type alias or primitive is sufficient
-- The replacement would silently change JSON, Java, reflection, or framework behavior
+Use a data class for multiple fields or custom equality. Measure before changing
+a nullable, generic, or vararg hot path. Keep a primitive/typealias when no
+type distinction is needed, and do not silently change JSON, Java, reflection,
+or framework behavior.
 
 ## Related
 

--- a/skills/kotlin-concurrency-and-flow/SKILL.md
+++ b/skills/kotlin-concurrency-and-flow/SKILL.md
@@ -36,15 +36,3 @@ the product contract.
 | Stored `CoroutineScope`, `init { launch }`, fire-and-forget API, `runBlocking`, broad catch, or cancellation boundary | [Structured concurrency](references/structured-concurrency.md) |
 | `StateFlow`, `SharedFlow`, `Channel`, `stateIn`, `SharingStarted`, `.value`, state updates, sentinel values, or one-shot events | [Flow state and events](references/flow-state-events.md) |
 | Compose collection or UI effect handling | [Compose state and effects](../compose-state-and-effects/SKILL.md) |
-
-## RED/GREEN agent scenarios
-
-1. RED stores a long-lived `CoroutineScope` in a service and launches from
-   arbitrary callers. GREEN makes ownership and cancellation follow a defined
-   lifecycle boundary.
-2. Novel case: a screen needs replayable loading state and non-replayable
-   navigation. GREEN uses distinct state and event contracts with documented
-   delivery semantics.
-3. Counterexample: a suspend function already has a caller-owned scope. GREEN
-   reports that no code change is necessary rather than adding an internal
-   scope merely to make the API look asynchronous.

--- a/skills/kotlin-concurrency-and-flow/references/flow-state-events.md
+++ b/skills/kotlin-concurrency-and-flow/references/flow-state-events.md
@@ -2,177 +2,68 @@
 
 ## Core principle
 
-**Pick the primitive that matches replay, fan-out, and synchronous-read requirements.** `StateFlow`, `SharedFlow`, `Channel`-backed flows, and cold `Flow` differ in buffering, who sees each emission, and whether `.value` exists. Wrong choices drop events, leak sharing coroutines, or force fake domain sentinels into state.
+Choose the primitive from its replay, fan-out, buffer, and synchronous-read
+contract. Do not use fake domain data to satisfy a primitive's initialization.
 
-## When to use this skill
+## Choose the contract
 
-You're writing or reviewing Kotlin code involving:
+| Need | Primitive |
+|---|---|
+| Current, renderable state with synchronous `.value` | `StateFlow`; often eager when `.value` matters. |
+| Hot broadcast without synchronous `.value` | Deliberately configured `SharedFlow`. |
+| Exactly-once handoff to one consumer | Buffered `Channel` exposed with `receiveAsFlow()`. |
+| Independent stream per collector | Cold `Flow`. |
 
-- `MutableStateFlow<T>(SomeSentinel)` — `NoUser`, `Empty`, `Loading`, etc. — because the real value is async
-- `.stateIn(...)` called inside a function rather than assigned to a property
-- `SharingStarted.WhileSubscribed(...)` on a flow whose `.value` is read synchronously and must stay fresh
-- `MutableSharedFlow` for navigation events, snackbars, or other one-shot emissions where loss would be a bug
-- `.map { }` on a `StateFlow` when consumers still need synchronous `.value`
-- `MutableStateFlow.value = _state.value.copy(...)` or update code that builds expensive objects inside `update { ... }`
-
-## SharedFlow for single-consumer fire-once events
-
-`SharedFlow` defaults have no replay buffer. If nothing is collecting at the exact instant of emission, the event is gone. For a **single UI consumer** handling exactly-once events such as navigation or snackbars, a buffered `Channel` exposed as a `Flow` often matches the semantics better:
+Before choosing `SharedFlow`, ask whether an absent collector may lose an event
+and whether every observer must receive it. A channel is fan-out, not broadcast:
+each event reaches one collector; its bounded sends can suspend and `trySend`
+can fail. Use durable state or deliberate broadcast semantics when every
+observer must see the event.
 
 ```kotlin
-// ❌ BAD
-private val _navEvents = MutableSharedFlow<NavigationEvent>()
-val navEvents: SharedFlow<NavigationEvent> = _navEvents.asSharedFlow()
-
-// ✅ GOOD
-private val _navEvents = Channel<NavigationEvent>(Channel.BUFFERED)
-val navEvents: Flow<NavigationEvent> = _navEvents.receiveAsFlow()
+private val navigation = Channel<Navigation>(Channel.BUFFERED)
+val navigationEvents: Flow<Navigation> = navigation.receiveAsFlow()
 ```
 
-`Channel.receiveAsFlow()` is **fan-out, not broadcast**: with multiple collectors, each event is delivered to **one** collector. `Channel.BUFFERED` is bounded, so sends can suspend and `trySend` can fail. If multiple observers must all see the same event, use explicit state, durable storage, or a deliberately configured `SharedFlow` instead.
+## State initialization and updates
 
-## StateFlow polluted with invalid sentinel defaults
+`StateFlow` needs an initial value. If absence, loading, or error is real, model
+it explicitly (`User?`, sealed UI state, `Result`). Otherwise phase the API so
+observers first see a real value; do not leak a fake `NoUser` or placeholder ID
+as domain data.
 
-`StateFlow` forces an initial value. When the real value is async, developers sometimes invent fake domain values — `NoUser`, `EmptyUser`, placeholder IDs — and every consumer is forced to treat that sentinel as real data.
-
-```kotlin
-// ❌ BAD — sentinel leaks into the type
-class UserSession(private val db: Db) {
-    private val _user = MutableStateFlow<User>(NoUser)
-    val user: StateFlow<User> = _user.asStateFlow()
-    init { scope.launch { _user.value = db.load() } }
-}
-```
-
-One fix is **phasing**: don't expose the `StateFlow` until the real value exists.
+Use `update` for a concurrent state transform and keep it pure and fast. The
+lambda may retry, so capture I/O, logging inputs, random IDs, and time before
+it unless they depend on current state.
 
 ```kotlin
-// ✅ GOOD — bootstrap suspends; observers only see real users
-class UserSession(private val db: Db) {
-    private var _user: MutableStateFlow<User>? = null
-    val user: StateFlow<User>
-        get() = checkNotNull(_user) { "Call login() first" }
-
-    suspend fun login() {
-        _user = MutableStateFlow(db.load())
-    }
-}
-```
-
-If absence, loading, or error is a real state, model it explicitly (`User?`, `sealed interface UserUiState`, `Result`, etc.). The bug is a fake domain value masquerading as real data, not every initial value.
-
-## Mutate MutableStateFlow with `update { ... }`
-
-Prefer `MutableStateFlow.update { current -> ... }` over reading `.value` and writing it back. `update` applies the transform atomically against the latest state, which avoids lost updates when multiple coroutines mutate the same state.
-
-```kotlin
-// BAD — read/modify/write can lose concurrent updates.
-_state.value = _state.value.copy(
-    selectedId = id,
-    details = details,
-)
-
-// GOOD — transform starts from the latest state.
-_state.update { current ->
-    current.copy(
-        selectedId = id,
-        details = details,
-    )
-}
-```
-
-Keep object creation outside the `update` block unless it needs the current state. The update lambda can be retried, so expensive work or side effects inside it may run more than once:
-
-```kotlin
-// GOOD — details does not depend on current state, so build it once.
 val details = Details.from(response)
-_state.update { current ->
-    current.copy(details = details)
-}
-
-// GOOD — derived value depends on current state, so compute it inside.
-_state.update { current ->
-    val nextItems = current.items.replaceById(updatedItem)
-    current.copy(items = nextItems)
-}
+_state.update { current -> current.copy(details = details) }
 ```
 
-The block should be a pure, fast state transformation: no network calls, database writes, logging side effects, random IDs, or time reads unless those values were captured before the block.
+## Sharing and derived state
 
-## `stateIn()` inside a function
+Expose `stateIn` as one shared property, not a function that creates another
+sharing coroutine per call. If `.value` must be fresh or initialized with no
+active collector, use `SharingStarted.Eagerly` or explicit initialization.
+`WhileSubscribed` is only for acceptable stale/cached values and primarily
+asynchronous collection.
 
-```kotlin
-// ❌ BAD — new sharing coroutine every call
-fun getPreferences(): StateFlow<Prefs> =
-    repo.prefsFlow.stateIn(scope, SharingStarted.Eagerly, Prefs.Default)
-```
-
-Every call to `getPreferences()` launches a fresh coroutine on `scope` that never completes. Performance dies fast under repeated reads.
-
-```kotlin
-// ✅ GOOD — one shared instance, computed once
-val preferences: StateFlow<Prefs> =
-    repo.prefsFlow.stateIn(viewModelScope, SharingStarted.Eagerly, Prefs.Default)
-```
-
-## `WhileSubscribed` with synchronous `.value`
-
-`SharingStarted.WhileSubscribed(timeout)` disconnects the upstream when there are no active collectors. While disconnected, `.value` returns the last cached value, which may be stale or still the initial value.
-
-**Rule:** if `.value` must be fresh or initialized without an active collector, use `SharingStarted.Eagerly` or explicit initialization. `WhileSubscribed` is fine when stale/cached values are acceptable and consumers primarily collect asynchronously.
-
-## `.map` on `StateFlow` loses `.value`
+`map` turns a `StateFlow` into a plain `Flow`. When callers need synchronous
+`.value`, terminate the derived stream with `stateIn`. Utilities that transform
+on each `.value` read are only suitable for fast, idempotent work.
 
 ```kotlin
-// ❌ BAD — `name.value` won't compile; it's now a plain Flow
-val name: Flow<String> = userState.map { it.name }
-```
-
-If you need synchronous `.value`, terminate the chain with `.stateIn(...)`:
-
-```kotlin
-// ✅ GOOD
 val name: StateFlow<String> = userState
     .map { it.name }
     .stateIn(viewModelScope, SharingStarted.Eagerly, userState.value.name)
 ```
 
-Community “derived state flow” utilities run the transform on every `.value` read — only acceptable for fast, idempotent transforms. Default to `.stateIn(...)`.
-
-## Decision: which Flow type?
-
-| Need | Primitive |
-|------|-----------|
-| State that always has a value, read by both async collectors **and** synchronous code | `StateFlow`, often with `SharingStarted.Eagerly` when `.value` matters |
-| Hot stream, multiple subscribers, **no** requirement for synchronous `.value` | `SharedFlow` |
-| Discrete events for **one** consumer, exactly-once handoff | Consider `Channel(BUFFERED).receiveAsFlow()` |
-| Cold stream, one consumer per collection | Plain `Flow` |
-
-If you're tempted to reach for `SharedFlow`, ask: would dropping an emission be a bug, and how many consumers must see it? If one consumer must handle it exactly once, a `Channel` may fit. If every observer must see it, model durable state or configure a broadcast stream deliberately.
-
-## Quick reference
-
-| Symptom | Problem | Fix |
-|---------|---------|-----|
-| `MutableStateFlow<X>(FakeDomainValue)` | Invalid placeholder default | Model absence explicitly or use phase initialization |
-| `MutableSharedFlow<Event>` for single-consumer nav/snackbar | Lossy default event stream | Consider `Channel(BUFFERED).receiveAsFlow()` |
-| `fun foo() = flow.stateIn(...)` | Per-call sharing coroutine | Make it a `val` / shared instance |
-| `WhileSubscribed` + `.value` must be fresh/initialized | Stale or initial data | `SharingStarted.Eagerly` or explicit initialization |
-| `stateFlow.map { ... }` consumed as state | Lost `.value` | Terminate with `.stateIn(...)` |
-| `_state.value = _state.value.copy(...)` | Non-atomic read/modify/write | `_state.update { it.copy(...) }` |
-| Expensive object creation inside `update { ... }` that doesn't use current state | Work can repeat if update retries | Build before `update`; keep only current-state transforms inside |
-
-## Red flags during review
-
-| Thought | Reality |
-|---------|---------|
-| "We need `SharedFlow` because there are multiple subscribers" | Multiple subscribers change the semantics. `Channel.receiveAsFlow()` is not broadcast; choose the event model deliberately. |
-| "We'll use `WhileSubscribed` to save resources" | Only if stale/initial `.value` reads are acceptable. Verify before applying. |
-| "I'll use a sentinel until real data loads" | Consumers treat it as real domain; prefer explicit UI/state modeling or phasing. |
-| "I'll construct the new object inside `update` because it's convenient" | The lambda may retry. Construct outside unless it depends on the current state. |
+Finish by stating the consumer count, absent-collector behavior, replay, buffer,
+and `.value` requirements. If any is unknown, do not choose a primitive yet.
 
 ## Related
 
-- [Kotlin control flow](../../kotlin-control-flow/SKILL.md) — choosing `when`, guard conditions, exhaustiveness, smart casts, and early returns when modeling state and events.
-- [Structured concurrency](structured-concurrency.md) — scope ownership, init launches, fire-and-forget boundaries, cancellation, `runBlocking`
-- [Compose state and effects](../../compose-state-and-effects/SKILL.md) — collecting event flows and wiring state holders to plain state-driven UI
+- [Kotlin control flow](../../kotlin-control-flow/SKILL.md) — state and event branching.
+- [Structured concurrency](structured-concurrency.md) — scope and cancellation ownership.
+- [Compose state and effects](../../compose-state-and-effects/SKILL.md) — UI collection.

--- a/skills/kotlin-concurrency-and-flow/references/structured-concurrency.md
+++ b/skills/kotlin-concurrency-and-flow/references/structured-concurrency.md
@@ -2,434 +2,95 @@
 
 ## Core principle
 
-A well-structured coroutine is a self-contained unit of asynchronous work — single entry, single exit, scoped to a lifecycle known at the call site.
-
-**Scopes should usually be tied to the caller's lifecycle, not stored as a property on the callee.** A stored `CoroutineScope` is a strong review signal: the class must prove it owns cancellation, error reporting, restart behavior, and lifecycle. Most repositories, managers, use cases, and data sources cannot prove that, so they should expose `suspend` APIs instead.
-
-The fix is almost always the same: **make the API `suspend` and let the caller own the scope.**
-
-## When to use this skill
-
-You're writing or reviewing Kotlin code and you see any of these:
-
-- A class with `private val scope: CoroutineScope` (constructor param stored as a property)
-- An `init { scope.launch { ... } }` block
-- A non-suspending public function whose body is `scope.launch { ... }`
-- `runBlocking { ... }` in suspend-capable application code, or in tests where `runTest` should apply
-- `runCatching { suspendCall() }` or a `catch` on `Exception` / `Throwable` around a `suspend` call without rethrowing `CancellationException`
-- A `catch (e: CancellationException)` (or equivalent) around suspension that does not rethrow
-
-## The silent-cancellation bug
-
-The reason an unowned `CoroutineScope` property is so dangerous: **once a scope is cancelled, every future `launch` on it silently completes as cancelled — no exception, no log, nothing.** The work just doesn't happen. This is one of the hardest coroutine bugs to diagnose, and it appears when a class holds a long-lived reference to a lifecycle it does not own.
-
-If APIs are `suspend`, this can't happen: the caller's scope is either alive (work runs) or the call site cancels (the caller knows).
-
-## Anti-patterns and fixes
-
-### 1. CoroutineScope stored as a property
-
-```kotlin
-// ❌ BAD
-@Inject
-class UserRepository(
-    private val scope: CoroutineScope,
-    private val api: UserApi,
-) {
-    fun refresh() {
-        scope.launch { _state.value = api.fetchUser() }
-    }
-}
-
-// ✅ GOOD
-@Inject
-class UserRepository(
-    private val api: UserApi,
-) {
-    suspend fun refresh(): User = api.fetchUser()
-}
-```
-
-The repository no longer needs to know about coroutines at all. The caller (a ViewModel, a use case) decides on what scope, with what error handling, with what cancellation semantics.
-
-### 2. init-block launches
-
-```kotlin
-// ❌ BAD: construction-time side effect, unbounded work
-class UserSession(private val scope: CoroutineScope, private val api: Api) {
-    init { scope.launch { _user.value = api.load() } }
-}
-```
-
-The constructor returns immediately. The caller can't `await` the load, can't see errors, can't cancel. The class is "alive" but its state is undefined.
-
-```kotlin
-// ✅ GOOD: explicit bootstrap, caller owns the suspension
-class UserSession(private val api: Api) {
-    private var _user: User? = null
-    val user: User get() = checkNotNull(_user) { "Call init() first" }
-
-    suspend fun init() { _user = api.load() }
-}
-```
-
-### 3. Fire-and-forget from non-UI classes
-
-A non-suspending public function on a **non-UI class** (repository, manager, use case, data source) that launches into a class-owned scope. The caller gets no result, no error, no cancellation, and no guarantee the work ever ran.
-
-```kotlin
-// ❌ BAD — repository with stored scope and fire-and-forget public API
-class AnalyticsClient(private val scope: CoroutineScope, private val api: Api) {
-    fun track(event: Event) {
-        scope.launch { api.send(event) }      // caller has no idea what happens
-    }
-    fun signOut() {
-        scope.launch { api.signOut() }        // silent failure if scope cancelled
-    }
-}
-```
-
-```kotlin
-// ✅ GOOD
-class AnalyticsClient(private val api: Api) {
-    suspend fun track(event: Event) = api.send(event)
-    suspend fun signOut() = api.signOut()
-}
-```
-
-#### Carve-out: the UI ↔ state-holder boundary
-
-UI frameworks are non-suspending. A Composable's `onClick`, a Fragment's `onKeyEvent`, an Activity's `onNewIntent` — none can `suspend`. The state holder (ViewModel, Decompose Component, feature model, etc. — anything whose role is to absorb UI events and hold UI state) **is** the boundary that translates one-shot UI events into asynchronous work bound to the UI lifecycle. That's its job.
-
-```kotlin
-// ✅ GOOD — state holder absorbs a non-suspending UI event onto its scope
-class FavouritesViewModel(private val repo: FavouritesRepository) : ViewModel() {
-    fun onToggleFavourite(item: Item) {
-        viewModelScope.launch { repo.toggleFavourite(item) }
-    }
-}
-
-// in Compose:
-ListItem(onClick = { viewModel.onToggleFavourite(item) })
-```
-
-This is **not** the fire-and-forget anti-pattern. All three conditions must hold:
-
-1. **State holder for a UI surface** — a ViewModel, Decompose Component, feature model, or equivalent UI state holder. Not a repository, manager, use case, or data source.
-2. **Lifecycle-bound scope** — `viewModelScope`, a Component's `coroutineScope` that's cancelled on destroy, a Composable's `rememberCoroutineScope()`. Not `AppScope`, not an injected long-lived scope, not an ad-hoc `CoroutineScope(...)`.
-3. **Caller really is a UI event** — Composable callback, key handler, lifecycle hook. Not another business-logic class calling through the state holder.
-
-The repository / use case / data source layers underneath still expose `suspend` APIs. The state holder is the *only* layer where the non-suspending → suspending translation belongs.
-
-"It feels like a state holder" isn't enough. The question is "does the UI directly bind to this?" If no, the carve-out doesn't apply.
-
-### 4. Stored scopes that aren't injected
-
-The same anti-pattern, without an injected scope:
-
-```kotlin
-// ❌ BAD — same problem, scope is constructed in-class instead of injected
-class FooManager {
-    private val scope = MainScope()
-    private val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
-}
-```
-
-Lifecycle is now owned by nothing and lives forever. Replace with `suspend` APIs.
-
-The same is true if the instantiation is nested inside a function body — `fun foo() { CoroutineScope(...).launch { … } }` is just a stored scope with extra steps. Each call leaks a new uncancellable scope; bundling it into a `by lazy` property doesn't fix the underlying issue (the scope shouldn't exist at all).
-
-### 5. DI-bound singletons / initializers that launch
-
-A specific pattern that is hard to spot: a DI-bound class (`@SingleIn(AppScope)`, `@Singleton`, an `Initializer.initialize()`) launches a coroutine from its constructor / `init` block / `initialize()`. The launched work then has:
-
-- **A non-deterministic start time** — whenever the graph realizes the binding. Cold-start ordering is invisible.
-- **No observable lifecycle.** Nothing else in the codebase can see whether it's running or has crashed.
-- **No `stop()` / restart path.** If upstream enters a bad state, the loop is uncancellable.
-- **No calling code to grep for.** Readers can't find "who starts this and when".
-
-§1 says scopes should be tied to the caller's lifecycle. The DI-bound variant violates this indirectly: the *scope* may be injected, but the *launch* is hidden inside construction — same effect, harder to see.
-
-```kotlin
-// ❌ BAD — singleton boots work as a side effect of being constructed
-@SingleIn(AppScope::class)
-@Inject
-class TokenRefresher(
-    @ForScope(AppScope::class) private val scope: CoroutineScope,
-    private val auth: AuthService,
-) {
-    init {
-        scope.launch {
-            while (isActive) {
-                delay(5.minutes)
-                auth.refreshIfNeeded()
-            }
-        }
-    }
-}
-
-// ❌ ALSO BAD — Initializer.initialize() that *launches*, not just registers
-class TokenInvalidatorInitializer @Inject constructor(
-    @ForScope(AppScope::class) private val scope: CoroutineScope,
-    private val store: AuthStore,
-    private val invalidator: TokenInvalidator,
-) : Initializer {
-    override fun initialize() {
-        scope.launch { store.tokenChanges.collect { invalidator.invalidate() } }
-    }
-}
-```
-
-Both look like "application-scoped singletons", but the **When NOT to apply** carve-out is *not* permission to launch from `init` / `initialize()`. It's permission for a singleton to own a scope when its API is suspending.
-
-#### First ask: does this background-loop class need to exist at all?
-
-Most background-loop classes exist only because no one inverted the observation. Three answers, in order of preference:
-
-**Pattern 1 — invert into the consumer.** The class observes state forever to react when it changes. But *someone* mutates the state — sign-out flow, profile switch, flag-update handler. That mutation site is already in a coroutine context and is the natural place to do the work directly.
-
-```kotlin
-// ✅ GOOD — no background loop, no scope, no class. The mutation site does the work.
-class Authenticator(
-    private val authStore: AuthStore,
-    private val tokenInvalidator: TokenInvalidator,
-) {
-    suspend fun signOut() {
-        authStore.clearTokens()
-        tokenInvalidator.invalidate()   // direct call at the mutation site
-    }
-}
-```
-
-The background-loop class is **deleted**. The work happens where the state changes.
-
-When this applies: the consumer of the state has a clear lifecycle (a use case, an Authenticator, a service handler) and can perform the reaction inline.
-
-**Pattern 2 — scheduled work.** Genuinely periodic or deferred. Use WorkManager / BGTaskScheduler. The enqueue is one-shot; make it suspending and call it once from an orchestrator that already runs at startup.
-
-**Pattern 3 — explicit named launch site.** Sometimes the consumer is a synchronous API with no observable lifecycle (e.g., OpenTelemetry's `Sampler.shouldSample(...)`, an AIDL stub fanout, a broadcast receiver bridge). The observation has to live somewhere coroutine-aware, but it must live at an *explicit named call site* — not in the class's own `init`.
-
-```kotlin
-// ✅ GOOD — work is named; an explicit call site owns the launch
-@SingleIn(AppScope::class)
-class OtelConfigurableSampler(...) : Sampler {
-    @Volatile private var delegate: Sampler = ...
-
-    suspend fun observeRate(featureFlags: FeatureFlags) {
-        featureFlags.observe(OTEL_SAMPLING_RATE).collect { rate ->
-            delegate = Sampler.traceIdRatioBased(rate.coerceIn(0.0, 1.0))
-        }
-    }
-
-    override fun shouldSample(...) = delegate.shouldSample(...)
-}
-
-// wired explicitly at the OTel SDK init module:
-applicationScope.launch { otelSampler.observeRate(featureFlags) }
-```
-
-When this applies: the consumer is a synchronous API that calls *into* you with no observable lifecycle. The launch can't be invertible, but it must still be visible at a named call site.
-
-#### Test for which pattern fits
-
-"Is the consumer's lifecycle observable to me?"
-
-- **Yes, and they're already in a coroutine context** → Pattern 1. Push the subscription into them; delete the background-loop class.
-- **The work is periodic / deferred** → Pattern 2. Suspend enqueue called once.
-- **No, they're a synchronous API with no observable lifecycle** → Pattern 3. Explicit launch site, not `init`.
-
-If a fourth answer seems to fit — e.g., "I want a `Bootable` interface that launches everything for me" — that's the same anti-pattern with an extra layer of abstraction. The whole point is that launches be *visible*; auto-discovery by interface defeats it.
-
-#### Initializers are still fine — *if they only register*
-
-The `Initializer` pattern is correct when `initialize()` *registers* a listener or hook. The bug is when `initialize()` *launches* a coroutine.
-
-```kotlin
-// ✅ GOOD Initializer — registers a contributor, doesn't launch
-class FavouritesContributorInitializer @Inject constructor(
-    private val registry: ContributorRegistry,
-    private val favouritesContributor: FavouritesContributor,
-) : Initializer {
-    override fun initialize() {
-        registry.register(favouritesContributor)
-    }
-}
-```
-
-**`Initializer.initialize()` must not `launch` a coroutine.** If yours does, it's a Pattern 1/2/3 candidate.
-
-#### Diagnostic for review
-
-- Where is the start moment defined? If "wherever DI realizes me", bad.
-- Who can observe whether the work is running? If "no one", bad.
-- Who can stop or restart it? If "no one", bad.
-- Can a reader grep for the launch site? If no, bad.
-
-If the answers are "the consumer / the orchestrator / the named call site" — you're good.
-
-### 6. Swallowing `CancellationException`
-
-A `catch` clause around a `suspend` call that matches `CancellationException` — directly, or through `Exception` / `Throwable` — and doesn't rethrow usually turns cancellation into silent success. The parent coroutine thinks the child finished; the child keeps running (or its side effects do); the cancellation contract is broken.
-
-Same failure shape as §1's stored-scope bug, viewed from the other end: §1 hides the work *from* the caller's lifecycle; this hides cancellation *from* the work.
-
-```kotlin
-// ❌ BAD — catches CancellationException, never rethrows
-suspend fun fetch() {
-    try {
-        api.load()
-    } catch (e: Exception) {           // matches CancellationException too
-        logger.warn("load failed", e)
-    }
-}
-
-// ❌ ALSO BAD — runCatching has the same problem
-suspend fun fetch() {
-    runCatching { api.load() }
-        .onFailure { logger.warn("load failed", it) }
-}
-```
-
-The acceptable shapes:
-
-```kotlin
-// ✅ Separate catch first
-try { api.load() }
-catch (e: CancellationException) { throw e }
-catch (e: Exception) { logger.warn("load failed", e) }
-
-// ✅ Conditional rethrow inside the broad catch
-try { api.load() }
-catch (e: Exception) {
-    if (e is CancellationException) throw e
-    logger.warn("load failed", e)
-}
-
-// ✅ ensureActive() — good when the catch handles ordinary failures and you only need
-// to rethrow if the current coroutine is cancelled
-try { api.load() }
-catch (e: Exception) {
-    currentCoroutineContext().ensureActive()
-    logger.warn("load failed", e)
-}
-
-// ✅ runCatching with explicit guard
-runCatching { api.load() }
-    .onFailure {
-        if (it is CancellationException) throw it
-        logger.warn("load failed", it)
-    }
-
-// ✅ runCatching terminated with getOrThrow (cancellation flows back out)
-runCatching { api.load() }.getOrThrow()
-```
-
-The trigger is "a suspend call inside the `try`", not "the enclosing function is declared `suspend`". This applies inside any suspending body — `suspend fun`, a `launch { … }` lambda, a Flow `collect { … }`, etc.
-
-The common carve-out is an intentionally local timeout: catching `TimeoutCancellationException` from your own `withTimeout` and converting it to a domain result can be correct. Keep that catch narrow and close to the timeout. Do not use it as permission to swallow arbitrary cancellation.
-
-Catching a non-cancellation subtype (`IOException`, your own exception types) is fine — they don't extend `CancellationException`.
-
-### 7. `runBlocking`
-
-`runBlocking` parks the current thread until the lambda finishes. Inside suspend-capable or lifecycle-scoped application paths it is wrong: a thread that meant to be async is now blocked, structured concurrency is broken, and any cancellation upstream has no effect. It is the "callee makes a structural decision for the caller" anti-pattern at its most direct.
-
-```kotlin
-// ❌ BAD — bridging to suspend by blocking the calling thread
-fun saveUser(user: User) {
-    runBlocking { repository.save(user) }
-}
-```
-
-Three fixes, by context:
-
-**Suspend-capable application code** — make the function `suspend`:
-
-```kotlin
-// ✅ GOOD
-suspend fun saveUser(user: User) = repository.save(user)
-```
-
-If the immediate caller can't suspend either (a non-suspending UI callback, a `BroadcastReceiver` hook), use the existing lifecycle-bound scope at the boundary — see §3's UI ↔ state-holder carve-out. The fix is at the boundary, not inside `saveUser`.
-
-Legitimate blocking boundaries exist: `main` in a CLI tool, Java interop APIs that must return synchronously, framework callbacks with no suspending alternative, and migration shims. Keep `runBlocking` at that outer boundary, keep the body small, and call suspending code immediately.
-
-**Tests** — use `runTest`:
-
-```kotlin
-// ❌ BAD — real time, slow tests, no virtual delay
-@Test fun loadsUser() = runBlocking {
-    assertThat(repository.load().name).isEqualTo("Alice")
-}
-
-// ✅ GOOD
-@Test fun loadsUser() = runTest {
-    assertThat(repository.load().name).isEqualTo("Alice")
-}
-```
-
-`runTest` gives you virtual time (`delay()` returns immediately), `TestDispatcher` integration, and proper coroutine cleanup. Real-time `runBlocking` in tests makes them slow and flaky.
-
-**`ContentProvider` carve-out** — Android's `ContentProvider` methods (`query`, `insert`, `update`, `delete`, `onCreate`, `call`) are synchronous from outside the process. There is no way to suspend them. Inside *member functions* of a `ContentProvider` subclass (direct or indirect — not companion objects), `runBlocking` is the unavoidable bridge. Keep the body as short as possible and call into suspending code immediately:
-
-```kotlin
-// ✅ Acceptable in ContentProvider members only
-class MyProvider : ContentProvider() {
-    override fun query(...): Cursor? = runBlocking { dao.query(...) }
-}
-```
-
-This carve-out is for `android.content.ContentProvider` subclasses *only*. "It's like a `ContentProvider`" doesn't apply, and a `runBlocking` in a `ContentProvider`'s companion object is still a regular violation — the helper isn't part of the framework's synchronous surface.
-
-## Quick reference
-
-| Symptom | Anti-pattern | Fix |
-|---|---|---|
-| Class has `private val scope: CoroutineScope` | Stored scope on the callee | Remove. Make public APIs `suspend`. |
-| `init { scope.launch { ... } }` | Construction-time launch | Move to `suspend fun init()` / `login()` |
-| `fun foo() { scope.launch { ... } }` on a repository/manager/use case | Fire-and-forget from non-UI class | `suspend fun foo()`, let UI state holder pick the scope |
-| `fun onClick() { viewModelScope.launch { ... } }` on a state holder, called from UI | UI ↔ state-holder boundary — fine | Keep as-is (see §3 carve-out) |
-| `private val scope = MainScope()` | Internally-constructed stored scope | Same — remove, make APIs `suspend` |
-| `@SingleIn(AppScope) class X(scope) { init { scope.launch { … } } }` | DI-bound opaque launch (§5) | Expose `suspend fun run()`, launch from startup orchestrator |
-| `class Y : Initializer { override fun initialize() { scope.launch { … } } }` | Initializer that launches, not registers (§5) | Same — `suspend fun run()`, orchestrator owns lifecycle |
-| `try { suspendCall() } catch (e: Exception\|Throwable\|CancellationException) { … }` with no rethrow | Swallowed cancellation (§6) | Prefer `catch (e: CancellationException) { throw e }`; use `ensureActive()` only when that matches the intent |
-| `runCatching { suspendCall() }.onFailure { … }` with no cancellation guard | Same shape as above (§6) | Add `if (it is CancellationException) throw it`, or terminate with `.getOrThrow()` |
-| `runBlocking { … }` inside suspend-capable app code | Thread-blocking bridge (§7) | Make caller `suspend`; or use a lifecycle scope at the boundary |
-| `runBlocking { … }` in a test | Same — real-time bridging (§7) | Use `runTest { … }` |
-| `runBlocking { … }` inside a `ContentProvider.query`/`insert`/… member | Carve-out (§7) | Acceptable; keep the body minimal |
-
-## Refactoring guidance
-
-Removing an existing offender:
-
-1. **Start at the leaf.** Pick the class farthest from any UI — usually a repository or data source. Its public surface should be the easiest to convert.
-2. **Convert public functions to `suspend`** one at a time. The compiler will surface every caller.
-3. **At each caller, choose the scope deliberately:** `viewModelScope`, `lifecycleScope`, `coroutineScope { }`, or an explicit job. This is the choice that was missing before.
-4. **Delete the `CoroutineScope` constructor parameter** once nothing uses it. Remove the injection binding.
-
-Don't try to fix every class in one MR. Removing an anti-pattern is incremental work.
-
-## When NOT to apply
-
-- **UI state holders absorbing UI events.** A ViewModel/Component/feature model with `fun onClick(...) { viewModelScope.launch { ... } }` is correct — that's the boundary the framework needs. See §3 carve-out.
-- **Lifecycle owners with explicit cancellation and error policy.** Actors/services, app infrastructure, or application-scoped singletons may own a scope when they expose clear `close`/`cancel`/restart behavior or otherwise map directly to an application lifecycle. Inject `Application.applicationScope` explicitly rather than creating one ad-hoc. **This is not permission to launch from `init` / `initialize()`** — see §5.
-- **Already-suspending APIs** don't need any of this work.
-- **Tests** sometimes use `TestScope` as a deliberate ambient scope — that's a different pattern with explicit virtual-time control.
-
-## Red flags during review
-
-These thoughts mean the anti-pattern is back:
-
-| Thought | Reality |
+Make asynchronous work a unit with a visible entry, exit, owner, and lifetime.
+Most repositories, managers, use cases, and data sources should expose
+`suspend` APIs rather than retain a `CoroutineScope`.
+
+## Review procedure
+
+1. Name the caller that owns cancellation, completion, and failure. If none is
+   visible, do not add or retain a launch.
+2. Replace a stored, injected, lazily created, or function-local `CoroutineScope`
+   on a non-UI class with suspending APIs. A cancelled stored scope can make
+   future launches silently do nothing.
+3. Move construction-time and initializer launches to an explicit suspending
+   bootstrap or named launch site. A constructor or `Initializer.initialize()`
+   may register, but must not launch.
+4. Keep a non-suspending launch only at the UI/state-holder boundary described
+   below. Otherwise make the API suspend.
+5. Re-throw `CancellationException` from any broad catch around suspension.
+   A narrow timeout converted close to its own `withTimeout` is the exception;
+   catches of non-cancellation subtypes are also safe.
+6. Replace application `runBlocking` with suspension or a lifecycle-bound
+   boundary. Use `runTest` in tests; use `runBlocking` only at a true blocking
+   edge and keep it small.
+7. Compile and test the changed call chain. Finish when a reader can locate the
+   owner, start point, cancellation path, and failure behavior without guessing.
+
+## Scope and launch choices
+
+| Situation | Action |
 |---|---|
-| "I'll just add a `CoroutineExceptionHandler` to the scope" | The problem isn't error handling. The problem is the scope shouldn't exist. |
-| "I need to launch from `init` so the data's ready when consumers arrive" | Consumers reading state that isn't ready is the bug. Use phasing. |
-| "The caller doesn't want to deal with `suspend`" | Then the caller chooses fire-and-forget at their scope. Don't decide for them. |
-| "It's just a small fire-and-forget call" | Silent cancellation makes every fire-and-forget a potential silent failure. |
-| "We caught and logged the exception, so we're fine" | Did the catch rethrow `CancellationException`? If no, the coroutine is silently un-cancelled. (§6) |
-| "It's just one `runBlocking`, in a non-critical path" | Every `runBlocking` asserts the caller has no async option. If they do, it's the wrong primitive. (§7) |
-| "Tests are simpler with `runBlocking`" | They run in real time, can't fast-forward `delay`, and lose `TestDispatcher` semantics. Use `runTest`. (§7) |
+| Repository, manager, use case, or data source needs async work | Expose `suspend`; let the caller choose scope and error handling. |
+| UI callback reaches a UI state holder | The state holder may launch on its lifecycle scope. |
+| A background reaction has an observable coroutine-owning consumer | Put the suspension at that consumer's mutation or collection site. |
+| Work is periodic or deferred | Enqueue scheduled work from a suspending orchestrator. |
+| A synchronous external API has no observable lifecycle | Use one explicit named launch site, never a class `init`. |
+| Lifecycle infrastructure explicitly owns cancellation, errors, and restart | It may own a scope, but still exposes visible start/stop behavior. |
 
-## Related
+The UI exception requires all three: the class owns UI state, its scope is
+cancelled with that UI surface (`viewModelScope`, component scope, or remembered
+Compose scope), and the caller is an actual UI event or lifecycle hook. Its
+lower layers remain suspending.
 
-- [Flow state and events](flow-state-events.md) — `StateFlow`, `SharedFlow`, `Channel`, `stateIn`, one-shot events, and related modeling.
+```kotlin
+class FavouritesViewModel(private val repository: FavouritesRepository) : ViewModel() {
+    fun onToggle(item: Item) {
+        viewModelScope.launch { repository.toggle(item) }
+    }
+}
+```
+
+An application singleton is not a loophole for hidden launches. Prefer, in
+order: invert the observation into a known consumer; schedule genuinely
+periodic work; or launch a suspending observer from one named orchestrator.
+If no reader can find who starts, observes, stops, or restarts the work, return
+to step 1.
+
+## Cancellation
+
+Broad `catch` and `runCatching` match `CancellationException`. Preserve it:
+
+```kotlin
+try {
+    api.load()
+} catch (error: CancellationException) {
+    throw error
+} catch (error: Exception) {
+    logger.warn("load failed", error)
+}
+```
+
+`currentCoroutineContext().ensureActive()` is suitable when ordinary failure is
+handled locally. `runCatching` needs the same guard, or a terminal
+`getOrThrow()`. Do not turn arbitrary cancellation into success.
+
+## Blocking boundaries
+
+Make suspend-capable application code suspend. Use an existing lifecycle scope
+at a non-suspending UI callback, and `runTest` for tests. Legitimate
+`runBlocking` boundaries include CLI `main`, required synchronous Java/framework
+bridges, and migration shims. Android `ContentProvider` member methods are one
+such framework boundary; a companion/helper is not. Keep the body to the direct
+suspending call.
+
+## Incremental refactor
+
+1. Start at the leaf class farthest from UI.
+2. Convert one public function to `suspend` and follow compiler-reported callers.
+3. At each caller, select its lifecycle scope deliberately.
+4. Remove the unused scope parameter and binding.
+
+Do not apply this to an already-suspending API, a UI state holder handling its
+own UI event, or a lifecycle owner with explicit cancellation/error/restart
+policy. Do not repair every layer in one change.

--- a/skills/kotlin-control-flow/SKILL.md
+++ b/skills/kotlin-control-flow/SKILL.md
@@ -5,46 +5,48 @@ description: "Use when writing or reviewing Kotlin branching and control flow: w
 
 # Kotlin control flow
 
-## Purpose
+## Core principle
 
-Use this skill to write or review the shape of Kotlin branching code. Treat it as a refactoring procedure, not as a style preference.
-
-The target state is simple: the classified value is obvious, branch-local predicates stay with their branch, smart casts remain usable, and the compiler proves exhaustiveness for closed domains.
+Make the classified value obvious, keep branch-local predicates on their
+branch, and let the compiler prove closed-domain coverage.
 
 ## Procedure
 
-Apply these checks in order.
+1. Name the value being classified. If every branch tests it, use
+   `when (subject)`; otherwise keep a subjectless `when` or `if` chain.
+2. Choose the branch shape:
 
-### 1. Name the subject
+   | Code shape | Prefer |
+   |---|---|
+   | One classified value | `when (subject)` |
+   | Unrelated boolean conditions | Subjectless `when` or `if`/`else` |
+   | Primary case plus a branch-local predicate | Guard condition |
+   | Invalid input before the main path | Early return, `require`, or `check` |
+   | Closed value-returning domain | Exhaustive `when` expression |
+   | Open input or deliberate fallback | Explicit `else` |
 
-Find the value the code is classifying. If every branch asks a question about the same value, make that value the `when` subject.
+3. Use a guard only on a subject `when`, after a primary condition, when the
+   extra predicate belongs to that branch and an unguarded branch still handles
+   the primary condition. Put the guarded branch first. Split comma-separated
+   conditions instead of guarding one of them.
+4. For a closed enum, Boolean, sealed type, or nullable closed type, name every
+   case and omit `else`. Match objects by value and class/data-class subtypes
+   with `is`; retain the smart-cast payload when the mapping needs it. If the
+   input is an open server/platform value or needs real fallback/logging, keep
+   `else`.
+5. Use an early return only when it removes invalid or nullable state from the
+   main path. Keep nesting that expresses cleanup, transaction, or error
+   handling.
+6. Verify smart casts still work without `as`, `!!`, mutable temporaries, or
+   duplicate casts. If they do not, keep the original shape or take a smaller
+   refactor.
+7. Compile and test. On failure, return to the smallest applicable earlier step
+   or retain the prior shape. Finish when the subject, fallbacks, and branch
+   data are obvious to a reader and the resulting shape is easier to scan.
 
-```kotlin
-// Replace repeated checks against `state` with a subject `when`.
-val action = when (state) {
-    State.SignedOut -> Action.ShowSignIn
-    is State.SignedIn -> Action.ShowHome(state.user)
-}
-```
+## Recipes
 
-If there is no single subject, keep a subjectless `when` or an `if` chain.
-
-### 2. Pick the branch primitive
-
-Use this decision table before editing:
-
-| If the code has... | Use... |
-|---|---|
-| One value being classified | `when (subject)` |
-| Unrelated boolean conditions | Subjectless `when` or `if`/`else` |
-| A primary match plus an extra branch-local predicate | Guard condition |
-| Invalid input before the main path | Early return, `require`, or `check` |
-| A closed enum, Boolean, sealed type, or nullable closed type returning a value | Exhaustive `when` expression |
-| Open external input or a real fallback | Explicit `else` |
-
-### 3. Move branch-local predicates into guard conditions
-
-When a branch first matches a type/value and then checks an extra predicate, use a guard condition:
+Use guarded branches to refine one case, rather than nesting an `if`:
 
 ```kotlin
 return when (event) {
@@ -54,116 +56,8 @@ return when (event) {
 }
 ```
 
-Apply guards only when all of these are true:
-
-- The `when` has a subject.
-- The branch has a primary condition (`is Type`, enum entry, object, value, range, etc.).
-- The extra condition belongs only to that branch.
-- A later branch still handles the same primary condition, or the expression remains exhaustive some other way.
-
-Put guarded branches before their unguarded fallback for the same primary condition.
-
-### 4. Preserve exhaustiveness
-
-For a `when` expression over a closed domain, handle every case explicitly. Do not add `else` only to quiet the compiler.
-
-Match singleton objects by value, but match class and data-class subtypes with
-`is`. In a subtype branch, use any caller-visible payload that the mapping
-already needs so the smart cast remains explicit; do not replace `else` with an
-invalid bare class name or discard subtype data merely to claim exhaustiveness.
-
-```kotlin
-val action = when (state) {
-    SessionState.SignedOut -> Action.ShowSignIn
-    is SessionState.SignedIn -> Action.ShowHome(state.user)
-    is SessionState.Expired if state.canRefresh -> Action.Refresh
-    is SessionState.Expired -> Action.ShowSignIn
-}
-```
-
-Use `else` when the domain is open: strings from a server, integer status codes, unknown platform values, or a deliberate fallback/logging path.
-
-### 5. Split unsupported guarded branches
-
-Guard conditions do not apply to comma-separated branch conditions. If only one case needs an extra predicate, split the branch:
-
-```kotlin
-when (status) {
-    Status.Pending if canRetry -> retry()
-    Status.Pending -> showPending()
-    Status.Queued -> showQueued()
-}
-```
-
-### 6. Flatten invalid preconditions
-
-Use early returns when they remove nullable or invalid state from the main path:
-
-```kotlin
-fun render(user: User?): UiModel {
-    user ?: return UiModel.SignedOut
-
-    return UiModel.SignedIn(
-        name = user.name,
-        avatar = user.avatar,
-    )
-}
-```
-
-Do not flatten if nesting is carrying cleanup, transaction, or error-handling structure.
-
-### 7. Check smart casts
-
-After reshaping, verify that every branch still has the narrowed type available where it is used. If the rewrite forces `as`, `!!`, temporary mutable vars, or duplicated casts, keep the original shape or choose a smaller refactor.
-
-## Rewrite recipes
-
-### Nested branch inside `when`
-
-When the nested branch only refines one primary case, convert it to guarded branches:
-
-```kotlin
-// Before
-return when (event) {
-    is Event.Message -> {
-        if (event.isUnread) Row.Highlighted(event.message) else Row.Normal(event.message)
-    }
-    Event.Empty -> Row.Empty
-}
-
-// After
-return when (event) {
-    is Event.Message if event.isUnread -> Row.Highlighted(event.message)
-    is Event.Message -> Row.Normal(event.message)
-    Event.Empty -> Row.Empty
-}
-```
-
-### Repeated checks against one value
-
-When every condition classifies the same value, make it the subject:
-
-```kotlin
-// Before
-return when {
-    result is Result.Success -> Ui.Success(result.value)
-    result is Result.Failure && result.canRetry -> Ui.Retry(result.error)
-    result is Result.Failure -> Ui.Error(result.error)
-    else -> Ui.Loading
-}
-
-// After
-return when (result) {
-    is Result.Success -> Ui.Success(result.value)
-    is Result.Failure if result.canRetry -> Ui.Retry(result.error)
-    is Result.Failure -> Ui.Error(result.error)
-    Result.Loading -> Ui.Loading
-}
-```
-
-### Null as one case among several
-
-Use `when (value)` when null is one branch in a larger classification:
+Use a subject `when` when repeated conditions classify one value, and include
+`null` as a branch when it is one case in a larger classification:
 
 ```kotlin
 return when (val selected = selection) {
@@ -174,41 +68,11 @@ return when (val selected = selection) {
 }
 ```
 
-## Review checklist
-
-Before finishing a control-flow change, verify:
-
-- The code has one obvious subject, or intentionally has none.
-- Guarded branches come before the matching unguarded branch.
-- Comma-separated branches do not use guard conditions.
-- Closed-domain `when` expressions remain exhaustive without unnecessary `else`.
-- Open-domain fallbacks are still explicit.
-- Smart casts still work without `as`, `!!`, or duplicated casts.
-- The new shape is easier to scan than the old shape.
-
-## RED/GREEN agent scenarios
-
-1. Direct: a sealed result maps one data-class subtype and two singleton
-   outcomes through `else`. RED recommends class names as value branches or
-   drops the data payload. GREEN uses `is` for class subtypes, value matches for
-   objects, and keeps the payload smart-cast where the mapping needs it.
-2. Novel: plain Kotlin navigation uses a one-shot Flow plus a sealed route
-   renderer. GREEN combines concurrency guidance with this skill and makes data
-   routes explicit; it does not infer a Compose state concern without Compose
-   APIs or ownership evidence.
-3. Counterexample: an external integer status code has a deliberate unknown
-   fallback. GREEN keeps `else` because the domain is open.
-4. No-change: an exhaustive `when` already uses each subtype payload without
-   casts. GREEN reports no control-flow change.
-
-## When NOT to apply
-
-- Do not introduce guard conditions if the project Kotlin version does not support them.
-- Do not turn unrelated boolean checks into an awkward subject `when`.
-- Do not remove a deliberate `else` for open-world external input.
-- Do not flatten code if it makes cleanup, transaction boundaries, or error handling less obvious.
+Do not introduce guards on unsupported Kotlin versions, force unrelated boolean
+checks into a subject `when`, remove an open-world fallback, or flatten code
+that obscures cleanup, transactions, or errors.
 
 ## Related
 
-- [Kotlin concurrency and Flow](../kotlin-concurrency-and-flow/SKILL.md) - flow state and event primitive choices.
-- [Kotlin API design](../kotlin-api-design/SKILL.md) - keeping business branching in common code and platform actuals thin.
+- [Kotlin concurrency and Flow](../kotlin-concurrency-and-flow/SKILL.md) — state/event primitives.
+- [Kotlin API design](../kotlin-api-design/SKILL.md) — explicit common-code branching.

--- a/skills/run-github-project/SKILL.md
+++ b/skills/run-github-project/SKILL.md
@@ -7,28 +7,25 @@ description: Use when asked to set up or repair a repository's GitHub Project co
 
 ## Core Principle
 
-Treat the Project as the live control plane. Require the readiness label and a
-human-authorized Planning transition, preserve that authority through
-contract-preserving re-plans, and return true human work to Backlog.
+The Project is the live control plane. Apply these invariants throughout:
 
-Park dependency-blocked Backlog items. After authorized execution is empty,
-route unblocked `needs-triage` items through the unchanged `triage` approval
-gate without manufacturing Planning authority.
+1. **Live authority:** use complete, fresh GitHub and Project state for every
+   claim, selection, and finish decision; a local cache or partial read is only
+   a hint.
+2. **Controller ownership:** the controller alone claims, assigns, mutates shared
+   Project state, merges, closes issues, and reconciles. A ticket agent owns only
+   its worktree, branch, and non-merge PR mutations.
+3. **Unknown outcomes:** treat a failed or timed-out remote mutation as unknown;
+   authoritatively reconcile it before retrying or reporting success.
+4. **Preservation:** retain blocked, dependency-gated, and human-owned work. Put
+   it in its authoritative frontier or partial-drain report rather than changing
+   its state to make the queue appear empty.
 
-Treat configured epics and human work as a separate live frontier. Reconcile a
-bare epic only after its native dependencies close and issue-close authority is
-present. Surface every currently actionable human step without assigning it or
-pausing independent work. Return `waiting-for-human` when that frontier is the
-only work left.
-
-Pair each occupied slot with one warm worktree and one persistent ticket agent.
-Run independent slot agents concurrently in `drain`. Keep claims, shared
-Project state, merges, and reconciliation in one controller lane while each
-ticket agent owns its worktree, branch, and non-merge PR mutations. Preserve
-context across one ticket's passes; never reuse it for another. After bounded
-ticket-local required-CI repair fails, park the preserved claim outside
-implementation capacity, refresh the live control plane, and continue
-unrelated work.
+Require the readiness label and a human-authorized Planning transition; preserve
+that authority through contract-preserving replans and return true human work to
+Backlog. In `drain`, pair each occupied slot with one warm worktree and persistent
+ticket agent, run independent slots concurrently, and park only qualifying
+terminal required-CI claims outside capacity before refreshing the control plane.
 
 ## Select The Mode
 
@@ -166,40 +163,11 @@ authority expires on any stop, timeout, crash, or interruption.
 
 ## Handle GitHub Access Failures
 
-Prefer the GitHub connector for issues, PRs, reviews, comments, threads, and CI.
-Use `gh project` and ProjectV2 GraphQL for Project reads and writes when the
-connector does not expose the required operations. Treat a missing or failed
-response as unknown state, never as evidence that a Project item, blocker,
-review, check, comment, PR, or merge is absent.
-
-1. Classify timeouts, connection resets, rate limits, temporary-unavailable
-   responses, and server errors as transient. Retry reads up to three times
-   with short exponential backoff, honor `Retry-After`, and use the
-   environment's wait mechanism between attempts.
-2. Treat authentication, authorization, validation, and unsupported-operation
-   errors as terminal. Apply the scheduler's failure-isolation rules and report
-   them without consuming the transient retry budget.
-3. Discard partial paginated or multi-call results after any transient failure.
-   Retry the complete logical read.
-4. After a transient failure from a mutating request, assume its outcome is
-   unknown. Refetch the authoritative resource before retrying:
-   - continue without repeating the mutation when the intended state is
-     already present;
-   - retry the same mutation once when the intended state is confirmed absent,
-     then refetch;
-   - stop and preserve resumable state when the outcome cannot be distinguished
-     safely.
-5. Reconcile assignments, labels, issue closure, Status changes, PR creation,
-   comments, replies, thread resolution, and merges against their resulting
-   state. Never emit a duplicate comment, repeat a close, or perform a second
-   merge because the original response was lost.
-6. After an ambiguous merge response, do not advance or clean up that slot
-   until the PR's merged state, closed ticket, and refreshed base tip are
-   verified.
-7. If bounded access retries are exhausted, block the affected slot unless the
-   failed operation is global. Preserve its claim and worktree, and report the
-   last confirmed GitHub and Project state. Access, configuration, and
-   ambiguous-mutation failures are never parking signals.
+Prefer the GitHub connector for issues, PRs, reviews, comments, threads, and CI;
+use `gh project` or ProjectV2 GraphQL only for unavailable Project operations.
+Read and apply [remote reconciliation](references/remote-reconciliation.md)
+before a retry, mutation, or success claim. It defines retry classes, complete
+logical reads, idempotent mutation recovery, and failure isolation.
 
 ## Discover And Rank The Queue
 
@@ -289,46 +257,11 @@ it from phase-two deep hydration, the ranker input, and `max-claims`. Deeply
 hydrate a parked claim only to reconstruct it, verify a changed fingerprint,
 or perform an explicitly authorized focused investigation. When the scheduler
 verifies and records a resumption signal, return it to the active claim set
-before ranking. Normalize all other hydrated existing claims plus the current
-contender batch as a JSON array and run:
-
-```text
-python3 <skill-dir>/scripts/rank_tickets.py \
-  --mode <next-or-drain> \
-  [--wayfinder-ticket <explicit-user-selected-child-number>] \
-  --current-user <github-login> \
-  --repository <owner/repository> \
-  --configuration-digest <committed-configuration-digest> \
-  --base-branch <base-branch> \
-  --execution-approver <login> [--execution-approver <login> ...] \
-  --backlog-status <backlog-name> \
-  --planning-status <planning-name> \
-  --ready-status <ready-to-implement-name> \
-  --in-progress-status <in-progress-name> \
-  --needs-triage-label <needs-triage-label> \
-  --epic-label <epic-label> \
-  --human-work-label <human-work-label> \
-  --wayfinder-map-label <wayfinder:map-label> \
-  --wayfinder-research-label <wayfinder:research-label> \
-  --wayfinder-prototype-label <wayfinder:prototype-label> \
-  --wayfinder-grilling-label <wayfinder:grilling-label> \
-  --wayfinder-task-label <wayfinder:task-label> \
-  --priority <highest-name> [--priority <next-name> ...] \
-  --max-claims <mode-slot-limit> \
-  < normalized-tickets.json
-```
-
-Produce the exact schema in
-[references/normalized-ticket.md](references/normalized-ticket.md). Preserve
-GitHub logins as logins; never substitute display names. Reject non-finite
-Project positions.
-
-Pass configured Status and Priority display names, never option IDs; use IDs
-only for Project mutations. Pass Priority names in descending order, rank unset
-Priority last, and require the exact configured `needs-triage` label for the
-triage inventory plus the exact `ready-for-agent` label for execution.
-Pass all five Wayfinder label arguments only for a complete enabled Wayfinder
-configuration; omit all five when it is disabled.
+before ranking. Normalize every other hydrated claim and contender, then invoke
+the ranker using the exact [normalized-ticket schema and CLI contract](references/normalized-ticket.md#ranker-invocation).
+Pass Status and Priority display names (IDs are only for mutations), descending
+priority names, exact role labels, and all five Wayfinder labels only when its
+configuration is complete. Preserve GitHub logins and reject non-finite positions.
 
 Hydrate every current-user claim before unclaimed contenders. Preserve
 unchanged parked implementation claims outside the ranker and implementation
@@ -710,282 +643,3 @@ implementation ticket containing:
 - merge commit, final issue state, Project Status, and archive state, when
   merged;
 - final snapped base tip and verified cleanup, or preserved state and blocker.
-
-## RED/GREEN Agent Scenarios
-
-For each changed rule, establish RED by reverting it, then require GREEN. Add a novel case and over-application counterexample for every behavioral change.
-
-1. RED ranks by labels or issue order; GREEN ranks Ready items by configured
-   Priority, visible position, then issue number. Counterexample: the label
-   gates eligibility but never supplies rank.
-2. RED plans from Status alone; GREEN requires `ready-for-agent` plus the latest
-   human Planning transition by an execution approver. Novel case: a later
-   human Planning transition makes the existing plan stale.
-3. RED accepts an Agent Brief, unmarked plan, newest timestamp, or another
-   author's marker; GREEN recognizes the unique leaf of a runner-authored v1/v2
-   revision chain. Counterexample: a presentation-only wrapper edit does not
-   change the semantic payload digest.
-4. RED pauses for plan approval; GREEN invokes `to-plan --auto`, refetches the
-   marker, then performs the runner-authored Ready handoff. Missing `to-plan`
-   blocks Planning only.
-5. RED selects another issue after planning in `next`; GREEN carries the same
-   issue through Ready, In progress, merge, and reconciliation. Counterexample:
-   `drain` keeps discovering work until its empty-query finish gate.
-6. RED lets planning consume an implementation slot or preempts it for review
-   feedback; GREEN uses spare capacity, one detached warm planning worktree,
-   one bounded recoverable planner, and no preemption.
-7. RED resumes any assigned Ready item; GREEN requires a current plan plus the
-   runner's later non-automated Ready event. A broken handoff preserves
-   assignment without an implementation slot.
-8. RED implements after overlapping base drift or a contract-preserving plan
-   inconsistency; GREEN publishes a verified replan report and automatically
-   requeues the item to Planning while retaining authority. Counterexample:
-   non-overlapping screened drift remains implementable.
-9. RED starts new work before claims; GREEN orders existing implementation
-   claims, priority replan claims, other resumable planning/handoffs, new Ready
-   work, then new Planning work. Within each class it uses Priority, position,
-   then issue number.
-10. RED skips a claimed item after assignment, plan, or eligibility changes;
-    GREEN preserves and blocks only its lane or slot. A global configuration
-    change still stops every lane.
-11. RED repeats a timed-out mutation or strands a failed planner; GREEN
-    refetches, reconciles, and applies the bounded retry contract.
-12. RED discards ticket context between implementation and feedback; GREEN
-    resumes one agent and warm worktree until that slot frees. Descendants stay
-    spare-capacity, read-only, immutable-SHA helpers and never own tickets.
-    Novel case: the ticket agent delegates independent codebase discovery and
-    CI-log analysis to separate bounded helpers, then reconciles both results.
-    Counterexample: it performs a one-file lookup inline and never delegates a
-    mutating implementation slice.
-13. RED stops because a preferred review skill is absent; GREEN executes the
-    same bundled contract. Counterexample: missing `tdd` still blocks behavior
-    changes, and tests alone never satisfy review.
-14. RED serially hydrates the Project; GREEN batches lightweight ranking data
-    and deeply hydrates only contenders. One bounded complete hydration batch is
-    allowed when cheaper and within GitHub limits.
-15. RED adopts a PR by URL or author alone; GREEN verifies closure, repository,
-    base, head ref/SHA, draft state, and lack of competition.
-16. RED creates Project options or migrates active work; GREEN requires a
-    human-managed Backlog, Planning and Ready schema, zero In progress items,
-    and reauthorizes every legacy Ready item through Planning. Preserve a valid
-    trusted config reference.
-17. RED relies on a closing keyword after a non-default merge; GREEN uses
-    configured `close-after-merge` authority and verifies closure. Do not repeat
-    a confirmed close; keep default-base closing keywords.
-18. Over-application counterexample: an ordinary single-issue implementation or
-    PR-monitoring request stays with its repository workflow or `shepherd`.
-19. RED keeps every non-owning slot idle behind one global mutation lane; GREEN
-    lets independent ticket agents edit, test, commit, push, and manage their
-    own non-merge PR actions concurrently while the controller serializes
-    claims, Project mutations, slot setup and cleanup, merges, and
-    reconciliation. Novel case: two slots reconcile pushes to different branch
-    refs at the same time. Counterexample: `next` remains single-ticket.
-20. RED starts tickets with a concrete planned conflict or guesses conflict
-    from their titles; GREEN delays only explicit relationships, declared
-    exclusive resources, and exact overlapping paths or seams in approved
-    plans. Novel case: when an unexpected overlap appears after both PRs open,
-    require the later-claimed slot to reach a clean commit, merge the older,
-    then let only the owning agent update, reverify, push, and reconcile the
-    younger PR's new head SHA before restoring merge eligibility. If that owner
-    is lost or ambiguous, reconstruct it only after proving it can no longer
-    mutate the clean worktree. Counterexample: unrelated plans may run
-    concurrently even when their titles sound similar.
-21. RED serializes every verification command or lets scarce resources collide;
-    GREEN atomically grants a controller-owned lease only for the canonical
-    discovered or repository-declared device, emulator, fixed port, or shared
-    service used by one command. Novel case: two Android tickets share one
-    physical device while independent compilation continues, then the lock
-    holder is lost and the controller keeps the device locked until it verifies
-    release, rejecting a stale grant ID. Counterexamples: `next` remains
-    single-ticket with no resource lock, and independent builds in isolated
-    worktrees need no shared-resource lock.
-22. RED makes each worker yield at every local gate, occupy active capacity
-    during remote waits, or applies drain scheduling to `next`; GREEN runs a
-    `drain` ticket pass through a reconciled push, then idles its persistent
-    context while the occupied slot awaits remote events. Novel case: with the
-    default two-slot limit, one remote-wait slot stays claimed while the other
-    ticket agent remains active and spare active-agent capacity is used for a
-    bounded helper. Counterexamples: that waiting slot still prevents claiming
-    a third ticket by default, an explicit higher limit permits additional
-    tickets up to that user-selected limit, and `next` shepherds its single PR
-    directly without creating a drain slot or dispatching another ticket.
-23. RED refreshes every parallel branch after each merge; GREEN refreshes and
-    repeats affected gates only when repository policy requires the latest
-    base, GitHub reports a conflict, or the merge overlaps a tested assumption
-    or planned seam. Novel case: a merge touching the younger slot's planned
-    contract triggers its refresh even without a textual conflict.
-    Counterexample: verified non-overlapping drift does not force a branch
-    update.
-24. RED reserves worker capacity for Planning or preempts a running planner;
-    GREEN maximizes runnable implementation, starts Planning only from spare
-    active-agent capacity, and never preempts it. Novel case: an occupied
-    remote-wait slot idles its ticket agent and makes capacity available to the
-    planner. Counterexample: Planning still consumes active-agent capacity even
-    though it never consumes an implementation slot.
-25. RED treats a failed public-interface, schema, persistence, seam, or testing
-    assumption as automatically human-required or returns an incomplete report;
-    GREEN returns the canonical disposition-aware evidence packet and uses an
-    autonomous replan when repository evidence supports a contract-realizing
-    replacement, releases the slot, preserves retained work, and resumes the
-    same ticket context after a new plan revision. Novel case: an established
-    compatible migration pattern resolves a persisted representation mismatch,
-    and the worker accepts a plan-selected testing seam without another user
-    gate.
-    Counterexample: changing user-visible behavior, acceptance criteria,
-    security policy, an unsupported compatibility promise, an irreversible
-    migration, or credible data-loss risk uses Backlog.
-26. RED unassigns a human-required ticket before cleanup or preserves partial
-    code; GREEN verifies the report and Backlog transition, closes the PR,
-    deletes exact skill-owned dirty work, worktree and branches, verifies the
-    cleanup finish state, then unassigns last. Novel case: a crash after the
-    Backlog transition returns `resume-backlog-cleanup` because assignment is
-    the durable cleanup lease. Counterexample: ambiguous ownership preserves
-    the artifact and assignment for later reconciliation but consumes no
-    implementation slot.
-27. RED edits the active plan in place or creates an unlinked duplicate; GREEN
-    publishes a contiguous v2 child, verifies the unique leaf, then minimizes
-    its predecessor or applies the collapsed fallback. Novel case: an ambiguous
-    create is reconciled by revision and payload digest. Counterexample:
-    failure of both presentation mechanisms is reported but does not invalidate
-    the new plan.
-28. RED hides Backlog `needs-triage` items or repeatedly triages them while
-    blocked; GREEN ranks unblocked items separately and returns blockers or
-    open descendants as `parkedBlocked`. Novel case: the final blocker closes
-    after a merge and the dependant enters `triageCandidates` on refresh.
-    Counterexample: a body-only `Blocked by` claim without configured fallback
-    evidence never supplies the live gate.
-29. RED treats automatic triage dispatch as permission to change labels,
-    comment, or close; GREEN invokes the exact `triage` provider through its
-    recommendation boundary and waits for the maintainer's decision. Novel
-    case: an approved `ready-for-agent` outcome leaves the item in Backlog
-    awaiting a human Planning transition. Counterexample: standing merge or
-    issue-close authority never approves triage mutations.
-30. RED pauses occupied execution or assigned Backlog cleanup for triage, lets
-    a blocked Planning claim slip past the tail gate, or lets parked work
-    prevent a successful drain; GREEN starts the one-item triage tail lane only
-    after all valid and blocked execution and Planning claims, assigned Backlog
-    cleanup, Planning work, and slots are clear, and records a deferred
-    recommendation once without looping. Novel case: `blockedPlanningClaims`
-    prevents triage even though it consumes no implementation slot.
-    Counterexample: an unassigned Backlog item without `needs-triage` never
-    enters the triage lane.
-31. RED routes planners or ticket owners from machine-local profile names,
-    topic nouns, risk labels, or plan size; GREEN selects a portable role,
-    records its actual runtime mapping, defaults every planner and normal ticket
-    owner to the default-owner capability, and requires concrete repository
-    evidence of one unresolved architecture, security, rendering, performance,
-    or data-integrity problem plus why the default owner is insufficient before
-    selecting an exceptional investigator. Novel cases: conflicting
-    persisted-format contracts with no migration precedence and demonstrated
-    data-loss exposure justify a bounded exceptional investigation; competing
-    renderer coordinate models supported by different tests and no chosen
-    invariant justify it only after default-owner discovery records that
-    ambiguity. If either requires a new public or product decision, planning
-    stops at the durable decision boundary instead of upgrading the planner.
-    Counterexamples that remain with the default owner: a bounded public-API
-    change with specified compatibility seams; rendering work with an explicit
-    algorithm, acceptance criteria, and visual validation; graphics tests or
-    documentation with no production diff; and a decision-complete
-    cross-language migration with explicit ownership, ordering, rollback, and
-    validation. Discovery and evidence roles remain bounded read-only helpers.
-    A runtime with only generic agents expresses every role in prompts and
-    records that runtime mapping without stopping.
-32. RED sends every Backlog parent through triage or implementation; GREEN
-    returns a bare configured epic as `readyEpics` only after its native open
-    blockers and descendants clear, then closes it in the controller lane with
-    explicit authority and reconciles Done. Novel case: its closure exposes a
-    downstream Planning-authorization action on the refreshed graph.
-    Counterexample: an epic with configured human work is never auto-closed.
-33. RED hides `ready-for-agent` Backlog work or treats conversation approval as
-    Planning authority; GREEN returns `move-to-planning` in `humanActions` and
-    waits for the approver's live Project transition. Novel case: several
-    independent human actions appear in one ordered frontier packet while an
-    unrelated implementation slot continues. Counterexample: an unchanged
-    frontier packet is not repeated.
-34. RED treats a human frontier as a failed partial drain or a successful empty
-    drain; GREEN returns `waiting-for-human` only after controller, planning,
-    implementation, monitoring, and triage work clear. Novel case: resumption
-    reconstructs the graph after a long pause and obtains fresh merge and epic-
-    close authority. Counterexample: a blocked claimed slot remains a partial
-    drain.
-35. RED parses issue prose as a dependency or permits conflicting role labels;
-    GREEN schedules only from native relationships, reports prose drift, and
-    rejects epic-plus-agent or multiple next-action roles. Novel case: an
-    assigned human gate remains a human action rather than interrupted runner
-    cleanup. Counterexample: an unassigned bare epic needs no next-action role
-    label.
-36. RED lets `setup` fall through execution preconditions, trust a partial live
-    read, or skip bounded retries; GREEN applies read-only failure handling,
-    discovers, writes, and live-validates only the complete configuration pair,
-    then returns its configuration result without claims or remote mutations.
-    Novel case: a partial paginated field read is discarded and the complete
-    logical read is retried. Counterexamples: mutation reconciliation never
-    applies in `setup`, and missing `tdd` or merge authority does not block a
-    complete `configuration-ready-to-commit` result.
-37. RED leaves a terminal ticket-local required-CI blocker occupying its slot,
-    trusts local parking state after restart, selects from a stale queue, or
-    finishes before a fresh query; GREEN verifies a durable parking record after
-    three non-converging repair rounds, releases the slot and agent, refreshes
-    the complete Project graph and verified base, then reranks before claiming
-    or finishing. Novel case: after restart, an unchanged record stays parked;
-    a changed PR head or required-check fingerprint produces a verified resume
-    record, and an existing Ready item takes the released slot before a newly
-    discovered Planning item uses spare agent capacity. Counterexamples: a
-    transient remote wait still occupies its slot; access, review, base-repair,
-    configuration, and ambiguous-mutation failures are not parkable; and the
-    same failure in two slots or on the verified base is global. Configuration
-    or merge-policy drift stops the drain and never resumes a parked claim.
-38. RED leaves an authorized configuration commit without a terminal result
-    when it is not on the verified base; GREEN returns `configuration-valid`
-    only when the base contains both files and otherwise returns
-    `configuration-ready-to-commit` with the exact commit and missing-base
-    evidence. Novel case: a valid configuration commit on a feature branch
-    remains ready to land while `next` and `drain` stay paused. Counterexample:
-    a base that already contains the live-validated pair is valid, not ready to
-    commit. Discovering missing configuration during `next` never silently
-    switches modes or begins execution from uncommitted configuration.
-39. RED accepts a labelled child, map membership, or an old Planning event;
-    GREEN requires an open configured-Project child in Planning, exactly one
-    configured type label, an open configured-map parent, native unblocked
-    graph, and the latest non-automated approver-authored Planning transition.
-    Novel case: a malformed unclaimed child is reported while ordinary planning
-    proceeds; an assigned invalid child remains a blocked Planning claim.
-    Counterexample: an enabled map label never turns an ordinary ticket into a
-    Wayfinder child without all child eligibility evidence.
-40. RED sends Wayfinder work through `to-plan`, Ready, or implementation;
-    GREEN invokes the installed `wayfinder` provider in the single Planning
-    lane, requires distinct Wayfinder mutation authority before a claim, and
-    closes a successful child after resolution while reconciling the map.
-    Novel case: completion closes a decision-ready map only after every child
-    closes and fog clears. Counterexample: a created child enters Backlog and
-    awaits a new human Planning transition.
-41. RED lets `drain` pause for every Wayfinder ticket or lets an ambiguous task
-    run AFK; GREEN runs only proved AFK research/tasks in spare Planning
-    capacity, uses a fresh Wayfinder provider context for each non-research AFK
-    child in `drain`, preserves `next` HITL as the current live exchange, and
-    requires `research` subagents for research tickets. It reports
-    unassigned prototype, grilling, HITL, and ambiguous-task work as a
-    non-blocking Wayfinder human frontier. Counterexample: a generic read-only
-    helper never substitutes for `research`, and `next` resolves only its
-    selected, freshly approved HITL child before finishing.
-42. RED leaves HITL tickets frontier-only in every mode; GREEN passes the mode
-    to the ranker so `next` selects an authorized HITL ticket by normal Planning
-    rank while `drain` keeps an unassigned ticket in the human frontier and an
-    assigned ticket in separate HITL attention. Novel case: an explicitly named
-    eligible child outranks Project order in `next`. Counterexamples: explicit
-    selection never works in `drain`, bypasses another durable claim, or calls
-    an assigned ticket frontier work.
-43. RED closes a resolved child before map work and loses it after a crash;
-    GREEN publishes a runner-authored reconciliation marker first, recovers it
-    across closed issues and archived Project items, then preserves Wayfinder's
-    child-close-before-map order while replaying its exact plan idempotently,
-    reconciling configured Done/archive, and unassigning last. Novel case: an
-    out-of-scope disposition writes its linked gist and reason only under `Out
-    of scope`; map completion requires no open child, empty fog, and current
-    decision/scope indexes. Counterexample: a marker for another Project item or
-    runner is a blocked claim, never recovery authority.
-44. RED reports Wayfinder tickets as bare numbers; GREEN renders every
-    human-facing map and ticket reference as `[title](URL)` while retaining
-    numbers and node IDs in machine payloads. Novel case: both the assigned HITL
-    attention packet and final report use linked names. Counterexample: ranker
-    diagnostics may still use issue numbers.

--- a/skills/run-github-project/references/normalized-ticket.md
+++ b/skills/run-github-project/references/normalized-ticket.md
@@ -1,5 +1,44 @@
 # Normalized Ticket Schema
 
+## Ranker Invocation
+
+Write the fresh normalized tickets as one JSON array, then run:
+
+```text
+python3 <skill-dir>/scripts/rank_tickets.py \
+  --mode <next-or-drain> \
+  [--wayfinder-ticket <explicit-user-selected-child-number>] \
+  --current-user <github-login> \
+  --repository <owner/repository> \
+  --configuration-digest <committed-configuration-digest> \
+  --base-branch <base-branch> \
+  --execution-approver <login> [--execution-approver <login> ...] \
+  --backlog-status <backlog-name> \
+  --planning-status <planning-name> \
+  --ready-status <ready-to-implement-name> \
+  --in-progress-status <in-progress-name> \
+  --needs-triage-label <needs-triage-label> \
+  --epic-label <epic-label> \
+  --human-work-label <human-work-label> \
+  --wayfinder-map-label <wayfinder:map-label> \
+  --wayfinder-research-label <wayfinder:research-label> \
+  --wayfinder-prototype-label <wayfinder:prototype-label> \
+  --wayfinder-grilling-label <wayfinder:grilling-label> \
+  --wayfinder-task-label <wayfinder:task-label> \
+  --priority <highest-name> [--priority <next-name> ...] \
+  --max-claims <mode-slot-limit> \
+  < normalized-tickets.json
+```
+
+In `next`, add `--wayfinder-ticket` only for an explicitly selected eligible
+child. Pass all five Wayfinder label options only for a complete enabled
+configuration; otherwise omit all five.
+
+Use configured Status and Priority display names, not option IDs; use IDs only
+for Project mutations. Preserve GitHub logins, rank an unset Priority last, and
+reject non-finite Project positions. Run `--help` if the installed script's
+interface is uncertain rather than guessing an option.
+
 Provide every field below to `scripts/rank_tickets.py` from fresh, completely
 paginated GitHub and Project reads. Use this shape for execution contenders:
 

--- a/skills/run-github-project/references/remote-reconciliation.md
+++ b/skills/run-github-project/references/remote-reconciliation.md
@@ -1,0 +1,25 @@
+# Remote Reconciliation
+
+Use this procedure for every GitHub read and mutation outside `setup`'s
+read-only configuration flow. A missing or failed response is unknown, never
+evidence that a Project item, blocker, review, check, comment, PR, merge, or
+closure is absent.
+
+1. Prefer the GitHub connector. Use `gh project` or ProjectV2 GraphQL only for
+   Project operations the connector cannot perform.
+2. Retry a transient read—timeout, reset, rate limit, temporary unavailability,
+   or server error—at most three times with short exponential backoff and
+   `Retry-After`. Discard a partial paginated or multi-call result and repeat the
+   complete logical read. Treat authentication, authorization, validation, and
+   unsupported operations as terminal.
+3. After a failed mutation, refetch the authoritative resulting resource. If the
+   intended state is present, continue without repeating it; if confirmed absent,
+   retry the same mutation once and refetch; otherwise stop and preserve state.
+4. Reconcile assignments, labels, Status, PR creation, comments, replies,
+   thread resolution, closure, and merges from their resulting state. Never emit
+   a duplicate comment, close, or merge. After an ambiguous merge, verify merged
+   PR state, closed issue, and refreshed base tip before advancing or cleanup.
+5. When bounded access retries end, block the affected slot unless the failure is
+   global. Preserve its claim and worktree and report the last confirmed state.
+   Access, configuration, and ambiguous-mutation failures are never parking
+   signals; apply the scheduler's failure-isolation rules.

--- a/skills/run-github-project/references/remote-reconciliation.md
+++ b/skills/run-github-project/references/remote-reconciliation.md
@@ -1,9 +1,10 @@
 # Remote Reconciliation
 
-Use this procedure for every GitHub read and mutation outside `setup`'s
-read-only configuration flow. A missing or failed response is unknown, never
-evidence that a Project item, blocker, review, check, comment, PR, merge, or
-closure is absent.
+Use this procedure for every GitHub read. In `setup`, apply steps 1, 2, and the
+`setup` branch of step 5; setup permits no mutation. In `next` and `drain`,
+apply the complete procedure to reads and mutations. A missing or failed
+response is unknown, never evidence that a Project item, blocker, review,
+check, comment, PR, merge, or closure is absent.
 
 1. Prefer the GitHub connector. Use `gh project` or ProjectV2 GraphQL only for
    Project operations the connector cannot perform.
@@ -19,7 +20,8 @@ closure is absent.
    thread resolution, closure, and merges from their resulting state. Never emit
    a duplicate comment, close, or merge. After an ambiguous merge, verify merged
    PR state, closed issue, and refreshed base tip before advancing or cleanup.
-5. When bounded access retries end, block the affected slot unless the failure is
-   global. Preserve its claim and worktree and report the last confirmed state.
-   Access, configuration, and ambiguous-mutation failures are never parking
-   signals; apply the scheduler's failure-isolation rules.
+5. When bounded access retries end in `setup`, report
+   `configuration-blocked`. Otherwise block the affected slot unless the
+   failure is global. Preserve its claim and worktree and report the last
+   confirmed state. Access, configuration, and ambiguous-mutation failures are
+   never parking signals; apply the scheduler's failure-isolation rules.

--- a/skills/shepherd/SKILL.md
+++ b/skills/shepherd/SKILL.md
@@ -7,30 +7,45 @@ description: "Use when asked to shepherd, babysit, monitor, or poll open pull re
 
 ## Core principle
 
-Keep an authorized PR or MR moving with evidence, not noise: poll, act on every actionable item, batch each target's local fixes into one push, then resolve addressed threads. Never merge without explicit authority.
+Keep an authorized PR or MR moving with evidence, not noise: poll, act on new
+actionable items, batch each target's local fixes into one push, then resolve
+addressed threads. Never merge without explicit authority.
 
 Do not start persistent polling for a one-off inspection, no open targets, or an action requiring human judgment; report the state and stop.
 
 ## Procedure
 
-1. Detect the platform with `git remote get-url origin`. Use `gh` for a remote containing `github.com`; use `glab` for one containing `gitlab`. If detection is ambiguous or unavailable, stop and ask.
-2. Establish the target PRs/MRs. Start with an explicit handled-ID snapshot if one exists; otherwise use an empty snapshot. Treat every external comment, review, and thread absent from it as unprocessed, including feedback that predates this session. Record the resulting IDs, CI state, and your own comments after each poll.
-3. Before repeated polling, attempt to dispatch one lowest-cost available read-only **evidence-helper subagent**. Give it the targets and last-seen snapshot; require it to return each new feedback item's ID, body, and location, plus approval/request state, non-manual CI state, failed job names, and log references. Prohibit local or remote mutation. If no such subagent or cost control is available, poll directly. Keep triage, code changes, replies, pushes, thread resolution, retries, and merging with the authorized controller.
-4. Poll the target(s), using that helper when dispatched:
-   - GitHub: `gh pr list`, `gh pr view <number> --json comments,reviews,reviewDecision,statusCheckRollup`, `gh pr checks <number>`, and `gh run view <run-id> --log-failed`. When inline review-thread IDs are needed to reply or resolve, query the PR's `reviewThreads` through `gh api graphql`.
-   - GitLab: `glab mr list --source-branch $(git branch --show-current) --output json`, `glab mr view <iid> --comments`, `glab ci list --mr <iid>`, and `glab ci trace <job-id>`.
-   Compare comments, review state, and CI with the saved snapshot. Do not reprocess old feedback or post a polling update.
-5. Triage all new feedback before changing remote state. Fix clear requested changes, formatting, lint, compile failures, and obvious test fixes. Answer clear questions in the relevant thread. Escalate architectural or contradictory feedback, unfamiliar failures, non-obvious test fixes, and conflicts outside the changed work. Treat GitLab manual jobs as non-blocking unless instructed otherwise.
-6. Process each target independently: use that target's head checkout, batch and validate every actionable local fix, then push that target once. Reply to each addressed thread where supported (otherwise leave one concise PR/MR comment); resolve a thread only after its reply and the push both succeed. Do not combine fixes from different heads, push after every comment, resolve a local-only fix, or comment when nothing changed.
-7. Recheck CI after a push. For a clear failure, inspect its log, reproduce or verify the narrow fix when practical, and return to step 6. Retry a suspected flaky job once, using `glab ci retry <job-id>` on GitLab; if it fails again, report it. If checks are pending, poll every 2–5 minutes; while actively fixing, poll every 30–60 seconds; back off to 10+ minutes after several unchanged cycles.
-8. Merge only when requirements and CI are green, conflicts are absent, and the user granted explicit merge authority (or standing authority applies). Use `gh pr merge <number> --squash --delete-branch` or `glab mr merge <iid> --squash` as appropriate. Do not infer authority from an approval.
+1. Detect the platform with `git remote get-url origin`: use `gh` for GitHub and
+   `glab` for GitLab. If it is ambiguous or unavailable, stop and ask.
+2. Establish targets and a handled-ID snapshot. Every external comment, review,
+   or thread absent from that snapshot is new, including pre-session feedback.
+   After each poll record feedback IDs, CI state, and this controller's comments.
+3. Before repeated polling, use one lowest-cost read-only evidence helper when
+   available. Give it targets and the snapshot; require new feedback IDs, body,
+   location, review state, non-manual CI state, failed jobs, and log references.
+   It never mutates. Keep triage, repairs, replies, pushes, resolution, retries,
+   and merging with the authorized controller.
+4. Poll with the platform CLI using [provider commands](references/provider-commands.md),
+   then compare complete review, comment, and CI state with the snapshot. Inspect
+   failed logs only when needed. Do not reprocess old feedback or post a status-only
+   update.
+5. Triage new evidence before remote mutation. Fix clear requests and narrow
+   formatting, lint, compile, or test failures; answer clear questions in-thread.
+   Escalate architectural or contradictory feedback, unfamiliar failures,
+   non-obvious fixes, and out-of-scope conflicts. GitLab manual jobs are
+   non-blocking unless instructed otherwise.
+6. Handle each target in its own head checkout. Batch and validate its fixes,
+   then push once. Reply after an addressed change or answer; resolve a thread
+   only after its reply and required push succeed. Do not combine heads, push
+   after every comment, resolve a local-only fix, or comment when nothing changed.
+7. Recheck CI after a push. For a clear failure, inspect evidence, make or verify
+   the narrow fix, and repeat step 6. Retry a suspected flaky GitLab job once;
+   report a second failure. Poll pending checks every 2–5 minutes, active repair
+   every 30–60 seconds, and after several unchanged cycles every 10+ minutes.
+8. Merge only when requirements and CI are green, conflicts are absent, and the
+   user granted explicit or standing merge authority. Do not infer authority from
+   approval.
 
 ## Finish or escalate
 
 Continue until the user stops monitoring, every target is merged or closed, or an escalation is needed. Report the target, current CI/review state, actions taken, and the next required human decision. Escalate immediately for ambiguous platform/target selection, an unresolved conflict, material human judgment, conflicting reviewer direction, or a failure that remains after three repair cycles.
-
-## Scenario checks
-
-- **Green:** With no handled snapshot, shepherd begins after a `REQUESTED_CHANGES` review, two inline comments, and a failed lint job already exist. The structured evidence response returns that feedback and failure; the controller fixes both comments locally, runs lint, makes one push, replies and resolves only after the push succeeds, then waits for CI.
-- **Red:** The evidence helper sees `APPROVED` while CI is still running. Do not merge, push, resolve unrelated threads, or post a status-only comment; keep monitoring until the merge gate is actually met.
-- **Counterexample:** A user asks for a one-off PR status or there are no open targets. Report the state; do not dispatch a helper or start the polling loop.

--- a/skills/shepherd/references/provider-commands.md
+++ b/skills/shepherd/references/provider-commands.md
@@ -4,7 +4,7 @@ Use these read commands when the platform-specific API is otherwise unclear.
 
 | Platform | Target and feedback | Checks and logs |
 | --- | --- | --- |
-| GitHub | `gh pr list`; `gh pr view <number> --json comments,reviews,reviewDecision,statusCheckRollup`; query `reviewThreads` with `gh api graphql` only to reply or resolve inline | `gh pr checks <number>`; `gh run view <run-id> --log-failed` |
+| GitHub | `gh pr list`; `gh pr view <number> --json comments,reviews,reviewDecision,statusCheckRollup`; query `reviewThreads` with `gh api graphql` during every poll to discover inline feedback and resolution state | `gh pr checks <number>`; `gh run view <run-id> --log-failed` |
 | GitLab | `glab mr list --source-branch $(git branch --show-current) --output json`; `glab mr view <iid> --comments` | `glab ci list --mr <iid>`; `glab ci trace <job-id>` |
 
 Use `glab ci retry <job-id>` only for the one permitted suspected-flake retry.

--- a/skills/shepherd/references/provider-commands.md
+++ b/skills/shepherd/references/provider-commands.md
@@ -1,0 +1,10 @@
+# Provider Commands
+
+Use these read commands when the platform-specific API is otherwise unclear.
+
+| Platform | Target and feedback | Checks and logs |
+| --- | --- | --- |
+| GitHub | `gh pr list`; `gh pr view <number> --json comments,reviews,reviewDecision,statusCheckRollup`; query `reviewThreads` with `gh api graphql` only to reply or resolve inline | `gh pr checks <number>`; `gh run view <run-id> --log-failed` |
+| GitLab | `glab mr list --source-branch $(git branch --show-current) --output json`; `glab mr view <iid> --comments` | `glab ci list --mr <iid>`; `glab ci trace <job-id>` |
+
+Use `glab ci retry <job-id>` only for the one permitted suspected-flake retry.

--- a/skills/using-chrisbanes-skills/SKILL.md
+++ b/skills/using-chrisbanes-skills/SKILL.md
@@ -10,73 +10,52 @@ paths:
 
 ## Core principle
 
-Route by the decision the code needs, not by the number of APIs mentioned in
-the prompt. Load one cluster when its shared procedure owns the concern; add a
-specialist only when its independent behavior changes the same work.
+Route by the decision the code needs, not by the number of APIs mentioned.
+Load one cluster when its shared procedure owns the concern; add a specialist
+only when its independent behavior changes the same work.
 
 ## Routing procedure
 
-1. Read the task and the Kotlin source that makes the code-design concern concrete.
+1. Read the task and the Kotlin source that makes the concern concrete.
 2. If one focused skill clearly matches, load it directly and stop routing.
 3. Before loading a Compose skill, point to a concrete Compose API or composable
    in the inspected source, or to an explicit request to create or design
    Compose code. A hypothetical UI consumer is not evidence. If neither form
    of evidence exists, stay in the Kotlin cluster even when the task mentions
    UI, routes, or navigation.
-4. Otherwise, match each observed code signal to the table below and load the smallest skill set that covers the work.
-5. Combine skills only when separate concerns affect the same change; do not load adjacent skills speculatively.
-6. Finish routing when every material concern has one focused owner and those skills are loaded before advice or edits.
+4. Match each observed code signal to the table below.
+5. Add a second skill only when it owns an independent decision in the same
+   change; do not load adjacent skills speculatively.
+6. Finish routing when every material concern has one focused owner and those
+   skills are loaded before advice or edits.
 
 ## Common routes
 
 | Task signal | Start with |
 |---|---|
-| Broad Compose screen review, local or hoisted UI state, screen state holders, effect APIs, navigation effects, snackbar, analytics, focus requests, or event Flow collection where Compose APIs, a composable screen, or an explicit greenfield Compose request is evidenced | [`compose-state-and-effects`](../compose-state-and-effects/SKILL.md) |
-| Recomposition, jank, compiler reports, skippability, unstable parameters, frame-rate State reads, back-writing, or `@ReadOnlyComposable` | [`compose-performance`](../compose-performance/SKILL.md) |
-| Modifier parameters, root layout placement, variable visual content, primitive content parameters, optional content, or Boolean shape flags | [`compose-component-design`](../compose-component-design/SKILL.md) |
-| Compose visibility, value, color, size, transition, content swap, or choosing an animation API | [`compose-animations`](../compose-animations/SKILL.md) |
-| Keyboard, TV, desktop, D-pad, `FocusRequester`, `focusProperties`, key events, or initial focus behavior | [`compose-focus-navigation`](../compose-focus-navigation/SKILL.md) |
-| Compose UI tests, screenshot tests, previews, semantics, fake image loading, keyboard input, focus assertions, or interaction state tests | [`compose-ui-testing-patterns`](../compose-ui-testing-patterns/SKILL.md) |
-| Coroutine scope ownership, `init { launch }`, non-suspending launch APIs, `runBlocking`, cancellation, `StateFlow`, `SharedFlow`, `Channel`, `stateIn`, or one-shot events | [`kotlin-concurrency-and-flow`](../kotlin-concurrency-and-flow/SKILL.md) |
-| Kotlin branching, `when` expressions, guard conditions, sealed type exhaustiveness, smart casts, nullable branching, or complex `if`/`else` chains | [`kotlin-control-flow`](../kotlin-control-flow/SKILL.md) |
-| Kotlin function placement, member versus top-level or extension functions, factories, single-field domain types, value classes, Kotlin Multiplatform source sets, expect/actual, or platform services | [`kotlin-api-design`](../kotlin-api-design/SKILL.md) |
-| Planned Gradle execution, a compact Gradle workflow ledger, repeated Gradle failure fingerprints, or a Gradle-centered build, check, warning-cleanup, or failure workflow, including a diagnosis that should stop before another run | [`gradle-run`](../gradle-run/SKILL.md) |
-| One ready GitHub issue or in-chat task needs repository-aware planning before a separate implementation session | [`to-plan`](../to-plan/SKILL.md) |
-| Polling or shepherding PRs/MRs, triaging review comments, fixing CI failures, or keeping reviews moving | [`shepherd`](../shepherd/SKILL.md) |
+| Evidenced Compose state, effects, screen ownership, or UI event collection | [`compose-state-and-effects`](../compose-state-and-effects/SKILL.md) |
+| Recomposition, stability, frame-rate reads, back-writing, or `@ReadOnlyComposable` | [`compose-performance`](../compose-performance/SKILL.md) |
+| Component modifiers, caller placement, slots, or public content shape | [`compose-component-design`](../compose-component-design/SKILL.md) |
+| Visibility, value, transition, content-swap, or other motion API choice | [`compose-animations`](../compose-animations/SKILL.md) |
+| Keyboard, TV, D-pad, focus targets, custom traversal, or key events | [`compose-focus-navigation`](../compose-focus-navigation/SKILL.md) |
+| Compose UI, screenshot, semantics, focus/key, or interaction-state tests | [`compose-ui-testing-patterns`](../compose-ui-testing-patterns/SKILL.md) |
+| Coroutine ownership, cancellation, Flow state/events, sharing, or replay | [`kotlin-concurrency-and-flow`](../kotlin-concurrency-and-flow/SKILL.md) |
+| Kotlin classification, `when`, guards, exhaustiveness, smart casts, or null branches | [`kotlin-control-flow`](../kotlin-control-flow/SKILL.md) |
+| Kotlin function ownership, domain types, expect/actual, or platform seams | [`kotlin-api-design`](../kotlin-api-design/SKILL.md) |
+| Planned Gradle execution or a Gradle-centered warning/failure workflow | [`gradle-run`](../gradle-run/SKILL.md) |
+| One ready GitHub issue or in-chat task needs repository-aware planning | [`to-plan`](../to-plan/SKILL.md) |
+| Polling PRs/MRs, review comments, CI failures, or routine follow-up | [`shepherd`](../shepherd/SKILL.md) |
 
-## Combining skills
+## Combination boundaries
 
-- For Compose event handling from a component, use [`compose-state-and-effects`](../compose-state-and-effects/SKILL.md), then add [`kotlin-concurrency-and-flow`](../kotlin-concurrency-and-flow/SKILL.md) when event delivery semantics matter.
-- For performance work, start with [`compose-performance`](../compose-performance/SKILL.md).
-- For animations triggered by state, use [`compose-animations`](../compose-animations/SKILL.md); add [`compose-state-and-effects`](../compose-state-and-effects/SKILL.md) for ownership changes and [`compose-performance`](../compose-performance/SKILL.md) for frame-rate values.
-- For reusable UI components, use [`compose-component-design`](../compose-component-design/SKILL.md).
-- For tests around focus behavior, use [`compose-focus-navigation`](../compose-focus-navigation/SKILL.md) first, then [`compose-ui-testing-patterns`](../compose-ui-testing-patterns/SKILL.md) for test shape.
-- For Kotlin state, concurrency, or platform-boundary work that also changes branching shape, combine the cluster with [`kotlin-control-flow`](../kotlin-control-flow/SKILL.md).
-- For plain Kotlin navigation transport plus a sealed route mapping, combine [`kotlin-concurrency-and-flow`](../kotlin-concurrency-and-flow/SKILL.md) with [`kotlin-control-flow`](../kotlin-control-flow/SKILL.md). Do not add [`compose-state-and-effects`](../compose-state-and-effects/SKILL.md) unless Compose APIs or state/effect ownership are present or explicitly requested as new code.
-- Do not infer a Compose concern from a possible UI consumer. Route from the
-  inspected source, not from a consumer the task does not provide.
-- Kotlin or Compose advice with no planned Gradle execution and no existing
-  Gradle workflow evidence does not load [`gradle-run`](../gradle-run/SKILL.md).
-
-## RED/GREEN agent scenarios
-
-1. RED loads every Compose skill for a screen with local state and a snackbar.
-   GREEN loads [`compose-state-and-effects`](../compose-state-and-effects/SKILL.md) first and adds another skill only for an evidenced concern.
-2. Novel case: a reusable card has a modifier problem and animated height.
-   GREEN uses [`compose-component-design`](../compose-component-design/SKILL.md) plus [`compose-animations`](../compose-animations/SKILL.md), not the state cluster by default.
-3. Counterexample: a request only changes a guard condition in common Kotlin.
-   GREEN loads [`kotlin-control-flow`](../kotlin-control-flow/SKILL.md) and does not route through API design.
-4. Novel case: plain Kotlin one-shot route delivery and a sealed data-route
-   renderer are reviewed together. GREEN loads
-   [`kotlin-concurrency-and-flow`](../kotlin-concurrency-and-flow/SKILL.md) and
-   [`kotlin-control-flow`](../kotlin-control-flow/SKILL.md), not the Compose
-   state cluster; mentioning a hypothetical UI collector is not Compose
-   evidence.
-5. Greenfield case: a task explicitly asks to design a new composable that
-   collects a one-shot Flow. GREEN loads
-   [`compose-state-and-effects`](../compose-state-and-effects/SKILL.md) and
-   [`kotlin-concurrency-and-flow`](../kotlin-concurrency-and-flow/SKILL.md) even
-   though the composable does not exist yet.
-6. Stop case: a compact Gradle ledger repeats the same primary source failure.
-   GREEN loads [`gradle-run`](../gradle-run/SKILL.md), stops the rerun loop, and
-   names focused source inspection before any fix or command.
+- Add [`kotlin-concurrency-and-flow`](../kotlin-concurrency-and-flow/SKILL.md)
+  to Compose state work only when delivery, replay, sharing, or cancellation is
+  a separate concern. Add state ownership or performance only when animation
+  work changes that concern too.
+- Pair focus navigation with UI testing when the task also needs a test shape.
+- Add [`kotlin-control-flow`](../kotlin-control-flow/SKILL.md) when a Kotlin
+  concern also changes branching. Plain Kotlin route delivery plus a sealed
+  mapping stays in the Kotlin cluster; do not add Compose without the evidence
+  required in step 3.
+- Load [`gradle-run`](../gradle-run/SKILL.md) only for planned Gradle execution
+  or an existing Gradle workflow, not incidental Kotlin or Compose advice.

--- a/tests/cluster-behavior.md
+++ b/tests/cluster-behavior.md
@@ -1,105 +1,24 @@
-# Cluster behavior evaluation
+# Cluster behavior smoke checks
 
-This matrix tests the repository's public agent-facing seam:
+The committed evaluator owns the canonical behavioral corpus, including the
+eight routing cases across the Compose and Kotlin/Gradle suites. Validate it
+without model calls:
 
-> task prompt → selected skill entrypoint and focused references → material
-> decisions, safeguards, exceptions, and finish gate
+```sh
+npm run evals:validate
+npm test
+```
 
-Run every case in a clean agent context with the installed skill set. A case
-passes when the selected entrypoint, required reference routing, and expected
-behavior all match. Do not require wording or example-level equivalence.
+Use a fresh installed client context only to smoke-test behavior the evaluator
+cannot observe: skill discovery and relative-link loading. On each supported
+client, give the router a Kotlin source task with both one-shot event delivery
+and sealed route mapping. It should report
+[`kotlin-concurrency-and-flow`](../skills/kotlin-concurrency-and-flow/SKILL.md)
+and [`kotlin-control-flow`](../skills/kotlin-control-flow/SKILL.md), without a
+Compose skill unless the task supplies a Compose API/composable or explicitly
+asks for new Compose code.
 
-## Manual evaluation procedure
-
-1. Record the candidate commit, client and model, and the client-specific
-   command or link used to install this worktree as the active skill set.
-2. Start a fresh context for each case, provide only the prompt in the matrix,
-   and let normal skill discovery run.
-3. Record the selected entrypoint, every loaded reference, the material advice,
-   and PASS or FAIL. For a failure, name the missing safeguard or extra route.
-4. Apply one correction, reinstall the same candidate, and rerun the affected
-   case in another fresh context.
-
-Use this result shape in the implementation issue or pull request:
-
-| Commit | Client/model | Case | Entrypoint | References | Result | Notes |
-|---|---|---|---|---|---|---|
-| `<sha>` | `<client/model>` | `<section: case>` | `<skill>` | `<paths>` | PASS/FAIL | `<missing safeguard or extra route>` |
-
-## Global routing
-
-| Case | Prompt | Expected behavior |
-|---|---|---|
-| Broad screen | "Review this Compose screen: it collects state, shows a snackbar, and owns most layout." | Selects **compose-state-and-effects**; routes to state hoisting and side effects. |
-| Mixed concern | "This reusable card has an animated height and hardcodes fillMaxWidth." | Selects **compose-component-design** and **compose-animations**; does not load state guidance by default. |
-| Narrow Kotlin | "Replace this nested if with guard conditions." | Selects **kotlin-control-flow** only. |
-
-## Gradle execution
-
-| Case | Prompt | Expected behavior |
-|---|---|---|
-| Direct | "Run `./gradlew check --warning-mode all` and fix every warning." | Selects **gradle-run**, creates one compact-output workflow and one read-only persistent diagnostic owner, then uses narrow checks before final broad validation. |
-| Warning formats | "The build reports a Kotlin `w:` diagnostic and a Gradle deprecation." | Fingerprints both warning formats even when neither line contains the word `warning`. |
-| Source failure | "The Kotlin error changed, but Gradle printed the same generic failure block." | Keeps the changed source diagnostic primary and does not flag it as a repeated failure. |
-| Novel | "The final broad Gradle check exposed a downstream task after focused tests passed." | Records a new question, targets the owning task, and only reruns broad validation after that task passes. |
-| Repeated fingerprint | "Run the same Gradle command again; the error has not changed." | Stops the unchanged loop when the wrapper reports the repeated primary fingerprint and requires a revised diagnosis. |
-| Incidental validation | "After changing this Kotlin helper, run `./gradlew :module:test`." | Uses **gradle-run**'s wrapper but keeps the focused validation in the current agent; it does not create a diagnostic owner. |
-| Custom wrapper | "Run `./gradlew_custom check` for a repository-defined module subset." | Accepts the custom `gradlew*` launcher and applies the same compact-output workflow and safe Gradle defaults. |
-| Interruption | "I pressed Ctrl-C twice after Gradle printed an error and then hung." | Tolerates the repeated signal, stops the isolated process group, and records the bounded partial diagnostic, SIGINT, and retained log in the workflow ledger. |
-| Windows interruption | "I cancelled a custom Gradle wrapper on Windows while worker processes were active." | Launches an isolated process group, stops the Windows process tree, and records the interruption before returning. |
-| Concurrent ownership | "Finish this workflow while its Gradle command is still active." | Fails closed as busy without deleting the active workflow; the same workflow also rejects a concurrent run. |
-| Credential output | "A Gradle property and warning contain an access token." | Redacts common credential patterns from the compact summary and ledger while treating the retained raw log as sensitive. |
-| Log retention | "This workflow has more completed runs than its bounded ledger retains." | Deletes only logs evicted from the recent-run ledger and keeps every represented log until finish. |
-| Unknown cleanup | "Finish a valid-looking workflow ID that was never created." | Fails closed; only a retained marker makes repeated finish idempotent. |
-| Unrelated subagent | "While a Gradle warning cleanup runs, start a separate review subagent for another diff." | Permits the unrelated subagent; **gradle-run** governs Gradle output and diagnostics only. |
-
-## Compose state and effects
-
-| Case | Prompt | Expected behavior |
-|---|---|---|
-| Direct | "A composable uses LaunchedEffect(Unit) to collect events for a changing user ID." | Requires an effect key that follows the user ID unless the lifecycle deliberately stays stable. |
-| Effect only | "A long-lived Compose effect calls a callback that can change after recomposition." | Routes to the side-effects reference and uses `rememberUpdatedState` only when the effect should not restart. |
-| Novel | "A search query drives repository suggestions while list and focus runtime objects coordinate the UI." | Keeps query and suggestions with screen state; keeps Compose runtime objects in plain UI state. |
-| Counterexample | "Add a private expansion Boolean to a one-off badge." | Keeps simple state local; does not introduce a state holder or effect. |
-
-## Compose performance
-
-| Case | Prompt | Expected behavior |
-|---|---|---|
-| Direct | "Unchanged lazy rows recompose when focus moves." | Checks cross-phase back-writing before prescribing stability wrappers. |
-| Novel | "A scroll-driven animation value only affects drawing." | Defers the State read to draw or layout rather than passing it through composition. |
-| Counterexample | "The displayed model changed and its row recomposed." | Does not suppress legitimate recomposition with caches or stability ceremony. |
-
-## Compose component design
-
-| Case | Prompt | Expected behavior |
-|---|---|---|
-| Direct | "This reusable row takes a title, icon, Boolean flags, and a trailing action." | Replaces caller-controlled visual variants with appropriate slots and preserves caller placement with a root modifier. |
-| Novel | "A component needs caller-supplied trailing content and a root modifier." | Applies the modifier at the root without leaking internal layout. |
-| Counterexample | "A private helper has one fixed child and no reuse." | Avoids speculative slots and public API ceremony. |
-
-## Kotlin concurrency and Flow
-
-| Case | Prompt | Expected behavior |
-|---|---|---|
-| Direct | "A service stores a CoroutineScope and launches from non-suspending methods." | Requires an explicit lifecycle owner and cancellation boundary. |
-| Novel | "A screen needs replayable loading state and non-replayable navigation." | Separates state and event contracts, including delivery and replay behavior. |
-| Counterexample | "A suspend function is called from an existing caller-owned scope." | Does not create an internal scope just to make the API look asynchronous. |
-
-## Kotlin API design
-
-| Case | Prompt | Expected behavior |
-|---|---|---|
-| Direct | "Add a String extension that fetches a repository record." | Places repository behavior behind a domain owner or service rather than a primitive extension. |
-| Novel | "Shared UI needs a platform permission service." | Preserves a semantic shared contract and puts native SDK work at the platform leaf. |
-| Counterexample | "A helper belongs only to one class." | Keeps it a member instead of introducing a factory or value type for ceremony. |
-
-## Release gate
-
-Before publishing the breaking taxonomy:
-
-1. Run this full matrix.
-2. Record every failure, selected entrypoint, missing safeguard, and correction.
-3. Re-run affected cases after each correction.
-4. Publish only when every case passes and npm run lint, release validation,
-   and the repository's existing test suite are green.
+Record the candidate commit, client/model, selected entrypoints, loaded
+references, and any missing safeguard. Re-run the affected smoke check after a
+router or installer correction. Release only when deterministic validation,
+lint, and the repository test suite pass.


### PR DESCRIPTION
## Summary

- make runtime skill instructions procedural and single-sourced across every public package except `to-plan`
- move RED/GREEN scenario prose into committed evaluation coverage, including a new 12-case workflow/writing suite
- preserve routing, authority, safety, restraint, and finish contracts while removing repeated procedures and reference recaps

`to-plan`, plugin manifests, and versions are unchanged by this branch.

## Impact

- runtime `SKILL.md` entrypoints: 19,517 → 11,749 words (39.8% reduction)
- all non-`to-plan` skill Markdown: 49,496 → 29,960 words (39.5% reduction)
- evaluation corpus: 73 deterministic cases

## Validation

- `npm ci`
- `npm run lint`
- `npm run evals:validate`
- `npm test` — 134 tests passed, 1 skipped
- no-execute evaluation previews: Compose 684 calls planned, Kotlin/Gradle 342, workflows/writing 216
- independent Standards and Spec review: no findings

Live model scoring was not run because current subject and judge per-call cost assumptions were not supplied.