### PR TITLE
Remove unsupported paths from skill frontmatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ See [`.opencode/INSTALL.md`](.opencode/INSTALL.md) for details.
 
 ### Routing
 
-- [`using-chrisbanes-skills`](skills/using-chrisbanes-skills/SKILL.md) — route Kotlin and Jetpack Compose work to the focused skills; current Claude Code versions also activate it when working with `.kt` or `.kts` files.
+- [`using-chrisbanes-skills`](skills/using-chrisbanes-skills/SKILL.md) — route Kotlin and Jetpack Compose work to the focused skills.
 
 ### Jetpack Compose
 
@@ -109,11 +109,10 @@ Skills live at `skills/<skill-name>/SKILL.md`, flat (no language nesting). The `
 
 Frontmatter is validated against [`skills.schema.json`](skills.schema.json), which
 tracks the core [Agent Skills specification](https://agentskills.io/specification)
-and permits `disable-model-invocation` and `paths` for Claude Code compatibility.
+and permits `disable-model-invocation` for Claude Code compatibility.
 `name` and `description` are required; portable optional fields are `license`,
 `compatibility`, `metadata`, and `allowed-tools`. Explicit-only workflow skills
-also mirror that policy in Codex's `agents/openai.yaml`; the router uses `paths`
-to activate for Kotlin source files in clients that support it.
+also mirror that policy in Codex's `agents/openai.yaml`.
 
 ### Releases
 

--- a/evals/tests/test_workflows_writing_matrix.py
+++ b/evals/tests/test_workflows_writing_matrix.py
@@ -158,7 +158,7 @@ class WorkflowsWritingMatrixTest(unittest.TestCase):
             "boolean",
             schema["properties"]["disable-model-invocation"]["type"],
         )
-        self.assertEqual(2, len(schema["properties"]["paths"]["oneOf"]))
+        self.assertNotIn("paths", schema["properties"])
 
     def test_automatic_conditions_exclude_explicit_only_workflow_skills(self):
         report = validate_corpus(REPO_ROOT, suite="workflows-writing")

--- a/skills.schema.json
+++ b/skills.schema.json
@@ -41,24 +41,6 @@
     "disable-model-invocation": {
       "type": "boolean",
       "description": "Claude Code extension that restricts a skill to explicit invocation"
-    },
-    "paths": {
-      "description": "Claude Code path patterns that limit automatic skill activation",
-      "oneOf": [
-        {
-          "type": "string",
-          "minLength": 1
-        },
-        {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "minLength": 1
-          },
-          "minItems": 1,
-          "uniqueItems": true
-        }
-      ]
     }
   },
   "required": ["name", "description"],

--- a/skills/using-chrisbanes-skills/SKILL.md
+++ b/skills/using-chrisbanes-skills/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: using-chrisbanes-skills
 description: Use when debugging, benchmarking, or profiling leads into Kotlin or Jetpack Compose source before the cause is known, or when one task spans multiple Kotlin or Compose concerns, especially plain Kotlin Flow or navigation delivery plus sealed branching.
-paths:
-  - "**/*.kt"
-  - "**/*.kts"
 ---
 
 # Using chrisbanes skills


### PR DESCRIPTION
## Summary

- remove the unsupported paths field from the Kotlin and Compose router skill
- stop allowing paths in the repository frontmatter schema
- correct the README and add a regression assertion

## Validation

- npm run lint
- python3 -m unittest discover -s evals/tests -v (143 tests)
- git diff --check

Fixes #61