### PR TITLE
Make advanced workflow skills explicit-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,9 +167,10 @@ may perform differently. These are not merge or release gates. See
 Values are per-run medians, baseline → automatic, followed by the automatic
 percentage change. These subject-only measurements use the latest complete,
 same-run evidence available for each suite and include failed runs and negative
-controls. Multi-skill scenarios contribute to every targeted skill row. A turn
-is one completed Codex turn; time remains environment-sensitive. The source
-runs, selection rules, and detailed scorecards are in the
+controls. Baseline-to-automatic efficiency comparisons use only cases eligible
+for automatic activation. Multi-skill scenarios contribute to every targeted
+skill row. A turn is one completed Codex turn; time remains environment-sensitive.
+The source runs, selection rules, and detailed scorecards are in the
 [evaluation change record](evals/artifacts/2026-08-27-skill-eval-efficiency.md).
 
 | Skill | Tokens / run | Tool calls / run | Turns / run | Time / run |

--- a/README.md
+++ b/README.md
@@ -186,9 +186,6 @@ The source runs, selection rules, and detailed scorecards are in the
 | [`kotlin-concurrency-and-flow`](skills/kotlin-concurrency-and-flow/SKILL.md) | 72.7k → 119.2k (+64%) | 4 → 5 (+25%) | 1 → 1 (+0%) | 46.0s → 64.2s (+40%) |
 | [`kotlin-control-flow`](skills/kotlin-control-flow/SKILL.md) | 71.8k → 109.6k (+53%) | 4 → 5 (+25%) | 1 → 1 (+0%) | 39.1s → 53.7s (+37%) |
 | [`grounded-writing`](skills/grounded-writing/SKILL.md) | 41.3k → 65.4k (+59%) | 2 → 3 (+50%) | 1 → 1 (+0%) | 16.2s → 26.9s (+66%) |
-| [`implement-with-subagents`](skills/implement-with-subagents/SKILL.md) | — | — | — | — |
-| [`run-github-project`](skills/run-github-project/SKILL.md) | — | — | — | — |
-| [`shepherd`](skills/shepherd/SKILL.md) | — | — | — | — |
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ This is a breaking taxonomy change. Replace the removed entrypoints as follows:
 
 Skills live at `skills/<skill-name>/SKILL.md`, flat (no language nesting). The `name:` in the SKILL.md frontmatter must match the directory name.
 
-Frontmatter is validated against [`skills.schema.json`](skills.schema.json) — `name` and `description` are required, `name` must be kebab-case. The router also uses Claude Code's optional `paths` extension. Clients that do not support this extension must ignore the `paths` field rather than rejecting the skill.
+Frontmatter is validated against [`skills.schema.json`](skills.schema.json) — `name` and `description` are required, `name` must be kebab-case, and `disable-model-invocation: true` makes a skill explicit-only. The router also uses Claude Code's optional `paths` extension. Clients that do not support this extension must ignore the `paths` field rather than rejecting the skill.
 
 ### Releases
 
@@ -158,9 +158,9 @@ may perform differently. These are not merge or release gates. See
 | [`kotlin-concurrency-and-flow`](skills/kotlin-concurrency-and-flow/SKILL.md) | 33.3% | 100.0% | 100.0% |
 | [`kotlin-control-flow`](skills/kotlin-control-flow/SKILL.md) | 27.8% | 100.0% | 100.0% |
 | [`grounded-writing`](skills/grounded-writing/SKILL.md) | — | 100.0% | 100.0% |
-| [`implement-with-subagents`](skills/implement-with-subagents/SKILL.md) | — | 100.0% | 100.0% |
-| [`run-github-project`](skills/run-github-project/SKILL.md) | — | 100.0% | 100.0% |
-| [`shepherd`](skills/shepherd/SKILL.md) | — | 100.0% | 100.0% |
+| [`implement-with-subagents`](skills/implement-with-subagents/SKILL.md) | — | — | 100.0% |
+| [`run-github-project`](skills/run-github-project/SKILL.md) | — | — | 100.0% |
+| [`shepherd`](skills/shepherd/SKILL.md) | — | — | 100.0% |
 
 ### Skill efficiency
 
@@ -185,9 +185,9 @@ runs, selection rules, and detailed scorecards are in the
 | [`kotlin-concurrency-and-flow`](skills/kotlin-concurrency-and-flow/SKILL.md) | 72.7k → 119.2k (+64%) | 4 → 5 (+25%) | 1 → 1 (+0%) | 46.0s → 64.2s (+40%) |
 | [`kotlin-control-flow`](skills/kotlin-control-flow/SKILL.md) | 71.8k → 109.6k (+53%) | 4 → 5 (+25%) | 1 → 1 (+0%) | 39.1s → 53.7s (+37%) |
 | [`grounded-writing`](skills/grounded-writing/SKILL.md) | 41.3k → 65.4k (+59%) | 2 → 3 (+50%) | 1 → 1 (+0%) | 16.2s → 26.9s (+66%) |
-| [`implement-with-subagents`](skills/implement-with-subagents/SKILL.md) | 40.9k → 50.9k (+24%) | 2 → 2 (+0%) | 1 → 1 (+0%) | 23.7s → 25.9s (+9%) |
-| [`run-github-project`](skills/run-github-project/SKILL.md) | 41.6k → 59.0k (+42%) | 2 → 3 (+50%) | 1 → 1 (+0%) | 25.0s → 24.1s (-3%) |
-| [`shepherd`](skills/shepherd/SKILL.md) | 51.8k → 74.3k (+43%) | 3 → 4 (+33%) | 1 → 1 (+0%) | 21.8s → 30.2s (+38%) |
+| [`implement-with-subagents`](skills/implement-with-subagents/SKILL.md) | — | — | — | — |
+| [`run-github-project`](skills/run-github-project/SKILL.md) | — | — | — | — |
+| [`shepherd`](skills/shepherd/SKILL.md) | — | — | — | — |
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ may perform differently. These are not merge or release gates. See
 | [`implement-with-subagents`](skills/implement-with-subagents/SKILL.md) | — | — | 100.0% |
 | [`run-github-project`](skills/run-github-project/SKILL.md) | — | — | 100.0% |
 | [`shepherd`](skills/shepherd/SKILL.md) | — | — | 100.0% |
+| [`to-plan`](skills/to-plan/SKILL.md) | — | — | — |
 
 ### Skill efficiency
 

--- a/README.md
+++ b/README.md
@@ -131,9 +131,9 @@ agent-facing seam.
 
 The advisory evaluator tests concrete scenarios modelled on real-world coding
 work, with expected outcomes and no-change controls. It compares no-skill,
-forced-skill, and automatic-routing runs. **Baseline** is the no-skill result,
-**automatic** is the headline result, and **restraint** checks that a skill does
-not make an unnecessary change. Scorecards also compare subject-side tokens,
+forced-skill, and automatic-routing runs. **Baseline** and **automatic** use
+the cases eligible for automatic activation; **restraint** checks that a skill
+does not make an unnecessary change. Scorecards also compare subject-side tokens,
 tool calls, completed turns, elapsed time, and total attempted work per
 successful outcome. The
 table reports the latest available result for each skill and correctness metric.

--- a/evals/README.md
+++ b/evals/README.md
@@ -88,9 +88,6 @@ The source runs, selection rules, and detailed scorecards are in the
 | `kotlin-concurrency-and-flow` | 72.7k → 119.2k (+64%) | 4 → 5 (+25%) | 1 → 1 (+0%) | 46.0s → 64.2s (+40%) |
 | `kotlin-control-flow` | 71.8k → 109.6k (+53%) | 4 → 5 (+25%) | 1 → 1 (+0%) | 39.1s → 53.7s (+37%) |
 | `grounded-writing` | 41.3k → 65.4k (+59%) | 2 → 3 (+50%) | 1 → 1 (+0%) | 16.2s → 26.9s (+66%) |
-| `implement-with-subagents` | — | — | — | — |
-| `run-github-project` | — | — | — | — |
-| `shepherd` | — | — | — | — |
 
 ## Evaluation setup
 

--- a/evals/README.md
+++ b/evals/README.md
@@ -4,10 +4,10 @@ This directory contains a reproducible, advisory evaluator with a shared core
 and suite-specific catalogs, fixtures, coverage rules, and safety policies. It
 tests concrete scenarios modelled on real-world coding work, with expected
 outcomes, allowed-write boundaries, and no-change controls. The committed suites
-cover six Compose skills, four Kotlin/Gradle skills, and four workflow/writing
+cover six Compose skills, four Kotlin/Gradle skills, and five workflow/writing
 skills: `grounded-writing`, `implement-with-subagents`,
-`run-github-project`, and `shepherd`. It is designed to answer three separate
-questions:
+`run-github-project`, `shepherd`, and `to-plan`. It is designed to answer three
+separate questions:
 
 1. Does a skill improve the correctness and restraint of the resulting work?
 2. Does automatic activation report the expected implicitly invokable public skill entrypoints?
@@ -63,6 +63,7 @@ suite-wide aggregate.
 | `implement-with-subagents` | — | — | 100.0% |
 | `run-github-project` | — | — | 100.0% |
 | `shepherd` | — | — | 100.0% |
+| `to-plan` | — | — | — |
 
 ### Skill efficiency
 
@@ -110,8 +111,8 @@ Each eligible `case × arm` condition runs three times by default. A case that
 targets no implicitly invokable skill is excluded from the automatic arm before
 execution. The 38-case Compose suite schedules 342 subject calls and 342
 blinded judge calls. The 19-case Kotlin/Gradle suite schedules 171 subject calls
-and 171 blinded judge calls. The 12-case workflows/writing suite schedules 81
-subject calls and 81 blinded judge calls.
+and 171 blinded judge calls. The 15-case workflows/writing suite schedules 99
+subject calls and 99 blinded judge calls.
 
 All subject and judge processes use `--ignore-user-config`, explicit
 `skills.config` entries, network-disabled sandboxes, disabled hosted web search,
@@ -166,8 +167,8 @@ The Kotlin/Gradle benchmark contains 19 scored cases:
 - three immutable public-source snapshots across API, Flow, and control-flow
   concerns.
 
-The workflows/writing benchmark contains 12 scored cases: direct, novel, and
-no-change coverage for each of its four skills. Its GitHub-style cases use
+The workflows/writing benchmark contains 15 scored cases: direct, novel, and
+no-change coverage for each of its five skills. Its GitHub-style cases use
 supplied immutable state and rubric plus forbidden-action grading; they do not
 contact a provider. Only `implement-with-subagents` declares the evaluator-owned
 `implement` fixture dependency, because that prerequisite is constant across its

--- a/evals/README.md
+++ b/evals/README.md
@@ -10,7 +10,7 @@ skills: `grounded-writing`, `implement-with-subagents`,
 questions:
 
 1. Does a skill improve the correctness and restraint of the resulting work?
-2. Does automatic activation report the expected public skill entrypoints?
+2. Does automatic activation report the expected implicitly invokable public skill entrypoints?
 3. What subject-side token, tool-call, and wall-clock cost does each arm require?
 
 The evaluator never turns a stochastic model score into a merge or release
@@ -30,8 +30,9 @@ corpus, and execution conditions are held constant.
 ## Results
 
 **Baseline** is the positive-case pass rate with no skills available.
-**Automatic** is the positive-case pass rate with every repository skill
-available but none named in the prompt. **Restraint** is the no-change-control
+**Automatic** is the positive-case pass rate with every implicitly invokable
+repository skill available but none named in the prompt. Explicit-only skills
+are measured only in forced runs, including their no-change controls. **Restraint** is the no-change-control
 pass rate: the skill may inspect the task, but must not make an unnecessary
 change. The table reports the latest available result for each skill and
 correctness metric. These scores were produced using
@@ -58,9 +59,9 @@ suite-wide aggregate.
 | `kotlin-concurrency-and-flow` | 33.3% | 100.0% | 100.0% |
 | `kotlin-control-flow` | 27.8% | 100.0% | 100.0% |
 | `grounded-writing` | — | 100.0% | 100.0% |
-| `implement-with-subagents` | — | 100.0% | 100.0% |
-| `run-github-project` | — | 100.0% | 100.0% |
-| `shepherd` | — | 100.0% | 100.0% |
+| `implement-with-subagents` | — | — | 100.0% |
+| `run-github-project` | — | — | 100.0% |
+| `shepherd` | — | — | 100.0% |
 
 ### Skill efficiency
 
@@ -85,9 +86,9 @@ runs, selection rules, and detailed scorecards are in the
 | `kotlin-concurrency-and-flow` | 72.7k → 119.2k (+64%) | 4 → 5 (+25%) | 1 → 1 (+0%) | 46.0s → 64.2s (+40%) |
 | `kotlin-control-flow` | 71.8k → 109.6k (+53%) | 4 → 5 (+25%) | 1 → 1 (+0%) | 39.1s → 53.7s (+37%) |
 | `grounded-writing` | 41.3k → 65.4k (+59%) | 2 → 3 (+50%) | 1 → 1 (+0%) | 16.2s → 26.9s (+66%) |
-| `implement-with-subagents` | 40.9k → 50.9k (+24%) | 2 → 2 (+0%) | 1 → 1 (+0%) | 23.7s → 25.9s (+9%) |
-| `run-github-project` | 41.6k → 59.0k (+42%) | 2 → 3 (+50%) | 1 → 1 (+0%) | 25.0s → 24.1s (-3%) |
-| `shepherd` | 51.8k → 74.3k (+43%) | 3 → 4 (+33%) | 1 → 1 (+0%) | 21.8s → 30.2s (+38%) |
+| `implement-with-subagents` | — | — | — | — |
+| `run-github-project` | — | — | — | — |
+| `shepherd` | — | — | — | — |
 
 ## Evaluation setup
 
@@ -102,9 +103,9 @@ Every case runs in a fresh workspace and conversation under three arms:
 - `forced` enables and explicitly invokes only the case's target skill or
   skills. Negative controls still force the target so over-application remains
   observable.
-- `automatic` enables all 16 public repository skills without naming any skill
-  in the task prompt. This measures cross-domain routing interference as well as
-  target-skill activation.
+- `automatic` enables every public repository skill whose frontmatter and
+  metadata permit implicit invocation, without naming a skill in the task prompt. This measures
+  cross-domain routing interference and automatic target-skill activation.
 
 Each `case × arm` condition runs three times by default. The 38-case Compose
 suite schedules 342 subject calls and 342 blinded judge calls. The 19-case

--- a/evals/README.md
+++ b/evals/README.md
@@ -107,11 +107,12 @@ Every case runs in a fresh workspace and conversation under three arms:
   metadata permit implicit invocation, without naming a skill in the task prompt. This measures
   cross-domain routing interference and automatic target-skill activation.
 
-Each `case × arm` condition runs three times by default. The 38-case Compose
-suite schedules 342 subject calls and 342 blinded judge calls. The 19-case
-Kotlin/Gradle suite schedules 171 subject calls and 171 blinded judge calls.
-The 12-case workflows/writing suite schedules 108 subject calls and 108 blinded
-judge calls.
+Each eligible `case × arm` condition runs three times by default. A case that
+targets no implicitly invokable skill is excluded from the automatic arm before
+execution. The 38-case Compose suite schedules 342 subject calls and 342
+blinded judge calls. The 19-case Kotlin/Gradle suite schedules 171 subject calls
+and 171 blinded judge calls. The 12-case workflows/writing suite schedules 81
+subject calls and 81 blinded judge calls.
 
 All subject and judge processes use `--ignore-user-config`, explicit
 `skills.config` entries, network-disabled sandboxes, disabled hosted web search,

--- a/evals/README.md
+++ b/evals/README.md
@@ -69,9 +69,10 @@ suite-wide aggregate.
 Values are per-run medians, baseline → automatic, followed by the automatic
 percentage change. These subject-only measurements use the latest complete,
 same-run evidence available for each suite and include failed runs and negative
-controls. Multi-skill scenarios contribute to every targeted skill row. A turn
-is one completed Codex turn; time remains environment-sensitive. The source
-runs, selection rules, and detailed scorecards are in the
+controls. Baseline-to-automatic efficiency comparisons use only cases eligible
+for automatic activation. Multi-skill scenarios contribute to every targeted
+skill row. A turn is one completed Codex turn; time remains environment-sensitive.
+The source runs, selection rules, and detailed scorecards are in the
 [evaluation change record](artifacts/2026-08-27-skill-eval-efficiency.md).
 
 | Skill | Tokens / run | Tool calls / run | Turns / run | Time / run |
@@ -292,6 +293,10 @@ python3 evals/run.py judge \
   --output-dir .scratch/skill-evals/<run-id> \
   --judge-model gpt-5.6-sol --judge-reasoning high
 ```
+
+It reconciles raw records with the current corpus first, then plans and
+rejudges only measured packets; automatic records that are now ineligible are
+left untouched.
 
 After all rejudgments complete, build a separate scorecard that combines those
 verdicts with the immutable subject and deterministic-grading evidence:

--- a/evals/README.md
+++ b/evals/README.md
@@ -29,12 +29,13 @@ corpus, and execution conditions are held constant.
 
 ## Results
 
-**Baseline** is the positive-case pass rate with no skills available.
-**Automatic** is the positive-case pass rate with every implicitly invokable
-repository skill available but none named in the prompt. Explicit-only skills
-are measured only in forced runs, including their no-change controls. **Restraint** is the no-change-control
-pass rate: the skill may inspect the task, but must not make an unnecessary
-change. The table reports the latest available result for each skill and
+**Baseline** is the positive-case pass rate with no skills available, restricted
+to cases eligible for automatic activation. **Automatic** is the matching
+positive-case pass rate with every implicitly invokable repository skill
+available but none named in the prompt. Explicit-only skills are measured only
+in forced runs, including their no-change controls. **Restraint** is the
+no-change-control pass rate: the skill may inspect the task, but must not make
+an unnecessary change. The table reports the latest available result for each skill and
 correctness metric. These scores were produced using
 [`gpt-5.6-terra`](https://developers.openai.com/api/docs/models/gpt-5.6-terra)
 with medium reasoning, judged by

--- a/evals/cases/to-plan-direct/case.json
+++ b/evals/cases/to-plan-direct/case.json
@@ -1,0 +1,18 @@
+{
+  "id": "to-plan-direct",
+  "title": "Confirm a complete conversation planning contract",
+  "family": "workflow",
+  "target_skills": ["to-plan"],
+  "expected_skills": ["to-plan"],
+  "task_mode": "review",
+  "kind": "direct",
+  "fixture": "workflow",
+  "allowed_write_paths": [],
+  "forbidden_command_patterns": ["\\b(?:gh|git)\\s+(?:api|issue|pr|project|push|fetch|pull)\\b"],
+  "validators": [{"argv": ["python3", "@validators/text_case.py", "to-plan-direct"], "timeout_seconds": 30}],
+  "rubric": [
+    {"id": "confirmation", "text": "The response gathers the missing planning-contract information one decision at a time and requires a confirmed self-contained summary before drafting"},
+    {"id": "no-draft", "text": "The response does not draft or write a plan before the conversation source is confirmed"}
+  ],
+  "provenance": {"kind": "synthetic"}
+}

--- a/evals/cases/to-plan-direct/expectations.json
+++ b/evals/cases/to-plan-direct/expectations.json
@@ -1,0 +1,1 @@
+{"files": ["state.md"], "must_contain": ["Immutable evaluation state", "Network access is disabled"]}

--- a/evals/cases/to-plan-direct/prompt.md
+++ b/evals/cases/to-plan-direct/prompt.md
@@ -1,0 +1,4 @@
+The user asks for an implementation plan for the current task: make validator
+failures name the missing file. No confirmed planning summary, acceptance
+criteria, or constraints are supplied. Review the next safe action only. Do not
+write a plan, edit files, or contact a provider.

--- a/evals/cases/to-plan-negative/case.json
+++ b/evals/cases/to-plan-negative/case.json
@@ -1,0 +1,18 @@
+{
+  "id": "to-plan-negative",
+  "title": "Do not turn an incidental issue link into planning work",
+  "family": "workflow",
+  "target_skills": ["to-plan"],
+  "expected_skills": ["to-plan"],
+  "task_mode": "review",
+  "kind": "negative",
+  "fixture": "workflow",
+  "allowed_write_paths": [],
+  "forbidden_command_patterns": ["\\b(?:gh|git)\\s+(?:api|issue|pr|project|push|fetch|pull)\\b"],
+  "validators": [{"argv": ["python3", "@validators/text_case.py", "to-plan-negative"], "timeout_seconds": 30}],
+  "rubric": [
+    {"id": "restraint", "text": "The response leaves planning inactive when an issue link is incidental to a non-planning review request"},
+    {"id": "preservation", "text": "The response does not draft, publish, or mutate a plan or repository state"}
+  ],
+  "provenance": {"kind": "synthetic"}
+}

--- a/evals/cases/to-plan-negative/expectations.json
+++ b/evals/cases/to-plan-negative/expectations.json
@@ -1,0 +1,1 @@
+{"files": ["state.md"], "must_contain": ["Immutable evaluation state", "Network access is disabled"]}

--- a/evals/cases/to-plan-negative/prompt.md
+++ b/evals/cases/to-plan-negative/prompt.md
@@ -1,0 +1,4 @@
+Review a release-note sentence that links to owner/repository#17 as background.
+The user asks only whether the wording says that no execution contract is
+needed. Do not treat the link as a planning request, edit files, or contact a
+provider.

--- a/evals/cases/to-plan-novel/case.json
+++ b/evals/cases/to-plan-novel/case.json
@@ -1,0 +1,18 @@
+{
+  "id": "to-plan-novel",
+  "title": "Resolve competing issue sources before planning",
+  "family": "workflow",
+  "target_skills": ["to-plan"],
+  "expected_skills": ["to-plan"],
+  "task_mode": "review",
+  "kind": "novel",
+  "fixture": "workflow",
+  "allowed_write_paths": [],
+  "forbidden_command_patterns": ["\\b(?:gh|git)\\s+(?:api|issue|pr|project|push|fetch|pull)\\b"],
+  "validators": [{"argv": ["python3", "@validators/text_case.py", "to-plan-novel"], "timeout_seconds": 30}],
+  "rubric": [
+    {"id": "source-selection", "text": "The response asks the user to choose between the two issue sources before inspection or drafting"},
+    {"id": "no-inference", "text": "The response does not infer which issue is the planning target or mutate either source"}
+  ],
+  "provenance": {"kind": "synthetic"}
+}

--- a/evals/cases/to-plan-novel/expectations.json
+++ b/evals/cases/to-plan-novel/expectations.json
@@ -1,0 +1,1 @@
+{"files": ["state.md"], "must_contain": ["Immutable evaluation state", "controller owns"]}

--- a/evals/cases/to-plan-novel/prompt.md
+++ b/evals/cases/to-plan-novel/prompt.md
@@ -1,0 +1,3 @@
+The user asks for an execution contract covering both #17 and #29, but gives no
+relationship between them. Review the next safe action using only the supplied
+state. Do not query a provider, draft a plan, or modify local files.

--- a/evals/harness/codex.py
+++ b/evals/harness/codex.py
@@ -113,6 +113,25 @@ def discover_skill_paths(
     return tuple(sorted(candidates, key=str))
 
 
+def automatically_invokable_public_skills(repo_root: Path) -> tuple[str, ...]:
+    """Return public skills whose frontmatter and metadata permit invocation."""
+    implicitly_invokable = []
+    for skill in PUBLIC_SKILLS:
+        skill_dir = repo_root / "skills" / skill
+        metadata = skill_dir / "agents" / "openai.yaml"
+        frontmatter = (skill_dir / "SKILL.md").read_text(encoding="utf-8").partition(
+            "\n---\n"
+        )[0]
+        is_explicit_only = "disable-model-invocation: true" in frontmatter or (
+            metadata.is_file()
+            and "allow_implicit_invocation: false"
+            in metadata.read_text(encoding="utf-8")
+        )
+        if not is_explicit_only:
+            implicitly_invokable.append(skill)
+    return tuple(implicitly_invokable)
+
+
 def is_generated_skill_path(path: Path, skill_root: Path) -> bool:
     relative = path.relative_to(skill_root)
     return "__pycache__" in relative.parts or (
@@ -129,13 +148,15 @@ def _ignore_generated_skill_paths(directory: str, names: list[str]) -> list[str]
     ]
 
 
-def _enabled_skills(case: EvalCase, arm: str) -> tuple[str, ...]:
+def _enabled_skills(
+    case: EvalCase, arm: str, repo_root: Path
+) -> tuple[str, ...]:
     if arm == "none":
         return ()
     if arm == "forced":
         return case.target_skills
     if arm == "automatic":
-        return PUBLIC_SKILLS
+        return automatically_invokable_public_skills(repo_root)
     raise ValueError(f"unknown arm: {arm}")
 
 
@@ -154,7 +175,7 @@ def _skill_config(
         raise ValueError(f"unknown arm: {arm}")
     enabled = {
         _workspace_skill_path(workspace, skill)
-        for skill in _enabled_skills(case, arm)
+        for skill in _enabled_skills(case, arm, repo_root)
     }
     enabled.update(
         _workspace_skill_path(workspace, skill) for skill in case.constant_skills
@@ -386,7 +407,7 @@ def run_subject(
         case,
         repo_root,
         workspace,
-        enabled_skills=_enabled_skills(case, arm),
+        enabled_skills=_enabled_skills(case, arm, repo_root),
     )
     command = build_subject_command(
         case,

--- a/evals/harness/experiment.py
+++ b/evals/harness/experiment.py
@@ -40,7 +40,7 @@ from evals.harness.results import (
     run_with_one_retry,
     write_result,
 )
-from evals.harness.score import compute_scorecard
+from evals.harness.score import compute_scorecard, is_measured_in_arm
 from evals.harness.suites import PUBLIC_SKILLS, ROUTER_SKILL, suite_for_skills
 
 
@@ -663,6 +663,8 @@ def write_rejudged_reports(
 
     rejudged: list[dict[str, Any]] = []
     for original in records:
+        if not is_measured_in_arm(original, str(original.get("arm"))):
+            continue
         fingerprint = original.get("fingerprint")
         repetition = original.get("repetition")
         if not isinstance(fingerprint, str) or not isinstance(repetition, int):
@@ -713,9 +715,37 @@ def rejudge_packets(
     *,
     execute: bool,
     codex_executable: str = "codex",
+    records: Iterable[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
-    packets = sorted((output_dir / "judge-packets").glob("*.json"))
-    plan = {"packet_count": len(packets), "judge_calls": len(packets), "execute": execute}
+    all_packets = sorted((output_dir / "judge-packets").glob("*.json"))
+    packets = all_packets
+    if records is not None:
+        eligible_packets: set[tuple[str, int]] = set()
+        for record in records:
+            if not is_measured_in_arm(record, str(record.get("arm"))):
+                continue
+            fingerprint = record.get("fingerprint")
+            repetition = record.get("repetition")
+            if not isinstance(fingerprint, str) or not isinstance(repetition, int):
+                raise ValueError(
+                    f"record lacks fingerprint or repetition: {record.get('id')}"
+                )
+            eligible_packets.add((fingerprint[:20], repetition))
+        packets = []
+        for packet_path in all_packets:
+            try:
+                _, fingerprint_prefix, repetition = packet_path.stem.rsplit("-", 2)
+                key = (fingerprint_prefix, int(repetition))
+            except ValueError as error:
+                raise ValueError(f"invalid judge packet filename: {packet_path}") from error
+            if key in eligible_packets:
+                packets.append(packet_path)
+    plan = {
+        "packet_count": len(packets),
+        "skipped_packet_count": len(all_packets) - len(packets),
+        "judge_calls": len(packets),
+        "execute": execute,
+    }
     if not execute:
         return plan
     codex_version = _command_output([codex_executable, "--version"], cwd=repo_root)

--- a/evals/harness/experiment.py
+++ b/evals/harness/experiment.py
@@ -14,6 +14,7 @@ from evals.harness.codex import (
     ARMS,
     RunConfig,
     SubjectResult,
+    automatically_invokable_public_skills,
     completed_turn_count,
     completed_tool_call_count,
     discover_skill_paths,
@@ -51,6 +52,22 @@ RUN_CONTROL_FIELDS = (
     "subject_model",
     "judge_model",
 )
+
+
+def _routing_expectations(
+    case: EvalCase, arm: str, repo_root: Path
+) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    if arm != "automatic":
+        return case.expected_skills, case.allowed_skills or case.expected_skills
+    automatic_skills = set(automatically_invokable_public_skills(repo_root))
+    return (
+        tuple(skill for skill in case.expected_skills if skill in automatic_skills),
+        tuple(
+            skill
+            for skill in (case.allowed_skills or case.expected_skills)
+            if skill in automatic_skills
+        ),
+    )
 
 
 def filter_cases(
@@ -250,8 +267,10 @@ def _result_payload(
     skill_paths: tuple[Path, ...],
     skill_sources: tuple[Path, ...],
     skill_catalog_digest: str,
+    repo_root: Path,
 ) -> dict[str, Any]:
     reported = reported_skill_names(subject.final_output)
+    expected_skills, allowed_skills = _routing_expectations(case, arm, repo_root)
     judge_pass = judge.returncode == 0 and judge_passes_rubric(
         judge.output, case.rubric
     )
@@ -279,8 +298,9 @@ def _result_payload(
         "task_mode": case.task_mode,
         "suite": suite_for_skills(case.target_skills).id,
         "target_skills": list(case.target_skills),
-        "expected_skills": list(case.expected_skills),
-        "allowed_skills": list(case.allowed_skills or case.expected_skills),
+        "expected_skills": list(expected_skills),
+        "allowed_skills": list(allowed_skills),
+        "automatic_eligible": arm != "automatic" or bool(expected_skills),
         "reported_skills": [skill for skill in reported if skill != ROUTER_SKILL],
         "reported_router": ROUTER_SKILL in reported,
         "objective_pass": grade.objective_pass,
@@ -436,6 +456,7 @@ def execute_experiment(
                     skill_paths=skill_paths,
                     skill_sources=skill_sources,
                     skill_catalog_digest=skill_catalog_digest,
+                    repo_root=repo_root,
                 )
                 write_result(result_path, fingerprint, payload)
                 records.append(payload)
@@ -536,8 +557,14 @@ def regrade_records(
             raise ValueError(f"unknown case in raw record: {case_id}")
         case = by_id[case_id]
         grade = grade_subject(case, _subject_result_from_record(record, output_dir))
-        record["expected_skills"] = list(case.expected_skills)
-        record["allowed_skills"] = list(case.allowed_skills or case.expected_skills)
+        expected_skills, allowed_skills = _routing_expectations(
+            case, str(record.get("arm")), repo_root
+        )
+        record["expected_skills"] = list(expected_skills)
+        record["allowed_skills"] = list(allowed_skills)
+        record["automatic_eligible"] = (
+            str(record.get("arm")) != "automatic" or bool(expected_skills)
+        )
         record["objective_pass"] = grade.objective_pass
         record["forbidden_action_failure"] = grade.forbidden_action_failure
         record["objective_failures"] = list(grade.objective_failures)

--- a/evals/harness/experiment.py
+++ b/evals/harness/experiment.py
@@ -70,6 +70,47 @@ def _routing_expectations(
     )
 
 
+def evaluation_conditions(
+    repo_root: Path, cases: Iterable[EvalCase], arms: Iterable[str]
+) -> tuple[tuple[EvalCase, str], ...]:
+    """Return only case and arm pairs that produce a measured result."""
+    return tuple(
+        (case, arm)
+        for case in cases
+        for arm in arms
+        if arm != "automatic" or bool(_routing_expectations(case, arm, repo_root)[0])
+    )
+
+
+def _apply_routing_expectations(
+    record: dict[str, Any], case: EvalCase, repo_root: Path
+) -> None:
+    expected_skills, allowed_skills = _routing_expectations(
+        case, str(record.get("arm")), repo_root
+    )
+    record["expected_skills"] = list(expected_skills)
+    record["allowed_skills"] = list(allowed_skills)
+    record["automatic_eligible"] = (
+        str(record.get("arm")) != "automatic" or bool(expected_skills)
+    )
+
+
+def reconcile_automatic_eligibility(
+    repo_root: Path, cases: Iterable[EvalCase], records: Iterable[dict[str, Any]]
+) -> None:
+    """Recompute automatic routing for legacy records against the current corpus."""
+    by_id = {case.id: case for case in cases}
+    for record in records:
+        if str(record.get("arm")) != "automatic":
+            continue
+        case = by_id.get(str(record.get("case_id")))
+        if case is None:
+            # A record outside the current corpus cannot establish automatic routing.
+            record["automatic_eligible"] = False
+            continue
+        _apply_routing_expectations(record, case, repo_root)
+
+
 def filter_cases(
     cases: Iterable[EvalCase], *, case_ids: list[str] | None, skills: list[str] | None
 ) -> list[EvalCase]:
@@ -93,6 +134,7 @@ def filter_cases(
 
 
 def experiment_plan(
+    repo_root: Path,
     cases: list[EvalCase],
     *,
     arms: list[str],
@@ -105,7 +147,8 @@ def experiment_plan(
     subject_cost_per_call_usd: float | None = None,
     judge_cost_per_call_usd: float | None = None,
 ) -> dict[str, Any]:
-    subject_calls = len(cases) * len(arms) * repetitions
+    conditions = evaluation_conditions(repo_root, cases, arms)
+    subject_calls = len(conditions) * repetitions
     estimated_cost = (
         subject_calls * subject_cost_per_call_usd
         + subject_calls * judge_cost_per_call_usd
@@ -115,6 +158,7 @@ def experiment_plan(
     )
     return {
         "case_count": len(cases),
+        "condition_count": len(conditions),
         "case_ids": [case.id for case in cases],
         "arms": arms,
         "repetitions": repetitions,
@@ -348,6 +392,9 @@ def execute_experiment(
     codex_executable: str = "codex",
     audit_seed: int = 20260816,
 ) -> dict[str, Path]:
+    conditions = evaluation_conditions(repo_root, cases, arms)
+    if not conditions:
+        return write_reports(output_dir, [], compute_scorecard([]), seed=audit_seed)
     codex_version, skill_sha = preflight(repo_root, codex_executable, cases)
     skill_paths = discover_skill_paths(repo_root)
     skill_sources = _skill_source_paths(repo_root)
@@ -355,111 +402,110 @@ def execute_experiment(
         tuple(sorted({*skill_paths, *skill_sources}, key=str))
     )
     records: list[dict[str, Any]] = []
-    for case in cases:
-        for arm in arms:
-            for repetition in range(1, repetitions + 1):
-                fingerprint = result_fingerprint(
-                    case_digest=_case_digest(case),
-                    arm=arm,
-                    skill_sha=skill_sha,
-                    codex_version=codex_version,
-                    model=run_config.model,
-                    reasoning=run_config.reasoning,
-                    judge_model=judge_config.model,
-                    judge_reasoning=judge_config.reasoning,
-                    skill_catalog_digest=skill_catalog_digest,
+    for case, arm in conditions:
+        for repetition in range(1, repetitions + 1):
+            fingerprint = result_fingerprint(
+                case_digest=_case_digest(case),
+                arm=arm,
+                skill_sha=skill_sha,
+                codex_version=codex_version,
+                model=run_config.model,
+                reasoning=run_config.reasoning,
+                judge_model=judge_config.model,
+                judge_reasoning=judge_config.reasoning,
+                skill_catalog_digest=skill_catalog_digest,
+            )
+            result_path = output_dir / "raw" / case.id / arm / f"{repetition}.json"
+            if result_path.is_file():
+                records.append(load_result(result_path, fingerprint))
+                continue
+
+            def run_subject_attempt() -> SubjectResult:
+                condition_dir = (
+                    output_dir
+                    / "workspaces"
+                    / case.id
+                    / arm
+                    / str(repetition)
                 )
-                result_path = output_dir / "raw" / case.id / arm / f"{repetition}.json"
-                if result_path.is_file():
-                    records.append(load_result(result_path, fingerprint))
-                    continue
-
-                def run_subject_attempt() -> SubjectResult:
-                    condition_dir = (
-                        output_dir
-                        / "workspaces"
-                        / case.id
-                        / arm
-                        / str(repetition)
-                    )
-                    workspace = next_attempt_workspace(condition_dir)
-                    return run_subject(
-                        case,
-                        arm,
-                        repo_root,
-                        workspace,
-                        run_config,
-                        codex_executable=codex_executable,
-                        skill_paths=skill_paths,
-                    )
-
-                subject_attempts: list[SubjectResult] = []
-
-                def recorded_subject_attempt() -> SubjectResult:
-                    result = run_subject_attempt()
-                    subject_attempts.append(result)
-                    return result
-
-                subject, subject_retries = run_with_one_retry(
-                    recorded_subject_attempt,
-                    lambda result: result.returncode != 0
-                    or not subject_output_valid(result.final_output),
-                )
-                grade = grade_subject(case, subject)
-                packet = build_judge_packet(case, subject, grade)
-                packet_path = _judge_packet_path(
-                    output_dir,
-                    str(packet["candidate_id"]),
-                    fingerprint,
-                    repetition,
-                )
-                packet_path.parent.mkdir(parents=True, exist_ok=True)
-                packet_path.write_text(
-                    json.dumps(packet, indent=2, sort_keys=True) + "\n", encoding="utf-8"
-                )
-
-                judge_attempts: list[JudgeResult] = []
-
-                def run_judge_attempt() -> JudgeResult:
-                    result = run_judge(
-                        packet_path,
-                        repo_root,
-                        judge_config,
-                        codex_executable=codex_executable,
-                        skill_paths=skill_paths,
-                    )
-                    judge_attempts.append(result)
-                    return result
-
-                judge, judge_retries = run_with_one_retry(
-                    run_judge_attempt,
-                    lambda result: _judge_retryable(result)
-                    or not judge_covers_rubric(result.output, case.rubric),
-                )
-                payload = _result_payload(
+                workspace = next_attempt_workspace(condition_dir)
+                return run_subject(
                     case,
                     arm,
-                    repetition,
-                    subject,
-                    grade,
-                    judge,
-                    subject_attempts=subject_attempts,
-                    judge_attempts=judge_attempts,
-                    subject_retries=subject_retries,
-                    judge_retries=judge_retries,
-                    codex_version=codex_version,
-                    skill_sha=skill_sha,
-                    case_digest=_case_digest(case),
-                    fingerprint=fingerprint,
-                    run_config=run_config,
-                    judge_config=judge_config,
+                    repo_root,
+                    workspace,
+                    run_config,
+                    codex_executable=codex_executable,
                     skill_paths=skill_paths,
-                    skill_sources=skill_sources,
-                    skill_catalog_digest=skill_catalog_digest,
-                    repo_root=repo_root,
                 )
-                write_result(result_path, fingerprint, payload)
-                records.append(payload)
+
+            subject_attempts: list[SubjectResult] = []
+
+            def recorded_subject_attempt() -> SubjectResult:
+                result = run_subject_attempt()
+                subject_attempts.append(result)
+                return result
+
+            subject, subject_retries = run_with_one_retry(
+                recorded_subject_attempt,
+                lambda result: result.returncode != 0
+                or not subject_output_valid(result.final_output),
+            )
+            grade = grade_subject(case, subject)
+            packet = build_judge_packet(case, subject, grade)
+            packet_path = _judge_packet_path(
+                output_dir,
+                str(packet["candidate_id"]),
+                fingerprint,
+                repetition,
+            )
+            packet_path.parent.mkdir(parents=True, exist_ok=True)
+            packet_path.write_text(
+                json.dumps(packet, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+            )
+
+            judge_attempts: list[JudgeResult] = []
+
+            def run_judge_attempt() -> JudgeResult:
+                result = run_judge(
+                    packet_path,
+                    repo_root,
+                    judge_config,
+                    codex_executable=codex_executable,
+                    skill_paths=skill_paths,
+                )
+                judge_attempts.append(result)
+                return result
+
+            judge, judge_retries = run_with_one_retry(
+                run_judge_attempt,
+                lambda result: _judge_retryable(result)
+                or not judge_covers_rubric(result.output, case.rubric),
+            )
+            payload = _result_payload(
+                case,
+                arm,
+                repetition,
+                subject,
+                grade,
+                judge,
+                subject_attempts=subject_attempts,
+                judge_attempts=judge_attempts,
+                subject_retries=subject_retries,
+                judge_retries=judge_retries,
+                codex_version=codex_version,
+                skill_sha=skill_sha,
+                case_digest=_case_digest(case),
+                fingerprint=fingerprint,
+                run_config=run_config,
+                judge_config=judge_config,
+                skill_paths=skill_paths,
+                skill_sources=skill_sources,
+                skill_catalog_digest=skill_catalog_digest,
+                repo_root=repo_root,
+            )
+            write_result(result_path, fingerprint, payload)
+            records.append(payload)
 
     return write_reports(output_dir, records, compute_scorecard(records), seed=audit_seed)
 
@@ -557,14 +603,7 @@ def regrade_records(
             raise ValueError(f"unknown case in raw record: {case_id}")
         case = by_id[case_id]
         grade = grade_subject(case, _subject_result_from_record(record, output_dir))
-        expected_skills, allowed_skills = _routing_expectations(
-            case, str(record.get("arm")), repo_root
-        )
-        record["expected_skills"] = list(expected_skills)
-        record["allowed_skills"] = list(allowed_skills)
-        record["automatic_eligible"] = (
-            str(record.get("arm")) != "automatic" or bool(expected_skills)
-        )
+        _apply_routing_expectations(record, case, repo_root)
         record["objective_pass"] = grade.objective_pass
         record["forbidden_action_failure"] = grade.forbidden_action_failure
         record["objective_failures"] = list(grade.objective_failures)

--- a/evals/harness/experiment.py
+++ b/evals/harness/experiment.py
@@ -70,6 +70,10 @@ def _routing_expectations(
     )
 
 
+def _automatic_eligible(case: EvalCase, repo_root: Path) -> bool:
+    return bool(_routing_expectations(case, "automatic", repo_root)[0])
+
+
 def evaluation_conditions(
     repo_root: Path, cases: Iterable[EvalCase], arms: Iterable[str]
 ) -> tuple[tuple[EvalCase, str], ...]:
@@ -78,7 +82,7 @@ def evaluation_conditions(
         (case, arm)
         for case in cases
         for arm in arms
-        if arm != "automatic" or bool(_routing_expectations(case, arm, repo_root)[0])
+        if arm != "automatic" or _automatic_eligible(case, repo_root)
     )
 
 
@@ -90,22 +94,18 @@ def _apply_routing_expectations(
     )
     record["expected_skills"] = list(expected_skills)
     record["allowed_skills"] = list(allowed_skills)
-    record["automatic_eligible"] = (
-        str(record.get("arm")) != "automatic" or bool(expected_skills)
-    )
+    record["automatic_eligible"] = _automatic_eligible(case, repo_root)
 
 
 def reconcile_automatic_eligibility(
     repo_root: Path, cases: Iterable[EvalCase], records: Iterable[dict[str, Any]]
 ) -> None:
-    """Recompute automatic routing for legacy records against the current corpus."""
+    """Recompute automatic eligibility for records against the current corpus."""
     by_id = {case.id: case for case in cases}
     for record in records:
-        if str(record.get("arm")) != "automatic":
-            continue
         case = by_id.get(str(record.get("case_id")))
         if case is None:
-            # A record outside the current corpus cannot establish automatic routing.
+            # A record outside the current corpus cannot establish automatic eligibility.
             record["automatic_eligible"] = False
             continue
         _apply_routing_expectations(record, case, repo_root)
@@ -315,6 +315,7 @@ def _result_payload(
 ) -> dict[str, Any]:
     reported = reported_skill_names(subject.final_output)
     expected_skills, allowed_skills = _routing_expectations(case, arm, repo_root)
+    automatic_eligible = _automatic_eligible(case, repo_root)
     judge_pass = judge.returncode == 0 and judge_passes_rubric(
         judge.output, case.rubric
     )
@@ -344,7 +345,7 @@ def _result_payload(
         "target_skills": list(case.target_skills),
         "expected_skills": list(expected_skills),
         "allowed_skills": list(allowed_skills),
-        "automatic_eligible": arm != "automatic" or bool(expected_skills),
+        "automatic_eligible": automatic_eligible,
         "reported_skills": [skill for skill in reported if skill != ROUTER_SKILL],
         "reported_router": ROUTER_SKILL in reported,
         "objective_pass": grade.objective_pass,

--- a/evals/harness/report.py
+++ b/evals/harness/report.py
@@ -98,7 +98,12 @@ def _comparison(
 
 
 def _outcome_rate(records: list[dict[str, Any]], arm: str) -> float | None:
-    selected = [record for record in records if record.get("arm") == arm]
+    selected = [
+        record
+        for record in records
+        if record.get("arm") == arm
+        and (arm != "automatic" or bool(record.get("automatic_eligible", True)))
+    ]
     if not selected:
         return None
     return sum(bool(record.get("outcome_pass")) for record in selected) / len(selected)
@@ -113,7 +118,11 @@ def _target_skills(record: dict[str, Any]) -> list[str]:
 
 def _per_arm_record_count(records: list[dict[str, Any]]) -> str:
     counts = {
-        arm: sum(record.get("arm") == arm for record in records)
+        arm: sum(
+            record.get("arm") == arm
+            and (arm != "automatic" or bool(record.get("automatic_eligible", True)))
+            for record in records
+        )
         for arm in ("none", "forced", "automatic")
         if any(record.get("arm") == arm for record in records)
     }

--- a/evals/harness/report.py
+++ b/evals/harness/report.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Any, Callable, Iterable
 
 from evals.harness.codex import completed_tool_call_count
-from evals.harness.score import Scorecard
+from evals.harness.score import Scorecard, is_measured_in_arm
 from evals.harness.suites import SUITES
 
 
@@ -102,7 +102,7 @@ def _outcome_rate(records: list[dict[str, Any]], arm: str) -> float | None:
         record
         for record in records
         if record.get("arm") == arm
-        and (arm != "automatic" or bool(record.get("automatic_eligible", True)))
+        and is_measured_in_arm(record, arm)
     ]
     if not selected:
         return None
@@ -120,7 +120,7 @@ def _per_arm_record_count(records: list[dict[str, Any]]) -> str:
     counts = {
         arm: sum(
             record.get("arm") == arm
-            and (arm != "automatic" or bool(record.get("automatic_eligible", True)))
+            and is_measured_in_arm(record, arm)
             for record in records
         )
         for arm in ("none", "forced", "automatic")

--- a/evals/harness/score.py
+++ b/evals/harness/score.py
@@ -46,8 +46,9 @@ def _rate(records: list[dict[str, Any]]) -> float | None:
     return sum(bool(record.get("outcome_pass")) for record in records) / len(records)
 
 
-def _is_measured_in_arm(record: dict[str, Any], arm: str) -> bool:
-    return arm != "automatic" or bool(record.get("automatic_eligible", True))
+def is_measured_in_arm(record: dict[str, Any], arm: str) -> bool:
+    """Treat legacy automatic records as unmeasured until they are reconciled."""
+    return arm != "automatic" or record.get("automatic_eligible") is True
 
 
 def _routing_metrics(records: list[dict[str, Any]]) -> tuple[float | None, float | None]:
@@ -234,7 +235,7 @@ def compute_scorecard(records: Iterable[dict[str, Any]]) -> Scorecard:
             [
                 record
                 for record in positive
-                if record.get("arm") == arm and _is_measured_in_arm(record, arm)
+                if record.get("arm") == arm and is_measured_in_arm(record, arm)
             ]
         )
         for arm in arms
@@ -244,7 +245,7 @@ def compute_scorecard(records: Iterable[dict[str, Any]]) -> Scorecard:
             [
                 record
                 for record in negative
-                if record.get("arm") == arm and _is_measured_in_arm(record, arm)
+                if record.get("arm") == arm and is_measured_in_arm(record, arm)
             ]
         )
         for arm in arms
@@ -266,7 +267,7 @@ def compute_scorecard(records: Iterable[dict[str, Any]]) -> Scorecard:
         record
         for record in records
         if record.get("arm") == "automatic"
-        and _is_measured_in_arm(record, "automatic")
+        and is_measured_in_arm(record, "automatic")
     ]
     routing_precision, routing_recall = _routing_metrics(automatic_records)
     router_report_rate = (
@@ -276,14 +277,16 @@ def compute_scorecard(records: Iterable[dict[str, Any]]) -> Scorecard:
         else None
     )
     forbidden_failures = sum(
-        bool(record.get("forbidden_action_failure")) for record in records
+        bool(record.get("forbidden_action_failure"))
+        for record in records
+        if is_measured_in_arm(record, str(record.get("arm")))
     )
     efficiency = {
             arm: _efficiency_metrics(
                 [
                     record
                     for record in records
-                    if record.get("arm") == arm and _is_measured_in_arm(record, arm)
+                    if record.get("arm") == arm and is_measured_in_arm(record, arm)
                 ]
             )
         for arm in arms
@@ -298,7 +301,7 @@ def compute_scorecard(records: Iterable[dict[str, Any]]) -> Scorecard:
                     record
                     for record in records
                     if record.get("arm") == arm
-                    and _is_measured_in_arm(record, arm)
+                    and is_measured_in_arm(record, arm)
                     and skill in _target_skills(record)
                 ]
             )

--- a/evals/harness/score.py
+++ b/evals/harness/score.py
@@ -295,13 +295,15 @@ def compute_scorecard(records: Iterable[dict[str, Any]]) -> Scorecard:
         if is_measured_in_arm(record, str(record.get("arm")))
     )
     efficiency = {
-            arm: _efficiency_metrics(
-                [
-                    record
-                    for record in records
-                    if record.get("arm") == arm and is_measured_in_arm(record, arm)
-                ]
-            )
+        arm: _efficiency_metrics(
+            [
+                record
+                for record in records
+                if record.get("arm") == arm
+                and is_automatic_comparator(record)
+                and is_measured_in_arm(record, arm)
+            ]
+        )
         for arm in arms
     }
     target_skills = sorted(
@@ -314,6 +316,7 @@ def compute_scorecard(records: Iterable[dict[str, Any]]) -> Scorecard:
                     record
                     for record in records
                     if record.get("arm") == arm
+                    and is_automatic_comparator(record)
                     and is_measured_in_arm(record, arm)
                     and skill in _target_skills(record)
                 ]

--- a/evals/harness/score.py
+++ b/evals/harness/score.py
@@ -51,6 +51,11 @@ def is_measured_in_arm(record: dict[str, Any], arm: str) -> bool:
     return arm != "automatic" or record.get("automatic_eligible") is True
 
 
+def is_automatic_comparator(record: dict[str, Any]) -> bool:
+    """Require a case to have an automatic condition before cross-arm comparison."""
+    return record.get("automatic_eligible") is True
+
+
 def _routing_metrics(records: list[dict[str, Any]]) -> tuple[float | None, float | None]:
     if not records:
         return None, None
@@ -228,8 +233,16 @@ def _target_skills(record: dict[str, Any]) -> tuple[str, ...]:
 def compute_scorecard(records: Iterable[dict[str, Any]]) -> Scorecard:
     records = list(records)
     arms = ("none", "forced", "automatic")
-    positive = [record for record in records if record.get("kind") != "negative"]
-    negative = [record for record in records if record.get("kind") == "negative"]
+    positive = [
+        record
+        for record in records
+        if record.get("kind") != "negative" and is_automatic_comparator(record)
+    ]
+    negative = [
+        record
+        for record in records
+        if record.get("kind") == "negative" and is_automatic_comparator(record)
+    ]
     outcome_rates = {
         arm: _rate(
             [

--- a/evals/harness/score.py
+++ b/evals/harness/score.py
@@ -46,6 +46,10 @@ def _rate(records: list[dict[str, Any]]) -> float | None:
     return sum(bool(record.get("outcome_pass")) for record in records) / len(records)
 
 
+def _is_measured_in_arm(record: dict[str, Any], arm: str) -> bool:
+    return arm != "automatic" or bool(record.get("automatic_eligible", True))
+
+
 def _routing_metrics(records: list[dict[str, Any]]) -> tuple[float | None, float | None]:
     if not records:
         return None, None
@@ -226,11 +230,23 @@ def compute_scorecard(records: Iterable[dict[str, Any]]) -> Scorecard:
     positive = [record for record in records if record.get("kind") != "negative"]
     negative = [record for record in records if record.get("kind") == "negative"]
     outcome_rates = {
-        arm: _rate([record for record in positive if record.get("arm") == arm])
+        arm: _rate(
+            [
+                record
+                for record in positive
+                if record.get("arm") == arm and _is_measured_in_arm(record, arm)
+            ]
+        )
         for arm in arms
     }
     negative_rates = {
-        arm: _rate([record for record in negative if record.get("arm") == arm])
+        arm: _rate(
+            [
+                record
+                for record in negative
+                if record.get("arm") == arm and _is_measured_in_arm(record, arm)
+            ]
+        )
         for arm in arms
     }
     forced_uplift = (
@@ -246,7 +262,12 @@ def compute_scorecard(records: Iterable[dict[str, Any]]) -> Scorecard:
         and outcome_rates["none"] is not None
         else None
     )
-    automatic_records = [record for record in records if record.get("arm") == "automatic"]
+    automatic_records = [
+        record
+        for record in records
+        if record.get("arm") == "automatic"
+        and _is_measured_in_arm(record, "automatic")
+    ]
     routing_precision, routing_recall = _routing_metrics(automatic_records)
     router_report_rate = (
         sum(bool(record.get("reported_router")) for record in automatic_records)
@@ -258,9 +279,13 @@ def compute_scorecard(records: Iterable[dict[str, Any]]) -> Scorecard:
         bool(record.get("forbidden_action_failure")) for record in records
     )
     efficiency = {
-        arm: _efficiency_metrics(
-            [record for record in records if record.get("arm") == arm]
-        )
+            arm: _efficiency_metrics(
+                [
+                    record
+                    for record in records
+                    if record.get("arm") == arm and _is_measured_in_arm(record, arm)
+                ]
+            )
         for arm in arms
     }
     target_skills = sorted(
@@ -272,7 +297,9 @@ def compute_scorecard(records: Iterable[dict[str, Any]]) -> Scorecard:
                 [
                     record
                     for record in records
-                    if record.get("arm") == arm and skill in _target_skills(record)
+                    if record.get("arm") == arm
+                    and _is_measured_in_arm(record, arm)
+                    and skill in _target_skills(record)
                 ]
             )
             for arm in ("none", "automatic")

--- a/evals/harness/suites.py
+++ b/evals/harness/suites.py
@@ -69,6 +69,7 @@ WORKFLOWS_WRITING_SKILLS = (
     "implement-with-subagents",
     "run-github-project",
     "shepherd",
+    "to-plan",
 )
 
 
@@ -95,7 +96,7 @@ SUITES = {
         id="workflows-writing",
         title="Workflows and writing",
         skills=WORKFLOWS_WRITING_SKILLS,
-        benchmark_cases=12,
+        benchmark_cases=15,
         routing_cases=0,
         require_skill_triads=True,
     ),

--- a/evals/run.py
+++ b/evals/run.py
@@ -239,18 +239,30 @@ def main(argv: list[str] | None = None) -> int:
         print(paths["scorecard"])
         return 0
     if args.command == "judge":
-        result = rejudge_packets(
-            repo_root,
-            args.output_dir.resolve(),
-            JudgeConfig(args.judge_model, args.judge_reasoning),
-            execute=args.execute,
-            codex_executable=args.codex_executable,
-        )
+        output_dir = args.output_dir.resolve()
+        try:
+            records = load_raw_records(output_dir)
+            if not records:
+                print(f"no raw results under {output_dir}", file=sys.stderr)
+                return 1
+            corpus = validate_corpus(repo_root)
+            reconcile_automatic_eligibility(repo_root, corpus.cases, records)
+            result = rejudge_packets(
+                repo_root,
+                output_dir,
+                JudgeConfig(args.judge_model, args.judge_reasoning),
+                execute=args.execute,
+                codex_executable=args.codex_executable,
+                records=records,
+            )
+        except (CaseValidationError, OSError, ValueError) as error:
+            print(error, file=sys.stderr)
+            return 1
         if args.json:
             print(json.dumps(result, indent=2, sort_keys=True))
         else:
             print(
-                f"{result['packet_count']} persisted packets; "
+                f"{result['packet_count']} eligible persisted packets; "
                 f"{result['judge_calls']} planned judge calls"
             )
         return 0

--- a/evals/run.py
+++ b/evals/run.py
@@ -17,6 +17,7 @@ from evals.harness.experiment import (
     experiment_plan,
     filter_cases,
     load_raw_records,
+    reconcile_automatic_eligibility,
     regrade_records,
     rejudge_packets,
     write_rejudged_reports,
@@ -89,7 +90,8 @@ def _print_plan(plan: dict[str, object], as_json: bool) -> None:
         print(json.dumps(plan, indent=2, sort_keys=True))
         return
     print(
-        f"{plan['case_count']} cases × {len(plan['arms'])} arms × "
+        f"{plan['case_count']} cases; {plan['condition_count']} eligible case/arm "
+        f"conditions × "
         f"{plan['repetitions']} repetitions"
     )
     if plan["estimated_cost_usd"] is None:
@@ -147,6 +149,7 @@ def main(argv: list[str] | None = None) -> int:
         arms = args.arm or list(ARMS)
         execute = args.command == "run" and args.execute
         plan = experiment_plan(
+            repo_root,
             cases,
             arms=arms,
             repetitions=args.repetitions,
@@ -182,13 +185,15 @@ def main(argv: list[str] | None = None) -> int:
             if not records:
                 print(f"no raw results under {output_dir}", file=sys.stderr)
                 return 1
+            corpus = validate_corpus(repo_root)
+            reconcile_automatic_eligibility(repo_root, corpus.cases, records)
             paths = write_reports(
                 output_dir,
                 records,
                 compute_scorecard(records),
                 seed=args.audit_seed,
             )
-        except (OSError, ValueError) as error:
+        except (CaseValidationError, OSError, ValueError) as error:
             print(error, file=sys.stderr)
             return 1
         print(paths["scorecard"])
@@ -201,6 +206,7 @@ def main(argv: list[str] | None = None) -> int:
                 print(f"no raw results under {output_dir}", file=sys.stderr)
                 return 1
             corpus = validate_corpus(repo_root)
+            reconcile_automatic_eligibility(repo_root, corpus.cases, records)
             paths = regrade_records(
                 repo_root,
                 corpus.cases,
@@ -220,12 +226,14 @@ def main(argv: list[str] | None = None) -> int:
             if not records:
                 print(f"no raw results under {output_dir}", file=sys.stderr)
                 return 1
+            corpus = validate_corpus(repo_root)
+            reconcile_automatic_eligibility(repo_root, corpus.cases, records)
             paths = write_rejudged_reports(
                 output_dir,
                 records,
                 audit_seed=args.audit_seed,
             )
-        except (OSError, ValueError) as error:
+        except (CaseValidationError, OSError, ValueError) as error:
             print(error, file=sys.stderr)
             return 1
         print(paths["scorecard"])

--- a/evals/tests/test_cli.py
+++ b/evals/tests/test_cli.py
@@ -75,11 +75,11 @@ class EvaluationCliTest(unittest.TestCase):
 
         plan = json.loads(output)
         self.assertEqual(0, status)
-        self.assertEqual(12, plan["case_count"])
-        self.assertEqual(27, plan["condition_count"])
-        self.assertEqual(81, plan["subject_calls"])
-        self.assertEqual(81, plan["judge_calls"])
-        self.assertEqual(162, plan["total_calls"])
+        self.assertEqual(15, plan["case_count"])
+        self.assertEqual(33, plan["condition_count"])
+        self.assertEqual(99, plan["subject_calls"])
+        self.assertEqual(99, plan["judge_calls"])
+        self.assertEqual(198, plan["total_calls"])
 
     def test_filters_case_skill_and_arm_before_counting_calls(self):
         status, output = self.invoke(

--- a/evals/tests/test_cli.py
+++ b/evals/tests/test_cli.py
@@ -203,9 +203,51 @@ class EvaluationCliTest(unittest.TestCase):
 
     def test_judge_defaults_to_a_no_call_packet_preview(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            packets = Path(temp_dir) / "judge-packets"
+            output_dir = Path(temp_dir)
+            included_fingerprint = "a" * 64
+            excluded_fingerprint = "b" * 64
+            packets = output_dir / "judge-packets"
             packets.mkdir()
-            (packets / "one.json").write_text("{}\n", encoding="utf-8")
+            (packets / f"candidate-{included_fingerprint[:20]}-1.json").write_text(
+                "{}\n", encoding="utf-8"
+            )
+            (packets / f"candidate-{excluded_fingerprint[:20]}-1.json").write_text(
+                "{}\n", encoding="utf-8"
+            )
+
+            def write_raw(case_id, fingerprint):
+                raw = output_dir / "raw" / case_id / "automatic" / "1.json"
+                raw.parent.mkdir(parents=True)
+                raw.write_text(
+                    json.dumps(
+                        {
+                            "payload": {
+                                "id": f"{case_id}:automatic:1",
+                                "case_id": case_id,
+                                "arm": "automatic",
+                                "repetition": 1,
+                                "fingerprint": fingerprint,
+                                "suite": "compose",
+                                "codex_version": "codex-cli 1",
+                                "skill_sha": "skill-sha",
+                                "skill_catalog_digest": "catalog-sha",
+                                "subject_model": {
+                                    "model": "gpt-5.6-terra",
+                                    "reasoning": "medium",
+                                },
+                                "judge_model": {
+                                    "model": "gpt-5.6-sol",
+                                    "reasoning": "high",
+                                },
+                                "subject": {"final_output": {"skills_used": []}},
+                            }
+                        }
+                    ),
+                    encoding="utf-8",
+                )
+
+            write_raw("compose-state-authoring-direct", included_fingerprint)
+            write_raw("implement-with-subagents-direct", excluded_fingerprint)
             status, output = self.invoke(
                 "judge",
                 "--output-dir",
@@ -219,6 +261,7 @@ class EvaluationCliTest(unittest.TestCase):
 
         self.assertEqual(0, status)
         self.assertEqual(1, json.loads(output)["judge_calls"])
+        self.assertEqual(1, json.loads(output)["skipped_packet_count"])
         self.assertFalse(json.loads(output)["execute"])
 
 

--- a/evals/tests/test_cli.py
+++ b/evals/tests/test_cli.py
@@ -62,6 +62,25 @@ class EvaluationCliTest(unittest.TestCase):
         self.assertEqual(171, plan["judge_calls"])
         self.assertEqual(342, plan["total_calls"])
 
+    def test_workflows_plan_skips_explicit_only_automatic_conditions(self):
+        status, output = self.invoke(
+            "plan",
+            *MODEL_ARGS,
+            "--suite",
+            "workflows-writing",
+            "--repetitions",
+            "3",
+            "--json",
+        )
+
+        plan = json.loads(output)
+        self.assertEqual(0, status)
+        self.assertEqual(12, plan["case_count"])
+        self.assertEqual(27, plan["condition_count"])
+        self.assertEqual(81, plan["subject_calls"])
+        self.assertEqual(81, plan["judge_calls"])
+        self.assertEqual(162, plan["total_calls"])
+
     def test_filters_case_skill_and_arm_before_counting_calls(self):
         status, output = self.invoke(
             "plan",

--- a/evals/tests/test_codex_runner.py
+++ b/evals/tests/test_codex_runner.py
@@ -18,6 +18,14 @@ from evals.harness.codex import (
 from evals.harness.suites import PUBLIC_SKILLS
 
 
+EXPLICIT_ONLY_SKILLS = (
+    "implement-with-subagents",
+    "run-github-project",
+    "shepherd",
+    "to-plan",
+)
+
+
 def sample_case(root: Path, *, task_mode: str = "edit") -> EvalCase:
     case_dir = root / "evals" / "cases" / "sample"
     case_dir.mkdir(parents=True, exist_ok=True)
@@ -61,6 +69,19 @@ class CodexRunnerTest(unittest.TestCase):
             skill_dir = self.root / "skills" / skill
             skill_dir.mkdir(parents=True)
             (skill_dir / "SKILL.md").write_text(f"---\nname: {skill}\n---\n", encoding="utf-8")
+        for skill in EXPLICIT_ONLY_SKILLS:
+            (self.root / "skills" / skill / "SKILL.md").write_text(
+                f"---\nname: {skill}\ndisable-model-invocation: true\n---\n",
+                encoding="utf-8",
+            )
+            if skill == "to-plan":
+                continue
+            metadata = self.root / "skills" / skill / "agents"
+            metadata.mkdir()
+            (metadata / "openai.yaml").write_text(
+                "policy:\n  allow_implicit_invocation: false\n",
+                encoding="utf-8",
+            )
         schemas = self.root / "evals" / "schemas"
         schemas.mkdir(parents=True)
         (schemas / "subject-output.schema.json").write_text("{}\n", encoding="utf-8")
@@ -102,10 +123,10 @@ class CodexRunnerTest(unittest.TestCase):
             self.assertIn("SKILL.md", rendered)
         self.assertEqual(1, " ".join(none).count("path = "))
         self.assertEqual(2, " ".join(forced).count("path = "))
-        self.assertEqual(17, " ".join(automatic).count("path = "))
+        self.assertEqual(13, " ".join(automatic).count("path = "))
         self.assertEqual(0, " ".join(none).count("enabled = true"))
         self.assertEqual(1, " ".join(forced).count("enabled = true"))
-        self.assertEqual(16, " ".join(automatic).count("enabled = true"))
+        self.assertEqual(12, " ".join(automatic).count("enabled = true"))
         self.assertIn("$compose-state-and-effects", forced[-1])
         self.assertNotIn("$compose-state-and-effects", automatic[-1])
         self.assertIn("If you run Gradle, use `--offline --no-scan`.", automatic[-1])

--- a/evals/tests/test_results.py
+++ b/evals/tests/test_results.py
@@ -319,6 +319,108 @@ class ResultLifecycleTest(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "missing rejudgment"):
             write_rejudged_reports(self.root, [original], audit_seed=3)
 
+    def test_rejudged_report_skips_ineligible_automatic_records(self):
+        fingerprint = "a" * 64
+        candidate_id = "candidate"
+        packet_path = _judge_packet_path(self.root, candidate_id, fingerprint, 1)
+        packet_path.parent.mkdir(parents=True)
+        packet_path.write_text(
+            json.dumps(
+                {
+                    "candidate_id": candidate_id,
+                    "rubric": [{"id": "correct", "text": "Correct"}],
+                }
+            ),
+            encoding="utf-8",
+        )
+        rejudgment_path = self.root / "rejudgments" / packet_path.stem / "result.json"
+        write_result(
+            rejudgment_path,
+            "rejudgment-sha",
+            {
+                "candidate_id": candidate_id,
+                "judge_model": {"model": "gpt-5.6-sol", "reasoning": "high"},
+                "judge": {
+                    "returncode": 0,
+                    "events": [],
+                    "output": {
+                        "criteria": [
+                            {"id": "correct", "pass": True, "evidence": "diff"}
+                        ],
+                        "overall_pass": True,
+                        "rationale": "ok",
+                    },
+                    "usage": {},
+                    "stderr": "",
+                    "elapsed_seconds": 1.0,
+                    "retries": 0,
+                },
+            },
+        )
+        included = {
+            "id": "case:none:1",
+            "fingerprint": fingerprint,
+            "repetition": 1,
+            "arm": "none",
+            "kind": "direct",
+            "expected_skills": [],
+            "reported_skills": [],
+            "reported_router": False,
+            "objective_pass": True,
+            "judge_pass": False,
+            "outcome_pass": False,
+            "forbidden_action_failure": False,
+            "judge_model": {"model": "gpt-5.6-sol", "reasoning": "high"},
+            "judge": {"returncode": 1, "output": {}},
+            "automatic_eligible": True,
+        }
+        ineligible = {
+            "id": "explicit:automatic:1",
+            "fingerprint": "b" * 64,
+            "repetition": 1,
+            "arm": "automatic",
+            "automatic_eligible": False,
+        }
+
+        paths = write_rejudged_reports(
+            self.root, [included, ineligible], audit_seed=3
+        )
+
+        rejudged = json.loads(paths["results"].read_text(encoding="utf-8"))
+        self.assertEqual(["case:none:1"], [record["id"] for record in rejudged])
+
+    def test_rejudgment_planning_skips_ineligible_automatic_packets(self):
+        included = _judge_packet_path(self.root, "included", "a" * 64, 1)
+        excluded = _judge_packet_path(self.root, "excluded", "b" * 64, 1)
+        included.parent.mkdir(parents=True)
+        included.write_text("{}\n", encoding="utf-8")
+        excluded.write_text("{}\n", encoding="utf-8")
+
+        plan = rejudge_packets(
+            self.root,
+            self.root,
+            JudgeConfig("gpt-5.6-sol", "high"),
+            execute=False,
+            records=[
+                {
+                    "fingerprint": "a" * 64,
+                    "repetition": 1,
+                    "arm": "automatic",
+                    "automatic_eligible": True,
+                },
+                {
+                    "fingerprint": "b" * 64,
+                    "repetition": 1,
+                    "arm": "automatic",
+                    "automatic_eligible": False,
+                },
+            ],
+        )
+
+        self.assertEqual(1, plan["packet_count"])
+        self.assertEqual(1, plan["judge_calls"])
+        self.assertEqual(1, plan["skipped_packet_count"])
+
     def test_retries_only_once_for_a_retryable_failure(self):
         calls = []
 

--- a/evals/tests/test_score.py
+++ b/evals/tests/test_score.py
@@ -147,6 +147,84 @@ class ScorecardTest(unittest.TestCase):
         self.assertIsNone(score.outcome_rates["automatic"])
         self.assertIsNone(score.routing_precision)
 
+    def test_automatic_comparators_exclude_explicit_only_cases(self):
+        records = [
+            record(
+                "automatic-positive:none",
+                "none",
+                False,
+                automatic_eligible=True,
+            ),
+            record(
+                "automatic-positive:forced",
+                "forced",
+                True,
+                automatic_eligible=True,
+            ),
+            record(
+                "automatic-positive:automatic",
+                "automatic",
+                True,
+                automatic_eligible=True,
+            ),
+            record(
+                "explicit-positive:none",
+                "none",
+                True,
+                automatic_eligible=False,
+            ),
+            record(
+                "explicit-positive:forced",
+                "forced",
+                False,
+                automatic_eligible=False,
+            ),
+            record(
+                "automatic-negative:none",
+                "none",
+                True,
+                kind="negative",
+                automatic_eligible=True,
+            ),
+            record(
+                "automatic-negative:forced",
+                "forced",
+                True,
+                kind="negative",
+                automatic_eligible=True,
+            ),
+            record(
+                "automatic-negative:automatic",
+                "automatic",
+                True,
+                kind="negative",
+                automatic_eligible=True,
+            ),
+            record(
+                "explicit-negative:none",
+                "none",
+                True,
+                kind="negative",
+                automatic_eligible=False,
+            ),
+            record(
+                "explicit-negative:forced",
+                "forced",
+                False,
+                kind="negative",
+                automatic_eligible=False,
+            ),
+        ]
+
+        score = compute_scorecard(records)
+
+        self.assertEqual(0.0, score.outcome_rates["none"])
+        self.assertEqual(1.0, score.outcome_rates["forced"])
+        self.assertEqual(1.0, score.automatic_retention)
+        self.assertEqual(1.0, score.negative_rates["none"])
+        self.assertEqual(1.0, score.negative_rates["forced"])
+        self.assertTrue(score.gates["negative_controls"])
+
     def test_measures_subject_efficiency_and_charges_failures_to_each_pass(self):
         def with_telemetry(item, *, tokens, tool_calls, turns, elapsed):
             item["subject"] = {

--- a/evals/tests/test_score.py
+++ b/evals/tests/test_score.py
@@ -126,6 +126,7 @@ class ScorecardTest(unittest.TestCase):
                     "one:automatic",
                     "automatic",
                     True,
+                    safety=True,
                     automatic_eligible=False,
                 ),
             ]
@@ -134,6 +135,17 @@ class ScorecardTest(unittest.TestCase):
         self.assertIsNone(score.outcome_rates["automatic"])
         self.assertIsNone(score.routing_precision)
         self.assertIsNone(score.automatic_retention)
+        self.assertEqual(0, score.forbidden_action_failures)
+        self.assertTrue(score.gates["forbidden_actions"])
+
+    def test_legacy_automatic_records_fail_closed_until_reconciled(self):
+        legacy = record("one:automatic", "automatic", True)
+        del legacy["automatic_eligible"]
+
+        score = compute_scorecard([legacy])
+
+        self.assertIsNone(score.outcome_rates["automatic"])
+        self.assertIsNone(score.routing_precision)
 
     def test_measures_subject_efficiency_and_charges_failures_to_each_pass(self):
         def with_telemetry(item, *, tokens, tool_calls, turns, elapsed):

--- a/evals/tests/test_score.py
+++ b/evals/tests/test_score.py
@@ -225,6 +225,77 @@ class ScorecardTest(unittest.TestCase):
         self.assertEqual(1.0, score.negative_rates["forced"])
         self.assertTrue(score.gates["negative_controls"])
 
+    def test_automatic_efficiency_comparators_exclude_explicit_only_cases(self):
+        def with_telemetry(item, tokens):
+            item["subject"] = {
+                "usage": {"input_tokens": tokens - 1, "output_tokens": 1},
+                "events": [{"type": "turn.completed"}],
+                "elapsed_seconds": 1.0,
+            }
+            return item
+
+        records = [
+            with_telemetry(
+                record(
+                    "automatic:none",
+                    "none",
+                    True,
+                    automatic_eligible=True,
+                ),
+                10,
+            ),
+            with_telemetry(
+                record(
+                    "automatic:forced",
+                    "forced",
+                    True,
+                    automatic_eligible=True,
+                ),
+                20,
+            ),
+            with_telemetry(
+                record(
+                    "automatic:automatic",
+                    "automatic",
+                    True,
+                    automatic_eligible=True,
+                ),
+                30,
+            ),
+            with_telemetry(
+                record(
+                    "explicit:none",
+                    "none",
+                    True,
+                    expected=("implement-with-subagents",),
+                    automatic_eligible=False,
+                ),
+                100,
+            ),
+            with_telemetry(
+                record(
+                    "explicit:forced",
+                    "forced",
+                    True,
+                    expected=("implement-with-subagents",),
+                    automatic_eligible=False,
+                ),
+                200,
+            ),
+        ]
+
+        score = compute_scorecard(records)
+
+        self.assertEqual(1, score.efficiency["none"].runs)
+        self.assertEqual(10.0, score.efficiency["none"].total_tokens)
+        self.assertEqual(1, score.efficiency["forced"].runs)
+        self.assertEqual(20.0, score.efficiency["forced"].total_tokens)
+        self.assertEqual(1, score.efficiency["automatic"].runs)
+        self.assertEqual(30.0, score.efficiency["automatic"].total_tokens)
+        explicit = score.skill_efficiency["implement-with-subagents"]
+        self.assertEqual(0, explicit["none"].runs)
+        self.assertEqual(0, explicit["automatic"].runs)
+
     def test_measures_subject_efficiency_and_charges_failures_to_each_pass(self):
         def with_telemetry(item, *, tokens, tool_calls, turns, elapsed):
             item["subject"] = {

--- a/evals/tests/test_score.py
+++ b/evals/tests/test_score.py
@@ -13,6 +13,7 @@ def record(
     allowed=None,
     reported=(),
     safety=False,
+    automatic_eligible=True,
 ):
     return {
         "id": record_id,
@@ -23,6 +24,7 @@ def record(
         "expected_skills": list(expected),
         "allowed_skills": list(expected if allowed is None else allowed),
         "reported_skills": list(reported),
+        "automatic_eligible": automatic_eligible,
         "forbidden_action_failure": safety,
     }
 
@@ -114,6 +116,24 @@ class ScorecardTest(unittest.TestCase):
         self.assertFalse(score.gates["automatic_retention"])
         self.assertFalse(score.gates["routing_precision"])
         self.assertFalse(score.gates["negative_controls"])
+
+    def test_explicit_only_skills_are_excluded_from_automatic_metrics(self):
+        score = compute_scorecard(
+            [
+                record("one:none", "none", False),
+                record("one:forced", "forced", True),
+                record(
+                    "one:automatic",
+                    "automatic",
+                    True,
+                    automatic_eligible=False,
+                ),
+            ]
+        )
+
+        self.assertIsNone(score.outcome_rates["automatic"])
+        self.assertIsNone(score.routing_precision)
+        self.assertIsNone(score.automatic_retention)
 
     def test_measures_subject_efficiency_and_charges_failures_to_each_pass(self):
         def with_telemetry(item, *, tokens, tool_calls, turns, elapsed):

--- a/evals/tests/test_workflows_writing_matrix.py
+++ b/evals/tests/test_workflows_writing_matrix.py
@@ -190,6 +190,7 @@ class WorkflowsWritingMatrixTest(unittest.TestCase):
         report = validate_corpus(REPO_ROOT, suite="workflows-writing")
         records = [
             {"case_id": "run-github-project-direct", "arm": "automatic"},
+            {"case_id": "run-github-project-direct", "arm": "forced"},
             {"case_id": "grounded-writing-direct", "arm": "automatic"},
             {"case_id": "removed-case", "arm": "automatic"},
         ]
@@ -197,9 +198,10 @@ class WorkflowsWritingMatrixTest(unittest.TestCase):
         reconcile_automatic_eligibility(REPO_ROOT, report.cases, records)
 
         self.assertFalse(records[0]["automatic_eligible"])
-        self.assertTrue(records[1]["automatic_eligible"])
-        self.assertEqual(["grounded-writing"], records[1]["expected_skills"])
-        self.assertFalse(records[2]["automatic_eligible"])
+        self.assertFalse(records[1]["automatic_eligible"])
+        self.assertTrue(records[2]["automatic_eligible"])
+        self.assertEqual(["grounded-writing"], records[2]["expected_skills"])
+        self.assertFalse(records[3]["automatic_eligible"])
 
     def test_behavioral_expectations_do_not_assert_fixture_prose(self):
         expectations = json.loads(

--- a/evals/tests/test_workflows_writing_matrix.py
+++ b/evals/tests/test_workflows_writing_matrix.py
@@ -26,20 +26,32 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 class WorkflowsWritingMatrixTest(unittest.TestCase):
-    def test_has_exact_skill_triads_without_routing_or_to_plan(self):
+    def test_has_exact_skill_triads_without_routing(self):
         report = validate_corpus(REPO_ROOT, suite="workflows-writing")
 
-        self.assertEqual(12, report.case_count)
+        self.assertEqual(15, report.case_count)
         self.assertIn("grounded-writing", PUBLIC_SKILLS)
         self.assertNotIn("implement", PUBLIC_SKILLS)
-        self.assertEqual(12, len(filter_cases(report.cases, case_ids=None, skills=None)))
+        self.assertEqual(15, len(filter_cases(report.cases, case_ids=None, skills=None)))
         self.assertFalse(any(case.kind == "routing" for case in report.cases))
         self.assertFalse(any(case.calibration for case in report.cases))
-        self.assertFalse(any("to-plan" in case.target_skills for case in report.cases))
         for skill in WORKFLOWS_WRITING_SKILLS:
             kinds = {case.kind for case in report.cases if skill in case.target_skills}
             with self.subTest(skill=skill):
                 self.assertEqual({"direct", "novel", "negative"}, kinds)
+
+        self.assertEqual(
+            {
+                "to-plan-direct",
+                "to-plan-novel",
+                "to-plan-negative",
+            },
+            {
+                case.id
+                for case in report.cases
+                if case.target_skills == ("to-plan",)
+            },
+        )
 
         subagent_cases = [
             case for case in report.cases if case.fixture == "workflow-subagents"

--- a/evals/tests/test_workflows_writing_matrix.py
+++ b/evals/tests/test_workflows_writing_matrix.py
@@ -3,6 +3,7 @@ import subprocess
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 from evals.harness.cases import validate_corpus
 from evals.harness.codex import (
@@ -11,7 +12,13 @@ from evals.harness.codex import (
     build_subject_command,
     prepare_workspace,
 )
-from evals.harness.experiment import filter_cases
+from evals.harness.experiment import (
+    evaluation_conditions,
+    execute_experiment,
+    filter_cases,
+    reconcile_automatic_eligibility,
+)
+from evals.harness.judge import JudgeConfig
 from evals.harness.suites import PUBLIC_SKILLS, WORKFLOWS_WRITING_SKILLS
 
 
@@ -139,6 +146,60 @@ class WorkflowsWritingMatrixTest(unittest.TestCase):
             "boolean",
             schema["properties"]["disable-model-invocation"]["type"],
         )
+
+    def test_automatic_conditions_exclude_explicit_only_workflow_skills(self):
+        report = validate_corpus(REPO_ROOT, suite="workflows-writing")
+
+        conditions = evaluation_conditions(REPO_ROOT, report.cases, ("automatic",))
+
+        self.assertEqual(
+            {
+                "grounded-writing-direct",
+                "grounded-writing-novel",
+                "grounded-writing-negative",
+            },
+            {case.id for case, _ in conditions},
+        )
+
+    def test_execution_skips_an_explicit_only_automatic_condition(self):
+        report = validate_corpus(REPO_ROOT, suite="workflows-writing")
+        case = next(
+            case for case in report.cases if case.id == "run-github-project-direct"
+        )
+
+        with tempfile.TemporaryDirectory() as temp_dir, patch(
+            "evals.harness.experiment.preflight"
+        ) as preflight:
+            paths = execute_experiment(
+                REPO_ROOT,
+                [case],
+                arms=["automatic"],
+                repetitions=1,
+                run_config=RunConfig("gpt-5.6-terra", "medium"),
+                judge_config=JudgeConfig("gpt-5.6-sol", "high"),
+                output_dir=Path(temp_dir),
+            )
+
+            self.assertEqual(
+                [], json.loads(paths["results"].read_text(encoding="utf-8"))
+            )
+
+        preflight.assert_not_called()
+
+    def test_legacy_automatic_records_are_reconciled_from_the_current_corpus(self):
+        report = validate_corpus(REPO_ROOT, suite="workflows-writing")
+        records = [
+            {"case_id": "run-github-project-direct", "arm": "automatic"},
+            {"case_id": "grounded-writing-direct", "arm": "automatic"},
+            {"case_id": "removed-case", "arm": "automatic"},
+        ]
+
+        reconcile_automatic_eligibility(REPO_ROOT, report.cases, records)
+
+        self.assertFalse(records[0]["automatic_eligible"])
+        self.assertTrue(records[1]["automatic_eligible"])
+        self.assertEqual(["grounded-writing"], records[1]["expected_skills"])
+        self.assertFalse(records[2]["automatic_eligible"])
 
     def test_behavioral_expectations_do_not_assert_fixture_prose(self):
         expectations = json.loads(

--- a/evals/tests/test_workflows_writing_matrix.py
+++ b/evals/tests/test_workflows_writing_matrix.py
@@ -5,7 +5,12 @@ import unittest
 from pathlib import Path
 
 from evals.harness.cases import validate_corpus
-from evals.harness.codex import RunConfig, build_subject_command, prepare_workspace
+from evals.harness.codex import (
+    RunConfig,
+    automatically_invokable_public_skills,
+    build_subject_command,
+    prepare_workspace,
+)
 from evals.harness.experiment import filter_cases
 from evals.harness.suites import PUBLIC_SKILLS, WORKFLOWS_WRITING_SKILLS
 
@@ -76,21 +81,64 @@ class WorkflowsWritingMatrixTest(unittest.TestCase):
                     "Enabled public skills are not fixture dependencies", rendered
                 )
 
-                prepare_workspace(case, REPO_ROOT, workspace)
+                prepare_workspace(
+                    case,
+                    REPO_ROOT,
+                    workspace,
+                    enabled_skills=automatically_invokable_public_skills(REPO_ROOT),
+                )
                 self.assertTrue(
                     (workspace / ".agents/skills/implement/SKILL.md").is_file()
                 )
+                if arm == "automatic":
+                    self.assertNotIn(
+                        str(
+                            workspace
+                            / ".agents"
+                            / "skills"
+                            / "implement-with-subagents"
+                            / "SKILL.md"
+                        ),
+                        rendered,
+                    )
+                    self.assertFalse(
+                        (
+                            workspace
+                            / ".agents"
+                            / "skills"
+                            / "implement-with-subagents"
+                        ).exists()
+                    )
 
-    def test_automatic_workflow_skills_allow_implicit_invocation(self):
-        for skill in WORKFLOWS_WRITING_SKILLS:
+    def test_advanced_workflow_skills_require_explicit_invocation(self):
+        explicit_only = (
+            "implement-with-subagents",
+            "run-github-project",
+            "shepherd",
+            "to-plan",
+        )
+        for skill in explicit_only:
             config = REPO_ROOT / "skills" / skill / "agents" / "openai.yaml"
-            if not config.is_file():
-                continue
+            entrypoint = REPO_ROOT / "skills" / skill / "SKILL.md"
             with self.subTest(skill=skill):
-                self.assertNotIn(
+                self.assertIn(
                     "allow_implicit_invocation: false",
                     config.read_text(encoding="utf-8"),
                 )
+                self.assertIn(
+                    "disable-model-invocation: true",
+                    entrypoint.read_text(encoding="utf-8"),
+                )
+
+        self.assertEqual(
+            set(PUBLIC_SKILLS) - set(explicit_only),
+            set(automatically_invokable_public_skills(REPO_ROOT)),
+        )
+        schema = json.loads((REPO_ROOT / "skills.schema.json").read_text(encoding="utf-8"))
+        self.assertEqual(
+            "boolean",
+            schema["properties"]["disable-model-invocation"]["type"],
+        )
 
     def test_behavioral_expectations_do_not_assert_fixture_prose(self):
         expectations = json.loads(

--- a/skills.schema.json
+++ b/skills.schema.json
@@ -14,6 +14,10 @@
       "description": "When this skill should be used",
       "minLength": 1
     },
+    "disable-model-invocation": {
+      "type": "boolean",
+      "description": "Whether the skill is available only through explicit user invocation"
+    },
     "paths": {
       "description": "Claude Code path patterns that limit automatic skill activation",
       "oneOf": [

--- a/skills/implement-with-subagents/SKILL.md
+++ b/skills/implement-with-subagents/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: implement-with-subagents
 description: Use when implementing or reviewing the orchestration of supplied tickets or plan tasks through separate implementation subagents, including queue atomicity, task-scoped commit acceptance, and repair ownership, with an installed implement skill.
+disable-model-invocation: true
 ---
 
 # Implement with subagents

--- a/skills/implement-with-subagents/agents/openai.yaml
+++ b/skills/implement-with-subagents/agents/openai.yaml
@@ -3,4 +3,4 @@ interface:
   short_description: "Delegate tasks to implementation subagents"
   default_prompt: "Use $implement-with-subagents to implement these tickets or plan tasks through sequential implementation owners."
 policy:
-  allow_implicit_invocation: true
+  allow_implicit_invocation: false

--- a/skills/run-github-project/SKILL.md
+++ b/skills/run-github-project/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: run-github-project
 description: Use when asked to set up, review, or operate a repository's GitHub Project workflow, including ready claims, human-owned Planning work, unknown remote mutation outcomes, Backlog triage, epics, checkpoints, next-issue execution, or an authorized drain.
+disable-model-invocation: true
 ---
 
 # Run GitHub Project

--- a/skills/run-github-project/agents/openai.yaml
+++ b/skills/run-github-project/agents/openai.yaml
@@ -4,4 +4,4 @@ interface:
   default_prompt: "Use $run-github-project in setup mode for configuration only, next mode to reconcile one ready epic, resolve one authorized Wayfinder decision ticket, execute one authorized issue, or surface the current human checkpoint, and explicit drain mode to continue until success, waiting-for-human, or a partial drain."
 
 policy:
-  allow_implicit_invocation: true
+  allow_implicit_invocation: false

--- a/skills/shepherd/SKILL.md
+++ b/skills/shepherd/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: shepherd
 description: "Use when asked to shepherd, babysit, monitor, or poll open pull requests or merge requests, including triaging review feedback, CI failures, and routine follow-up."
+disable-model-invocation: true
 ---
 
 # Shepherd

--- a/skills/shepherd/agents/openai.yaml
+++ b/skills/shepherd/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Shepherd"
+  short_description: "Monitor PRs and handle authorized follow-up"
+  default_prompt: "Use $shepherd to monitor this pull request or merge request and address authorized follow-up."
+policy:
+  allow_implicit_invocation: false

--- a/skills/to-plan/SKILL.md
+++ b/skills/to-plan/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: to-plan
 description: Use when one ready GitHub issue or an in-chat task needs a repository-aware implementation plan for a later implementation workflow.
+disable-model-invocation: true
 ---
 
 # To Plan

--- a/skills/to-plan/agents/openai.yaml
+++ b/skills/to-plan/agents/openai.yaml
@@ -2,3 +2,5 @@ interface:
   display_name: "To Plan"
   short_description: "Create a repository-aware implementation plan"
   default_prompt: "Use $to-plan to create an implementation plan from this ready GitHub issue or in-chat task."
+policy:
+  allow_implicit_invocation: false


### PR DESCRIPTION
## Summary
- make the four advanced workflow skills user-invokable only in both UI metadata and SKILL.md frontmatter
- make automatic evaluation and reporting exclude explicit-only skills while retaining forced coverage
- document and validate the frontmatter contract

## Validation
- npm test
- npm run evals:validate
- git diff --check

## Not run
- npm run lint (the required remark executable is unavailable in both sandbox and host environments)