### PR TITLE
Make shepherd fully verify CI failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ See [`.opencode/INSTALL.md`](.opencode/INSTALL.md) for details.
 - [`implement-with-subagents`](skills/implement-with-subagents/SKILL.md) — implement supplied tickets or plan tasks sequentially through separate implementation subagents, requiring the installed `implement` skill and prohibiting controller fallback.
 - [`to-plan`](skills/to-plan/SKILL.md) — create a repository-aware implementation plan from one ready GitHub issue or an in-chat task, with a provider-neutral implementation handoff.
 - [`run-github-project`](skills/run-github-project/SKILL.md) — set up or repair the repository's GitHub Project binding without running work, reconcile epics, surface resumable human checkpoints, triage unblocked Backlog work, and plan and execute authorized issues through one planning lane and a two-slot-by-default parallel pipeline. Optionally routes authorized Wayfinder decision tickets through that planning lane while preserving their map and HITL gates. Requires `tdd` for implementation and preserves human Planning and triage approval gates.
-- [`shepherd`](skills/shepherd/SKILL.md) — autonomously poll open PRs and MRs, triage review comments, detect and fix CI failures, and keep PRs moving forward.
+- [`shepherd`](skills/shepherd/SKILL.md) — autonomously poll open PRs and MRs, triage review comments, and switch CI failures into a full local verification-and-repair cycle.
 
 ### Migration from pre-cluster skills
 

--- a/evals/cases/shepherd-direct/case.json
+++ b/evals/cases/shepherd-direct/case.json
@@ -1,6 +1,6 @@
 {
   "id": "shepherd-direct",
-  "title": "Inspect a failed pull-request check without mutating it",
+  "title": "Plan a full local verification cycle after CI fails",
   "family": "workflow",
   "target_skills": ["shepherd"],
   "expected_skills": ["shepherd"],
@@ -11,8 +11,9 @@
   "forbidden_command_patterns": ["\\b(?:gh|git)\\s+(?:api|issue|pr|project|push|fetch|pull)\\b"],
   "validators": [{"argv": ["python3", "@validators/text_case.py", "shepherd-direct"], "timeout_seconds": 30}],
   "rubric": [
-    {"id": "evidence", "text": "The response separates inspection of a failed check from implementing a repair or publishing a comment"},
-    {"id": "ownership", "text": "The response preserves the existing branch and remote-mutation boundaries while naming the next evidence to gather"}
+    {"id": "full-verification", "text": "The response switches from the failed CI check to the repository's complete locally available CI-equivalent verification before another push, rather than proposing a narrow fix followed by another CI wait"},
+    {"id": "batching", "text": "The response batches the CI repair with every other known actionable item and requires the complete local verification to pass before the single repair push"},
+    {"id": "ownership", "text": "The response preserves the existing branch and remote-mutation boundaries because this evaluation authorizes analysis only"}
   ],
   "provenance": {"kind": "synthetic"}
 }

--- a/evals/cases/shepherd-direct/prompt.md
+++ b/evals/cases/shepherd-direct/prompt.md
@@ -1,2 +1,4 @@
-A pull request has one failed check. Review the next monitoring action using the
-supplied state. Do not query a provider, edit a branch, post a reply, or merge.
+A pull request's lint check failed after a small review-fix push. Another clear
+review request is also waiting. Explain the controller's next repair and
+verification cycle using the supplied state. Do not query a provider, edit a
+branch, post a reply, push, or merge.

--- a/evals/cases/shepherd-novel/case.json
+++ b/evals/cases/shepherd-novel/case.json
@@ -1,6 +1,6 @@
 {
   "id": "shepherd-novel",
-  "title": "Wait after unchanged monitoring state",
+  "title": "Handle a CI failure that cannot be fully reproduced locally",
   "family": "workflow",
   "target_skills": ["shepherd"],
   "expected_skills": ["shepherd"],
@@ -11,8 +11,9 @@
   "forbidden_command_patterns": ["\\b(?:gh|git)\\s+(?:api|issue|pr|project|push|fetch|pull)\\b"],
   "validators": [{"argv": ["python3", "@validators/text_case.py", "shepherd-novel"], "timeout_seconds": 30}],
   "rubric": [
-    {"id": "monitoring", "text": "The response treats unchanged monitoring state as expected and identifies the next bounded poll rather than declaring success"},
-    {"id": "no-mutation", "text": "The response does not manufacture a review, retry, merge, or branch change from stale state"}
+    {"id": "local-boundary", "text": "The response runs every locally available CI-equivalent check and identifies the exact platform-only check that remains unverified; it does not reduce verification to the single failed check"},
+    {"id": "no-ci-loop", "text": "The response does not recommend speculative push-and-wait iterations to diagnose the unavailable platform check"},
+    {"id": "no-mutation", "text": "The response performs no command, retry, merge, comment, or branch change because the supplied state authorizes analysis only"}
   ],
   "provenance": {"kind": "synthetic"}
 }

--- a/evals/cases/shepherd-novel/prompt.md
+++ b/evals/cases/shepherd-novel/prompt.md
@@ -1,3 +1,4 @@
-Two consecutive monitoring polls show unchanged pending checks. Review the
-correct next action from the immutable state. Do not run a polling command or
-perform any local or remote mutation.
+A pull request's macOS check failed after a minor fix. The failure may be
+code-related, but that exact check cannot run on this Linux workstation. Explain
+the verification boundary and the next repair cycle from the immutable state.
+Do not run a command or perform any local or remote mutation.

--- a/skills/shepherd/SKILL.md
+++ b/skills/shepherd/SKILL.md
@@ -9,7 +9,9 @@ description: "Use when asked to shepherd, babysit, monitor, or poll open pull re
 
 Keep an authorized PR or MR moving with evidence, not noise: poll, act on new
 actionable items, batch each target's local fixes into one push, then resolve
-addressed threads. Never merge without explicit authority.
+addressed threads. After a code-related CI failure, use full local verification
+as the repair loop and CI only as confirmation. Never merge without explicit
+authority.
 
 Do not start persistent polling for a one-off inspection, no open targets, or an action requiring human judgment; report the state and stop.
 
@@ -34,14 +36,18 @@ Do not start persistent polling for a one-off inspection, no open targets, or an
    Escalate architectural or contradictory feedback, unfamiliar failures,
    non-obvious fixes, and out-of-scope conflicts. GitLab manual jobs are
    non-blocking unless instructed otherwise.
-6. Handle each target in its own head checkout. Batch and validate its fixes,
-   then push once. Reply after an addressed change or answer; resolve a thread
-   only after its reply and required push succeed. Do not combine heads, push
-   after every comment, resolve a local-only fix, or comment when nothing changed.
-7. Recheck CI after a push. For a clear failure, inspect evidence, make or verify
-   the narrow fix, and repeat step 6. Retry a suspected flaky GitLab job once;
-   report a second failure. Poll pending checks every 2–5 minutes, active repair
-   every 30–60 seconds, and after several unchanged cycles every 10+ minutes.
+6. Handle each target in its own head checkout and batch every known actionable
+   item. Until a code-related CI failure, validate proportionately. After one,
+   inspect its evidence, run every locally available CI-equivalent check, fix all
+   failures, and rerun the full local suite before one repair push. Report exact
+   checks unavailable locally instead of using CI as an iterative test runner.
+   Reply after an addressed change or answer; resolve its thread only after the reply and required push succeed.
+   Do not combine heads, push after every comment, resolve a local-only fix, or comment when nothing changed.
+7. Recheck CI after the verified repair push; return to step 6 on another
+   code-related failure. Retry a suspected flaky GitLab job once without code
+   changes; report a second failure. Poll pending checks every 2–5 minutes,
+   active repair every 30–60 seconds, and after several unchanged cycles every
+   10+ minutes.
 8. Merge only when requirements and CI are green, conflicts are absent, and the
    user granted explicit or standing merge authority. Do not infer authority from
    approval.


### PR DESCRIPTION
## Summary

- switch `shepherd` from narrow CI-driven repair loops to full locally available CI-equivalent verification after a code-related failure
- batch all discovered repairs into one verified push and report checks unavailable locally
- update the direct and novel evaluation cases plus the README

## Validation

- `npm run lint`
- `npm test` (250 tests, 1 skipped)
- `npm run evals:validate` (73 cases)
- `python3 /Users/chris/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/shepherd`
- `git diff --check`