### PR TITLE
Add Agent Plugins v1 manifest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,6 +79,7 @@ jobs:
         run: |
           set -euo pipefail
 
+          jq . plugin.json
           jq . package.json
           jq . .claude-plugin/plugin.json
           jq . .claude-plugin/marketplace.json
@@ -97,12 +98,12 @@ jobs:
 
           git diff --check
 
-          if git diff --quiet -- package.json .claude-plugin/plugin.json .codex-plugin/plugin.json; then
+          if git diff --quiet -- plugin.json package.json .claude-plugin/plugin.json .codex-plugin/plugin.json; then
             echo "has_changes=false" >> "$GITHUB_OUTPUT"
             echo "No manifest version changes needed."
           else
             echo "has_changes=true" >> "$GITHUB_OUTPUT"
-            git diff -- package.json .claude-plugin/plugin.json .codex-plugin/plugin.json
+            git diff -- plugin.json package.json .claude-plugin/plugin.json .codex-plugin/plugin.json
           fi
 
       - name: Stop before publishing
@@ -123,7 +124,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          git add package.json .claude-plugin/plugin.json .codex-plugin/plugin.json
+          git add plugin.json package.json .claude-plugin/plugin.json .codex-plugin/plugin.json
           git commit -m "Bump version to $VERSION"
           git push origin HEAD:main
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ Before considering any skill addition or edit complete, verify:
 
 - Use SemVer-compatible CalVer: `YYYY.M.D`.
 - Do not zero-pad month or day values. Use `2026.6.17`, not `2026.06.17`.
-- Keep `.claude-plugin/plugin.json` and `.codex-plugin/plugin.json` on the same version.
+- Keep root `plugin.json`, `.claude-plugin/plugin.json`, and `.codex-plugin/plugin.json` on the same version.
 - New Git release tags should match the manifest version exactly.
 - Existing zero-padded tags from before this policy map to the non-padded manifest version. For example, origin tag `2026.06.16` maps to manifest version `2026.6.16`.
 - Only cut a release when publishing installable changes. Skill wording/fixes, new skills/triggers, removals, and renames all use the publication date as the version.
@@ -48,8 +48,9 @@ Before considering any skill addition or edit complete, verify:
 
 ## Manifests
 
-- `.claude-plugin/marketplace.json`, `.claude-plugin/plugin.json`, `.agents/plugins/marketplace.json`, and `.codex-plugin/plugin.json` are all JSON (not JSONC). Validate with `jq . <file>` before committing.
-- The plugin `name` field in both manifests must stay `chrisbanes-skills`.
+- Root `plugin.json`, `.claude-plugin/marketplace.json`, `.claude-plugin/plugin.json`, `.agents/plugins/marketplace.json`, and `.codex-plugin/plugin.json` are all JSON (not JSONC). Validate with `jq . <file>` before committing.
+- Root `plugin.json` targets Agent Plugins v1.0.0 and contains only portable schema fields. Keep client-specific fields in the client manifests.
+- The plugin `name` field in all three manifests must stay `chrisbanes-skills`.
 
 ## Commits and PRs
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 A set of skills for Kotlin, Jetpack Compose, Android development, and grounded
 writing.
 
+The repository is also a portable [Agent Plugins](https://agent-plugins.org/)
+v1.0.0 package. Conforming clients discover the root [`plugin.json`](plugin.json)
+and the immediate skill directories under [`skills/`](skills/).
+
 ## Install
 
 With the [skills CLI](https://skills.sh):
@@ -103,13 +107,23 @@ This is a breaking taxonomy change. Replace the removed entrypoints as follows:
 
 Skills live at `skills/<skill-name>/SKILL.md`, flat (no language nesting). The `name:` in the SKILL.md frontmatter must match the directory name.
 
-Frontmatter is validated against [`skills.schema.json`](skills.schema.json) — `name` and `description` are required, `name` must be kebab-case, and `disable-model-invocation: true` makes a skill explicit-only. The router also uses Claude Code's optional `paths` extension. Clients that do not support this extension must ignore the `paths` field rather than rejecting the skill.
+Frontmatter is validated against [`skills.schema.json`](skills.schema.json), which
+tracks the core [Agent Skills specification](https://agentskills.io/specification)
+and permits `disable-model-invocation` and `paths` for Claude Code compatibility.
+`name` and `description` are required; portable optional fields are `license`,
+`compatibility`, `metadata`, and `allowed-tools`. Explicit-only workflow skills
+also mirror that policy in Codex's `agents/openai.yaml`; the router uses `paths`
+to activate for Kotlin source files in clients that support it.
 
 ### Releases
 
 Release versions use SemVer-compatible CalVer: `YYYY.M.D` without zero-padded month or day values, for example `2026.6.17`.
 
-Keep `.claude-plugin/plugin.json`, `.codex-plugin/plugin.json`, and new Git release tags on the same version. Existing zero-padded tags from before this policy map to the non-padded manifest version, so `2026.06.16` maps to `2026.6.16`. Only bump versions when publishing an installable release.
+Keep root `plugin.json`, `.claude-plugin/plugin.json`,
+`.codex-plugin/plugin.json`, and new Git release tags on the same version.
+Existing zero-padded tags from before this policy map to the non-padded manifest
+version, so `2026.06.16` maps to `2026.6.16`. Only bump versions when publishing
+an installable release.
 
 To publish a release, run the **Release** workflow from GitHub Actions. Leave the version input empty to use today's UTC `YYYY.M.D` version, or provide a specific non-zero-padded CalVer value. Use the dry-run option to validate without creating a commit, tag, or GitHub release.
 

--- a/evals/tests/test_workflows_writing_matrix.py
+++ b/evals/tests/test_workflows_writing_matrix.py
@@ -158,6 +158,7 @@ class WorkflowsWritingMatrixTest(unittest.TestCase):
             "boolean",
             schema["properties"]["disable-model-invocation"]["type"],
         )
+        self.assertEqual(2, len(schema["properties"]["paths"]["oneOf"]))
 
     def test_automatic_conditions_exclude_explicit_only_workflow_skills(self):
         report = validate_corpus(REPO_ROOT, suite="workflows-writing")

--- a/plugin.json
+++ b/plugin.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "chrisbanes-skills",
+  "version": "2026.9.2",
+  "description": "Skills for Kotlin, Android, JVM, and Jetpack Compose development by Chris Banes.",
+  "author": {
+    "name": "Chris Banes",
+    "url": "https://github.com/chrisbanes"
+  },
+  "homepage": "https://github.com/chrisbanes/skills",
+  "repository": "https://github.com/chrisbanes/skills",
+  "license": "Apache-2.0",
+  "keywords": [
+    "kotlin",
+    "android",
+    "jetpack-compose",
+    "skills"
+  ]
+}

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -10,6 +10,19 @@ import sys
 VERSION_PATTERN = re.compile(r"^[0-9]{4}\.([1-9]|1[0-2])\.([1-9]|[12][0-9]|3[01])$")
 PLUGIN_NAME = "chrisbanes-skills"
 OPENCODE_MAIN = ".opencode/plugins/chrisbanes-skills.js"
+AGENT_PLUGINS_SCHEMA = "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json"
+AGENT_PLUGINS_FIELDS = {
+    "$schema",
+    "name",
+    "version",
+    "description",
+    "author",
+    "homepage",
+    "repository",
+    "license",
+    "keywords",
+    "extensions",
+}
 
 
 def validate_version(version):
@@ -43,15 +56,33 @@ def update_manifests(root, version):
 def validate_manifests(root, version):
     validate_version(version)
 
+    portable = read_json(root / "plugin.json")
     claude = read_json(root / ".claude-plugin" / "plugin.json")
     codex = read_json(root / ".codex-plugin" / "plugin.json")
     package = read_json(root / "package.json")
     claude_marketplace = read_json(root / ".claude-plugin" / "marketplace.json")
     codex_marketplace = read_json(root / ".agents" / "plugins" / "marketplace.json")
 
+    require(
+        portable.get("$schema") == AGENT_PLUGINS_SCHEMA,
+        "Agent Plugins schema must target version 1.0.0",
+    )
+    require(
+        set(portable) <= AGENT_PLUGINS_FIELDS,
+        "Agent Plugins manifest has unknown fields: "
+        f"{sorted(set(portable) - AGENT_PLUGINS_FIELDS)}",
+    )
+    require(
+        portable.get("name") == PLUGIN_NAME,
+        "Agent Plugins name must be chrisbanes-skills",
+    )
     require(claude.get("name") == PLUGIN_NAME, "Claude plugin name must be chrisbanes-skills")
     require(codex.get("name") == PLUGIN_NAME, "Codex plugin name must be chrisbanes-skills")
     require(package.get("name") == PLUGIN_NAME, "OpenCode package name must be chrisbanes-skills")
+    require(
+        portable.get("version") == version,
+        f"Agent Plugins version mismatch: {portable.get('version')}",
+    )
     require(claude.get("version") == version, f"Claude plugin version mismatch: {claude.get('version')}")
     require(codex.get("version") == version, f"Codex plugin version mismatch: {codex.get('version')}")
     require(package.get("version") == version, f"OpenCode package version mismatch: {package.get('version')}")
@@ -69,6 +100,7 @@ def validate_manifests(root, version):
 
 def plugin_manifest_paths(root):
     return [
+        root / "plugin.json",
         root / ".claude-plugin" / "plugin.json",
         root / ".codex-plugin" / "plugin.json",
         root / "package.json",

--- a/scripts/test_release.py
+++ b/scripts/test_release.py
@@ -27,6 +27,10 @@ class ReleaseScriptTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.release.validate_version("2026.06.17")
 
+    def test_repository_manifests_are_valid(self):
+        version = self.read_json(ROOT / "plugin.json")["version"]
+        self.release.validate_manifests(ROOT, version)
+
     def test_update_and_validate_manifests(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = pathlib.Path(tmp)
@@ -34,6 +38,14 @@ class ReleaseScriptTest(unittest.TestCase):
             (root / ".codex-plugin").mkdir()
             (root / ".agents" / "plugins").mkdir(parents=True)
 
+            self.write_json(
+                root / "plugin.json",
+                {
+                    "$schema": self.release.AGENT_PLUGINS_SCHEMA,
+                    "name": "chrisbanes-skills",
+                    "version": "2026.6.16",
+                },
+            )
             self.write_json(
                 root / ".claude-plugin" / "plugin.json",
                 {"name": "chrisbanes-skills", "version": "2026.6.16"},
@@ -62,9 +74,11 @@ class ReleaseScriptTest(unittest.TestCase):
             self.release.update_manifests(root, "2026.6.17")
             self.release.validate_manifests(root, "2026.6.17")
 
+            portable = self.read_json(root / "plugin.json")
             claude = self.read_json(root / ".claude-plugin" / "plugin.json")
             codex = self.read_json(root / ".codex-plugin" / "plugin.json")
             package = self.read_json(root / "package.json")
+            self.assertEqual(portable["version"], "2026.6.17")
             self.assertEqual(claude["version"], "2026.6.17")
             self.assertEqual(codex["version"], "2026.6.17")
             self.assertEqual(package["version"], "2026.6.17")
@@ -79,6 +93,30 @@ class ReleaseScriptTest(unittest.TestCase):
             self.write_json(package_path, package)
 
             with self.assertRaisesRegex(ValueError, "OpenCode package name"):
+                self.release.validate_manifests(root, "2026.6.17")
+
+    def test_validate_manifests_rejects_agent_plugins_schema_mismatch(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            self.write_valid_manifests(root)
+            portable_path = root / "plugin.json"
+            portable = self.read_json(portable_path)
+            portable["$schema"] = "https://example.com/plugin.schema.json"
+            self.write_json(portable_path, portable)
+
+            with self.assertRaisesRegex(ValueError, "Agent Plugins schema"):
+                self.release.validate_manifests(root, "2026.6.17")
+
+    def test_validate_manifests_rejects_unknown_agent_plugins_field(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            self.write_valid_manifests(root)
+            portable_path = root / "plugin.json"
+            portable = self.read_json(portable_path)
+            portable["skills"] = "./skills/"
+            self.write_json(portable_path, portable)
+
+            with self.assertRaisesRegex(ValueError, "unknown fields"):
                 self.release.validate_manifests(root, "2026.6.17")
 
     def test_validate_manifests_rejects_opencode_package_version_mismatch(self):
@@ -110,6 +148,14 @@ class ReleaseScriptTest(unittest.TestCase):
         (root / ".codex-plugin").mkdir()
         (root / ".agents" / "plugins").mkdir(parents=True)
 
+        self.write_json(
+            root / "plugin.json",
+            {
+                "$schema": self.release.AGENT_PLUGINS_SCHEMA,
+                "name": "chrisbanes-skills",
+                "version": version,
+            },
+        )
         self.write_json(
             root / ".claude-plugin" / "plugin.json",
             {"name": "chrisbanes-skills", "version": version},

--- a/skills.schema.json
+++ b/skills.schema.json
@@ -6,17 +6,41 @@
   "properties": {
     "name": {
       "type": "string",
-      "description": "Skill name, must match the directory name (kebab-case)",
-      "pattern": "^[a-z][a-z0-9]*(-[a-z0-9]+)*$"
+      "description": "Skill name, must match the directory name",
+      "minLength": 1,
+      "maxLength": 64,
+      "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$"
     },
     "description": {
       "type": "string",
-      "description": "When this skill should be used",
-      "minLength": 1
+      "description": "What this skill does and when it should be used",
+      "minLength": 1,
+      "maxLength": 1024
+    },
+    "license": {
+      "type": "string",
+      "description": "License name or reference to a bundled license file"
+    },
+    "compatibility": {
+      "type": "string",
+      "description": "Environment requirements",
+      "minLength": 1,
+      "maxLength": 500
+    },
+    "metadata": {
+      "type": "object",
+      "description": "Client-defined string metadata",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "allowed-tools": {
+      "type": "string",
+      "description": "Space-separated pre-approved tools"
     },
     "disable-model-invocation": {
       "type": "boolean",
-      "description": "Whether the skill is available only through explicit user invocation"
+      "description": "Claude Code extension that restricts a skill to explicit invocation"
     },
     "paths": {
       "description": "Claude Code path patterns that limit automatic skill activation",


### PR DESCRIPTION
## Summary

- add the portable Agent Plugins v1.0.0 root manifest
- keep release versioning and validation synchronized across the portable, Claude, Codex, and OpenCode manifests
- align the repository skill schema with Agent Skills core fields while retaining the existing Claude Code `disable-model-invocation` and `paths` extensions

## Validation

- `npm run lint`
- `npm test` (280 tests passed, 1 skipped)
- `python3 evals/run.py validate` (79 cases)
- `python3 scripts/release.py validate-manifests 2026.9.2`
- canonical Agent Plugins v1.0.0 JSON Schema validation
- `git diff --check`