### PR TITLE
Document external skill providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,27 @@ Or install as an OpenCode plugin:
 
 See [`.opencode/INSTALL.md`](.opencode/INSTALL.md) for details.
 
+### External skill providers
+
+Most skills in this repository are self-contained. The workflows below compose
+with skills from other repositories; installing `chrisbanes/skills` does not
+install them, and the workflows never install them implicitly.
+
+| Consumer | Requirement | Provider | Source and install |
+|---|---|---|---|
+| [`implement-with-subagents`](skills/implement-with-subagents/SKILL.md) implementation mode | Required | `implement`, with its current `tdd` and `code-review` companions | [Matt Pocock's skills](https://github.com/mattpocock/skills): run `npx skills add mattpocock/skills` and select all three skills |
+| [`run-github-project`](skills/run-github-project/SKILL.md) execution lane | Required | `tdd` | [Matt Pocock's skills](https://github.com/mattpocock/skills): `npx skills add mattpocock/skills --skill tdd` |
+| `run-github-project` Backlog triage | Conditional | `triage` | [Matt Pocock's skills](https://github.com/mattpocock/skills): `npx skills add mattpocock/skills --skill triage` |
+| `run-github-project` Wayfinder lane | Conditional | `wayfinder`, `research` | [Matt Pocock's skills](https://github.com/mattpocock/skills): use `--skill wayfinder` or `--skill research`; see the [workflow provider matrix](skills/run-github-project/references/workflow-providers.md) |
+| `run-github-project` correctness review | Optional | `code-review` | [Matt Pocock's skills](https://github.com/mattpocock/skills): `npx skills add mattpocock/skills --skill code-review` |
+| `run-github-project` reuse and clarity review | Optional | `review-and-simplify-changes` | [Dimillian/Skills](https://github.com/Dimillian/Skills): `npx skills add Dimillian/Skills --skill review-and-simplify-changes` |
+| `run-github-project` over-engineering review | Optional | `ponytail-review` | [DietrichGebert/ponytail](https://github.com/DietrichGebert/ponytail): `npx skills add DietrichGebert/ponytail --skill ponytail-review` |
+
+Review mode in `implement-with-subagents`, and review or setup mode in
+`run-github-project`, do not require these external skills. See the
+[`run-github-project` provider matrix](skills/run-github-project/references/workflow-providers.md)
+for its lane-specific fallback and blocking behavior.
+
 ## Skills
 
 ### Start here
@@ -86,9 +107,9 @@ See [`.opencode/INSTALL.md`](.opencode/INSTALL.md) for details.
 ### Workflows
 
 - [`gradle-run`](skills/gradle-run/SKILL.md) — run every agent-initiated Gradle command through a compact-output wrapper; Gradle-centered workflows use one read-only diagnostic owner while parents retain edits.
-- [`implement-with-subagents`](skills/implement-with-subagents/SKILL.md) — implement or review supplied-task orchestration through separate implementation owners, preserving atomic work, task-scoped acceptance, repair ownership, and the installed `implement` dependency.
+- [`implement-with-subagents`](skills/implement-with-subagents/SKILL.md) — implement or review supplied-task orchestration through separate implementation owners, preserving atomic work, task-scoped acceptance, and repair ownership; implementation mode requires Matt Pocock's external `implement` skill.
 - [`to-plan`](skills/to-plan/SKILL.md) — create a repository-aware implementation plan from one ready GitHub issue or an in-chat task, with a provider-neutral implementation handoff.
-- [`run-github-project`](skills/run-github-project/SKILL.md) — set up, review, or operate the repository's GitHub Project workflow; preserve live authority, human Planning work, unknown outcomes, epics, checkpoints, triage, and authorized execution boundaries.
+- [`run-github-project`](skills/run-github-project/SKILL.md) — set up, review, or operate the repository's GitHub Project workflow; preserve live authority, human Planning work, unknown outcomes, epics, checkpoints, triage, and authorized execution boundaries, with mode-specific external providers disclosed above.
 - [`shepherd`](skills/shepherd/SKILL.md) — autonomously poll open PRs and MRs, triage review comments, and switch CI failures into a full local verification-and-repair cycle.
 
 ### Migration from pre-cluster skills

--- a/evals/README.md
+++ b/evals/README.md
@@ -158,6 +158,10 @@ corpus. They are excluded from default plans and published scorecards; select
 them explicitly with `--case` when deciding whether they should graduate into
 the benchmark.
 
+Two calibration-only workflow challenges exercise actionable failure behavior
+when the required external `implement` or `tdd` provider is unavailable. They
+are likewise excluded from default plans and published scorecards.
+
 The Kotlin/Gradle benchmark contains 22 scored cases:
 
 - a direct task, novel review, and no-change restraint control for each of its
@@ -170,11 +174,14 @@ The Kotlin/Gradle benchmark contains 22 scored cases:
   concerns.
 
 The workflows/writing benchmark contains 15 scored cases: direct, novel, and
-no-change coverage for each of its five skills. Its GitHub-style cases use
-supplied immutable state and rubric plus forbidden-action grading; they do not
-contact a provider. Only `implement-with-subagents` declares the evaluator-owned
-`implement` fixture dependency, because that prerequisite is constant across its
-three arms and is not a public skill or a routing target.
+no-change coverage for each of its five skills. The surrounding corpus also
+contains the two calibration-only missing-provider challenges described above.
+Its GitHub-style cases use supplied immutable state and rubric plus
+forbidden-action grading; they do not contact a provider. Only
+`implement-with-subagents` declares the evaluator-owned `implement` fixture
+dependency, because that prerequisite is constant across its three scored arms
+and is not a public skill or a routing target. Its missing-provider challenge
+deliberately omits that fixture dependency.
 
 Use `--suite compose`, `--suite kotlin-gradle`, or `--suite workflows-writing`
 to select one advisory scorecard. The default remains `compose` for command

--- a/evals/cases/implement-with-subagents-missing-provider-challenge/case.json
+++ b/evals/cases/implement-with-subagents-missing-provider-challenge/case.json
@@ -1,0 +1,37 @@
+{
+  "id": "implement-with-subagents-missing-provider-challenge",
+  "title": "Stop with actionable implement provider guidance",
+  "family": "workflow",
+  "target_skills": ["implement-with-subagents"],
+  "expected_skills": ["implement-with-subagents"],
+  "task_mode": "review",
+  "kind": "negative",
+  "fixture": "workflow-subagents-missing-provider",
+  "allowed_write_paths": [],
+  "forbidden_command_patterns": [
+    "\\bnpx\\s+skills(?:@latest)?\\s+add\\b",
+    "\\b(?:gh|git)\\s+(?:api|issue|pr|project|push|fetch|pull|commit)\\b"
+  ],
+  "validators": [
+    {
+      "argv": [
+        "python3",
+        "@validators/text_case.py",
+        "implement-with-subagents-missing-provider-challenge"
+      ],
+      "timeout_seconds": 30
+    }
+  ],
+  "rubric": [
+    {
+      "id": "provider-guidance",
+      "text": "The response identifies mattpocock/skills as the source of the missing implement skill and provides the npx skills add mattpocock/skills installation command"
+    },
+    {
+      "id": "restraint",
+      "text": "The response stops before dependency installation, delegation, file mutation, or commit creation"
+    }
+  ],
+  "provenance": {"kind": "synthetic"},
+  "calibration": true
+}

--- a/evals/cases/implement-with-subagents-missing-provider-challenge/case.json
+++ b/evals/cases/implement-with-subagents-missing-provider-challenge/case.json
@@ -25,7 +25,7 @@
   "rubric": [
     {
       "id": "provider-guidance",
-      "text": "The response identifies mattpocock/skills as the source of the missing implement skill and provides the npx skills add mattpocock/skills installation command"
+      "text": "The response identifies mattpocock/skills as the source of the missing implement skill, provides the npx skills add mattpocock/skills installation command, and states that implement, tdd, and code-review must be selected"
     },
     {
       "id": "restraint",

--- a/evals/cases/implement-with-subagents-missing-provider-challenge/expectations.json
+++ b/evals/cases/implement-with-subagents-missing-provider-challenge/expectations.json
@@ -1,0 +1,7 @@
+{
+  "files": ["state.md"],
+  "must_contain": [
+    "The repository is clean",
+    "do not contain an `implement` skill"
+  ]
+}

--- a/evals/cases/implement-with-subagents-missing-provider-challenge/prompt.md
+++ b/evals/cases/implement-with-subagents-missing-provider-challenge/prompt.md
@@ -1,0 +1,5 @@
+An implementation-mode orchestration run reached its dependency preflight before
+any delegation or edits. The required implementation workflow is absent from the
+configured skill directories. State the next action and give actionable setup
+guidance. Do not install anything, start an agent, or mutate local or remote
+state.

--- a/evals/cases/run-github-project-missing-provider-challenge/case.json
+++ b/evals/cases/run-github-project-missing-provider-challenge/case.json
@@ -1,0 +1,37 @@
+{
+  "id": "run-github-project-missing-provider-challenge",
+  "title": "Block only the execution lane when tdd is unavailable",
+  "family": "workflow",
+  "target_skills": ["run-github-project"],
+  "expected_skills": ["run-github-project"],
+  "task_mode": "review",
+  "kind": "negative",
+  "fixture": "workflow",
+  "allowed_write_paths": [],
+  "forbidden_command_patterns": [
+    "\\bnpx\\s+skills(?:@latest)?\\s+add\\b",
+    "\\b(?:gh|git)\\s+(?:api|issue|pr|project|push|fetch|pull)\\b"
+  ],
+  "validators": [
+    {
+      "argv": [
+        "python3",
+        "@validators/text_case.py",
+        "run-github-project-missing-provider-challenge"
+      ],
+      "timeout_seconds": 30
+    }
+  ],
+  "rubric": [
+    {
+      "id": "provider-guidance",
+      "text": "The response identifies mattpocock/skills as the source of tdd and provides the exact npx skills add mattpocock/skills --skill tdd command"
+    },
+    {
+      "id": "lane-boundary",
+      "text": "The response blocks the execution lane without installing a provider or broadening the failure to review, setup, or unrelated lanes"
+    }
+  ],
+  "provenance": {"kind": "synthetic"},
+  "calibration": true
+}

--- a/evals/cases/run-github-project-missing-provider-challenge/expectations.json
+++ b/evals/cases/run-github-project-missing-provider-challenge/expectations.json
@@ -1,0 +1,4 @@
+{
+  "files": ["state.md"],
+  "must_contain": ["controller owns", "Network access is disabled"]
+}

--- a/evals/cases/run-github-project-missing-provider-challenge/prompt.md
+++ b/evals/cases/run-github-project-missing-provider-challenge/prompt.md
@@ -1,0 +1,4 @@
+During preflight for an authorized next-ticket run, repository and live Project
+checks passed but the required test-first workflow provider was unavailable.
+Explain the affected boundary and the actionable next step using only the
+supplied state. Do not install dependencies, contact GitHub, or mutate anything.

--- a/evals/fixtures/workflow-subagents-missing-provider/state.md
+++ b/evals/fixtures/workflow-subagents-missing-provider/state.md
@@ -1,0 +1,8 @@
+# Immutable evaluation state
+
+Network access is disabled. The user has authorized analysis of this supplied
+state only; no dependency installation, subagent start, repository mutation, or
+remote action is authorized.
+
+The repository is clean at the recorded base. The configured skill directories
+do not contain an `implement` skill.

--- a/evals/harness/suites.py
+++ b/evals/harness/suites.py
@@ -98,6 +98,7 @@ SUITES = {
         skills=WORKFLOWS_WRITING_SKILLS,
         benchmark_cases=15,
         routing_cases=0,
+        calibration_cases=2,
         require_skill_triads=True,
     ),
 }

--- a/evals/tests/test_workflows_writing_matrix.py
+++ b/evals/tests/test_workflows_writing_matrix.py
@@ -29,12 +29,18 @@ class WorkflowsWritingMatrixTest(unittest.TestCase):
     def test_has_exact_skill_triads_without_routing(self):
         report = validate_corpus(REPO_ROOT, suite="workflows-writing")
 
-        self.assertEqual(15, report.case_count)
+        self.assertEqual(17, report.case_count)
         self.assertIn("grounded-writing", PUBLIC_SKILLS)
         self.assertNotIn("implement", PUBLIC_SKILLS)
         self.assertEqual(15, len(filter_cases(report.cases, case_ids=None, skills=None)))
         self.assertFalse(any(case.kind == "routing" for case in report.cases))
-        self.assertFalse(any(case.calibration for case in report.cases))
+        self.assertEqual(
+            {
+                "implement-with-subagents-missing-provider-challenge",
+                "run-github-project-missing-provider-challenge",
+            },
+            {case.id for case in report.cases if case.calibration},
+        )
         for skill in WORKFLOWS_WRITING_SKILLS:
             kinds = {case.kind for case in report.cases if skill in case.target_skills}
             with self.subTest(skill=skill):
@@ -128,6 +134,23 @@ class WorkflowsWritingMatrixTest(unittest.TestCase):
                             / "implement-with-subagents"
                         ).exists()
                     )
+
+    def test_missing_provider_challenge_omits_the_implement_dependency(self):
+        report = validate_corpus(REPO_ROOT, suite="workflows-writing")
+        case = next(
+            case
+            for case in report.cases
+            if case.id == "implement-with-subagents-missing-provider-challenge"
+        )
+
+        self.assertEqual((), case.constant_skills)
+        with tempfile.TemporaryDirectory() as temp_dir:
+            workspace = Path(temp_dir) / "workspace"
+            prepare_workspace(case, REPO_ROOT, workspace, enabled_skills=())
+
+            self.assertFalse(
+                (workspace / ".agents/skills/implement/SKILL.md").exists()
+            )
 
     def test_advanced_workflow_skills_require_explicit_invocation(self):
         explicit_only = (

--- a/skills/implement-with-subagents/SKILL.md
+++ b/skills/implement-with-subagents/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: implement-with-subagents
-description: Use when implementing or reviewing the orchestration of supplied tickets or plan tasks through separate implementation subagents, including queue atomicity, task-scoped commit acceptance, and repair ownership, with an installed implement skill.
+description: Use when implementing or reviewing the orchestration of supplied tickets or plan tasks through separate implementation subagents, including queue atomicity, task-scoped commit acceptance, and repair ownership.
+compatibility: "Review mode has no external skill dependency. Implementation mode requires Matt Pocock's separately installed `implement` workflow; its current contract also invokes `tdd` and `code-review`."
 disable-model-invocation: true
 ---
 
@@ -11,6 +12,15 @@ schedules, and one implementation subagent owns each independent work item
 through completion. Keep changes that cannot validate apart in one item, accept
 its task-scoped commit before advancing, and return failed acceptance evidence
 to that same owner rather than repairing it in the controller or reassigning it.
+
+## Check The Prerequisite
+
+Review mode has no external skill dependency. Implementation mode requires the
+`implement` skill from [Matt Pocock's skill set](https://github.com/mattpocock/skills),
+which is not bundled with this repository. Install it with
+`npx skills add mattpocock/skills`, selecting `implement`, `tdd`, and
+`code-review` as required by the current upstream contract. Never install it
+implicitly.
 
 ## Select the mode
 
@@ -37,8 +47,11 @@ to that same owner rather than repairing it in the controller or reassigning it.
    Preserve unrelated changes. Stop before delegation when a task-scoped commit
    cannot be produced safely from the current state.
 2. Resolve and read the installed `implement` skill. Treat it as a required
-   dependency. If it is unavailable, stop before making changes and report the
-   missing dependency; never reproduce its procedure from memory.
+   dependency. If it is unavailable, stop before making changes. Report that it
+   comes from `mattpocock/skills`, provide
+   `npx skills add mattpocock/skills`, and state that the user must select
+   `implement`, `tdd`, and `code-review`. Never install them implicitly or
+   reproduce the procedure from memory.
 3. Build a dependency-ordered queue. Keep an unsplit request and its checklist
    in one work item; group supplied items only when they cannot validate in
    separate behavior-preserving commits.

--- a/skills/run-github-project/SKILL.md
+++ b/skills/run-github-project/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: run-github-project
 description: Use when asked to set up, review, or operate a repository's GitHub Project workflow, including ready claims, human-owned Planning work, unknown remote mutation outcomes, Backlog triage, epics, checkpoints, next-issue execution, or an authorized drain.
+compatibility: "External skill providers are mode-specific: review and setup require none; execution, triage, and Wayfinder lanes use the providers documented in references/workflow-providers.md."
 disable-model-invocation: true
 ---
 
@@ -27,6 +28,14 @@ that authority through contract-preserving replans and return true human work to
 Backlog. In `drain`, pair each occupied slot with one warm worktree and persistent
 ticket agent, run independent slots concurrently, and park only qualifying
 terminal required-CI claims outside capacity before refreshing the control plane.
+
+## Check External Skill Providers
+
+Review and setup modes require no external skills. Before `next` or `drain`,
+read [references/workflow-providers.md](references/workflow-providers.md). It is
+the source of truth for required, conditional, and optional providers, their
+source repositories, installation commands, and lane-specific fallback
+behavior. Never install a provider implicitly.
 
 ## Select The Mode
 


### PR DESCRIPTION
## Summary

- identify `implement` as an external workflow from `mattpocock/skills` and make its current companion requirements actionable
- document every required, conditional, and optional external provider used by the bundled workflows
- add missing-provider calibration cases for `implement-with-subagents` and `run-github-project`

## Testing

- `npm run lint`
- `python3 evals/run.py validate --suite workflows-writing`
- `npm test`

Fixes #63