### PR TITLE
Improve screenshot test baseline guidance

### DIFF
--- a/evals/cases/compose-ui-testing-patterns-direct/case.json
+++ b/evals/cases/compose-ui-testing-patterns-direct/case.json
@@ -1,6 +1,6 @@
 {
   "id": "compose-ui-testing-patterns-direct",
-  "title": "Move a component check to a plain UI test",
+  "title": "Update a baseline for an intentional screenshot configuration change",
   "family": "testing",
   "target_skills": [
     "compose-ui-testing-patterns"
@@ -12,7 +12,8 @@
   "kind": "direct",
   "fixture": "compose-jvm",
   "allowed_write_paths": [
-    "src/test/kotlin/example/SubjectTest.kt"
+    "src/test/kotlin/example/SubjectTest.kt",
+    "src/test/resources/baselines/Subject.txt"
   ],
   "validators": [
     {
@@ -27,11 +28,11 @@
   "rubric": [
     {
       "id": "criterion-1",
-      "text": "Uses a plain Compose UI-test entry point and controlled setContent"
+      "text": "Keeps the test on the named public configuration and updates the affected baseline"
     },
     {
       "id": "criterion-2",
-      "text": "Removes the unnecessary activity integration boundary"
+      "text": "Preserves the existing tolerance rather than weakening the visual assertion"
     }
   ],
   "provenance": {

--- a/evals/cases/compose-ui-testing-patterns-direct/expectations.json
+++ b/evals/cases/compose-ui-testing-patterns-direct/expectations.json
@@ -2,17 +2,18 @@
   "files": [
     "src/test/kotlin/example/SubjectTest.kt"
   ],
-  "must_contain": [
-    "CaptureOptions.Default",
-    "tolerance = 0.02f"
-  ],
+  "must_contain": [],
   "must_contain_any": [],
   "must_contain_by_file": {
     "src/test/resources/baselines/Subject.txt": [
       "configuration=default"
     ]
   },
-  "must_not_contain": [
-    "CaptureOptions.Fixed"
+  "must_not_contain": [],
+  "must_match_code": [
+    "@Test\\s+fun\\s+\\w+\\s*\\(\\s*\\)\\s*\\{[^}]*captureScreenshot\\s*\\(\\s*options\\s*=\\s*CaptureOptions\\.Default\\s*,\\s*tolerance\\s*=\\s*0\\.02f\\s*,?\\s*\\)"
+  ],
+  "must_not_match_code": [
+    "captureScreenshot\\s*\\(\\s*options\\s*=\\s*CaptureOptions\\.Fixed"
   ]
 }

--- a/evals/cases/compose-ui-testing-patterns-direct/expectations.json
+++ b/evals/cases/compose-ui-testing-patterns-direct/expectations.json
@@ -4,16 +4,21 @@
   ],
   "must_contain": [],
   "must_contain_any": [],
-  "must_contain_by_file": {
-    "src/test/resources/baselines/Subject.txt": [
-      "configuration=default"
-    ]
+  "exact_content_by_file": {
+    "src/test/resources/baselines/Subject.txt": "configuration=default\n"
   },
   "must_not_contain": [],
-  "must_match_code": [
-    "@Test\\s+fun\\s+\\w+\\s*\\(\\s*\\)\\s*\\{[^}]*captureScreenshot\\s*\\(\\s*options\\s*=\\s*CaptureOptions\\.Default\\s*,\\s*tolerance\\s*=\\s*0\\.02f\\s*,?\\s*\\)"
-  ],
-  "must_not_match_code": [
-    "captureScreenshot\\s*\\(\\s*options\\s*=\\s*CaptureOptions\\.Fixed"
-  ]
+  "required_test_call": {
+    "name": "captureScreenshot",
+    "arguments": {
+      "options": "CaptureOptions.Default",
+      "tolerance": "0.02f"
+    }
+  },
+  "forbidden_test_call": {
+    "name": "captureScreenshot",
+    "arguments": {
+      "options": "CaptureOptions.Fixed"
+    }
+  }
 }

--- a/evals/cases/compose-ui-testing-patterns-direct/expectations.json
+++ b/evals/cases/compose-ui-testing-patterns-direct/expectations.json
@@ -3,12 +3,16 @@
     "src/test/kotlin/example/SubjectTest.kt"
   ],
   "must_contain": [
-    "setContent"
+    "CaptureOptions.Default",
+    "tolerance = 0.02f"
   ],
-  "must_contain_any": [
-    ["runComposeUiTest", "createComposeRule"]
-  ],
+  "must_contain_any": [],
+  "must_contain_by_file": {
+    "src/test/resources/baselines/Subject.txt": [
+      "configuration=default"
+    ]
+  },
   "must_not_contain": [
-    "ActivityScenario"
+    "CaptureOptions.Fixed"
   ]
 }

--- a/evals/cases/compose-ui-testing-patterns-direct/overlay/src/test/kotlin/example/SubjectTest.kt
+++ b/evals/cases/compose-ui-testing-patterns-direct/overlay/src/test/kotlin/example/SubjectTest.kt
@@ -1,11 +1,19 @@
 package example
 
-import androidx.test.core.app.ActivityScenario
 import kotlin.test.Test
 
-class SearchFieldTest {
+class SubjectTest {
   @Test
-  fun entersQuery() {
-    ActivityScenario.launch(MainActivity::class.java)
+  fun rendersWithDefaultConfiguration() {
+    captureScreenshot(
+      options = CaptureOptions.Fixed(width = 480),
+      tolerance = 0.02f,
+    )
   }
 }
+
+private object CaptureOptions {
+  object Default
+  fun Fixed(width: Int) = Unit
+}
+private fun captureScreenshot(options: Any, tolerance: Float) = Unit

--- a/evals/cases/compose-ui-testing-patterns-direct/overlay/src/test/resources/baselines/Subject.txt
+++ b/evals/cases/compose-ui-testing-patterns-direct/overlay/src/test/resources/baselines/Subject.txt
@@ -1,0 +1,1 @@
+configuration=fixed

--- a/evals/cases/compose-ui-testing-patterns-direct/prompt.md
+++ b/evals/cases/compose-ui-testing-patterns-direct/prompt.md
@@ -1,1 +1,4 @@
-Refactor this component test to use the plain Compose UI-test boundary with controlled content instead of launching the full activity.
+The named screenshot configuration intentionally changed. Update this screenshot
+test and its affected baseline to cover that public configuration. Do not use a
+low-level fixed override just to preserve the previous image. Preserve the
+existing tolerance.

--- a/evals/cases/compose-ui-testing-patterns-negative/case.json
+++ b/evals/cases/compose-ui-testing-patterns-negative/case.json
@@ -1,6 +1,6 @@
 {
   "id": "compose-ui-testing-patterns-negative",
-  "title": "Preserve a value-only unit test",
+  "title": "Preserve an explicit screenshot configuration contract",
   "family": "testing",
   "target_skills": [
     "compose-ui-testing-patterns"
@@ -27,11 +27,11 @@
   "rubric": [
     {
       "id": "criterion-1",
-      "text": "Recognizes a plain unit test is the correct seam"
+      "text": "Recognizes that a fixed configuration is the visual contract and keeps the explicit value"
     },
     {
       "id": "criterion-2",
-      "text": "Leaves the workspace unchanged"
+      "text": "Leaves the workspace unchanged instead of substituting a named preset"
     }
   ],
   "provenance": {

--- a/evals/cases/compose-ui-testing-patterns-negative/overlay/src/test/kotlin/example/SubjectTest.kt
+++ b/evals/cases/compose-ui-testing-patterns-negative/overlay/src/test/kotlin/example/SubjectTest.kt
@@ -1,13 +1,15 @@
 package example
 
 import kotlin.test.Test
-import kotlin.test.assertEquals
 
-class CountLabelTest {
+class SubjectTest {
   @Test
-  fun pluralizesCount() {
-    assertEquals("2 items", countLabel(2))
+  fun rendersWithFixedConfiguration() {
+    captureScreenshot(
+      width = 480,
+      tolerance = 0.02f,
+    )
   }
 }
 
-private fun countLabel(count: Int) = if (count == 1) "1 item" else "$count items"
+private fun captureScreenshot(width: Int, tolerance: Float) = Unit

--- a/evals/cases/compose-ui-testing-patterns-negative/prompt.md
+++ b/evals/cases/compose-ui-testing-patterns-negative/prompt.md
@@ -1,1 +1,3 @@
-Inspect this value-only formatter test and move it to a UI harness only if rendering or interaction is required.
+Inspect this screenshot test. Its contract is a fixed capture configuration;
+leave it unchanged unless a different behavior is actually requested. Do not
+replace its explicit fixed value with a named configuration.

--- a/evals/cases/compose-ui-testing-patterns-novel/case.json
+++ b/evals/cases/compose-ui-testing-patterns-novel/case.json
@@ -1,6 +1,6 @@
 {
   "id": "compose-ui-testing-patterns-novel",
-  "title": "Review timing-dependent interaction coverage",
+  "title": "Review screenshot baseline recording evidence",
   "family": "testing",
   "target_skills": [
     "compose-ui-testing-patterns"
@@ -25,11 +25,11 @@
   "rubric": [
     {
       "id": "criterion-1",
-      "text": "Identifies the fixed sleep as nondeterministic and production integration as a broader-than-needed asynchronous seam"
+      "text": "Distinguishes a passing verification result from evidence that recording wrote the expected artifact path"
     },
     {
       "id": "criterion-2",
-      "text": "Recommends a controlled UI seam with an observable callback or semantic assertion and does not recommend a fixed delay"
+      "text": "Recommends inspecting the expected artifact path and intentional baseline diff while preserving the tolerance"
     }
   ],
   "provenance": {

--- a/evals/cases/compose-ui-testing-patterns-novel/case.json
+++ b/evals/cases/compose-ui-testing-patterns-novel/case.json
@@ -34,9 +34,9 @@
   ],
   "provenance": {
     "kind": "historical",
-    "source_url": "https://github.com/android/compose-samples/blob/018c5207fb63c4f78e5841bd8ddd4faabdf19d3a/Jetchat/app/src/androidTest/java/com/example/compose/jetchat/UserInputTest.kt",
-    "revision": "018c5207fb63c4f78e5841bd8ddd4faabdf19d3a",
+    "source_url": "https://github.com/takahirom/roborazzi/blob/56f6987180b28a10c8fe79dfd524c3f0d9c633d0/README.md",
+    "revision": "56f6987180b28a10c8fe79dfd524c3f0d9c633d0",
     "license": "Apache-2.0",
-    "normalization_note": "Reduced and perturbed interaction test preserving the user-input semantics and synchronization boundary."
+    "normalization_note": "Reduced and generalized the documented record, compare, and verify workflow to test that verification does not prove a baseline was recorded."
   }
 }

--- a/evals/cases/compose-ui-testing-patterns-novel/overlay/src/test/kotlin/example/SubjectTest.kt
+++ b/evals/cases/compose-ui-testing-patterns-novel/overlay/src/test/kotlin/example/SubjectTest.kt
@@ -2,19 +2,16 @@ package example
 
 import kotlin.test.Test
 
-class UserInputTest {
+class SubjectTest {
   @Test
-  fun sendMessage() {
-    launchProductionApplication()
-    Thread.sleep(2_000)
-    findNode("message-input").typeText("hello")
-    findNode("send").click()
+  fun capturesSubject() {
+    captureScreenshot(
+      artifactPath = "build/recorded/subject.png",
+      tolerance = 0.02f,
+    )
   }
 }
 
-private fun launchProductionApplication() = Unit
-private fun findNode(tag: String) = FakeNode()
-private class FakeNode {
-  fun typeText(value: String) = Unit
-  fun click() = Unit
-}
+// The log says: "Verification passed".
+// No recording output or changed baseline was reported.
+private fun captureScreenshot(artifactPath: String, tolerance: Float) = Unit

--- a/evals/cases/compose-ui-testing-patterns-novel/prompt.md
+++ b/evals/cases/compose-ui-testing-patterns-novel/prompt.md
@@ -1,1 +1,3 @@
-Review this interaction test for determinism and for the narrowest useful test seam. Report findings only.
+Review this screenshot-test run for whether the claimed baseline update is actually
+evidenced. Report findings only. Do not suggest tool-specific flags or alter the
+tolerance without an independent reason.

--- a/evals/tests/test_compose_matrix.py
+++ b/evals/tests/test_compose_matrix.py
@@ -98,7 +98,7 @@ class ComposeMatrixTest(unittest.TestCase):
         self.assertIn("recommends first", repair_criterion["text"].lower())
         self.assertIn("then deciding", repair_criterion["text"].lower())
 
-    def test_ui_testing_novel_does_not_require_unnecessary_synchronization(self):
+    def test_ui_testing_novel_requires_recording_evidence(self):
         report = validate_corpus(REPO_ROOT, suite="compose")
         case = next(
             case
@@ -111,9 +111,8 @@ class ComposeMatrixTest(unittest.TestCase):
             for criterion in case.rubric
             if criterion["id"] == "criterion-2"
         )["text"].lower()
-        self.assertIn("callback or semantic assertion", seam_criterion)
-        self.assertIn("does not recommend a fixed delay", seam_criterion)
-        self.assertNotIn("synchronization", seam_criterion)
+        self.assertIn("expected artifact path", seam_criterion)
+        self.assertIn("preserving the tolerance", seam_criterion)
 
     def test_fixture_declares_pinned_compose_jvm_dependencies_and_offline_wrapper(self):
         fixture = REPO_ROOT / "evals" / "fixtures" / "compose-jvm"
@@ -202,11 +201,14 @@ import androidx.compose.runtime.Composable
 }
 """),
             ("compose-ui-testing-patterns-direct", """package example
-import androidx.compose.ui.test.junit4.createComposeRule
 class SubjectTest {
-  val composeTestRule = createComposeRule()
-  fun test() { composeTestRule.setContent {} }
+  fun test() = captureScreenshot(
+    options = CaptureOptions.Default,
+    tolerance = 0.02f,
+  )
 }
+private object CaptureOptions { object Default }
+private fun captureScreenshot(options: Any, tolerance: Float) = Unit
 """),
         )
 
@@ -224,6 +226,9 @@ class SubjectTest {
                     )
                     subject = workspace / relative_path
                     subject.write_text(source, encoding="utf-8")
+                    if case_id == "compose-ui-testing-patterns-direct":
+                        baseline = workspace / "src/test/resources/baselines/Subject.txt"
+                        baseline.write_text("configuration=default\n", encoding="utf-8")
                     result = make_result(workspace, paths=(str(subject.relative_to(workspace)),))
                     self.assertTrue(grade_subject(case, result).objective_pass)
 

--- a/evals/tests/test_compose_matrix.py
+++ b/evals/tests/test_compose_matrix.py
@@ -203,11 +203,13 @@ import androidx.compose.runtime.Composable
             ("compose-ui-testing-patterns-direct", """package example
 import kotlin.test.Test
 class SubjectTest {
-  @Test fun test() {
-    captureScreenshot(
-      options = CaptureOptions.Default,
-      tolerance = 0.02f,
-    )
+  @Test fun test(): Unit {
+    run {
+      captureScreenshot(
+        tolerance = 0.02f,
+        options = CaptureOptions.Default,
+      )
+    }
   }
 }
 private object CaptureOptions { object Default }
@@ -248,6 +250,17 @@ class SubjectTest {
 private object CaptureOptions { object Default; object Other }
 private fun captureScreenshot(options: Any, tolerance: Float) = Unit
 """,
+                            encoding="utf-8",
+                        )
+                        result = make_result(
+                            workspace,
+                            paths=(str(subject.relative_to(workspace)),),
+                        )
+                        self.assertFalse(grade_subject(case, result).objective_pass)
+
+                        subject.write_text(source, encoding="utf-8")
+                        baseline.write_text(
+                            "configuration=fixed\nconfiguration=default\n",
                             encoding="utf-8",
                         )
                         result = make_result(

--- a/evals/tests/test_compose_matrix.py
+++ b/evals/tests/test_compose_matrix.py
@@ -203,14 +203,10 @@ import androidx.compose.runtime.Composable
             ("compose-ui-testing-patterns-direct", """package example
 import kotlin.test.Test
 class SubjectTest {
-  @Test fun test(): Unit {
-    run {
-      captureScreenshot(
-        tolerance = 0.02f,
-        options = CaptureOptions.Default,
-      )
-    }
-  }
+  @Test fun `renders default`(): Unit = captureScreenshot(
+    tolerance = 0.02f,
+    options = CaptureOptions.Default,
+  )
 }
 private object CaptureOptions { object Default }
 private fun captureScreenshot(options: Any, tolerance: Float) = Unit
@@ -261,6 +257,31 @@ private fun captureScreenshot(options: Any, tolerance: Float) = Unit
                         subject.write_text(source, encoding="utf-8")
                         baseline.write_text(
                             "configuration=fixed\nconfiguration=default\n",
+                            encoding="utf-8",
+                        )
+                        result = make_result(
+                            workspace,
+                            paths=(str(subject.relative_to(workspace)),),
+                        )
+                        self.assertFalse(grade_subject(case, result).objective_pass)
+
+                        baseline.write_text("configuration=default\n", encoding="utf-8")
+                        subject.write_text(
+                            """package example
+import kotlin.test.Test
+class SubjectTest {
+  @Test fun test() {
+    captureScreenshot(
+      options = CaptureOptions.Other,
+      tolerance = 0.02f,
+      configure(options = CaptureOptions.Default),
+    )
+  }
+}
+private object CaptureOptions { object Default; object Other }
+private fun configure(options: Any) = Unit
+private fun captureScreenshot(options: Any, tolerance: Float, configure: Unit) = Unit
+""",
                             encoding="utf-8",
                         )
                         result = make_result(

--- a/evals/tests/test_compose_matrix.py
+++ b/evals/tests/test_compose_matrix.py
@@ -201,11 +201,14 @@ import androidx.compose.runtime.Composable
 }
 """),
             ("compose-ui-testing-patterns-direct", """package example
+import kotlin.test.Test
 class SubjectTest {
-  fun test() = captureScreenshot(
-    options = CaptureOptions.Default,
-    tolerance = 0.02f,
-  )
+  @Test fun test() {
+    captureScreenshot(
+      options = CaptureOptions.Default,
+      tolerance = 0.02f,
+    )
+  }
 }
 private object CaptureOptions { object Default }
 private fun captureScreenshot(options: Any, tolerance: Float) = Unit
@@ -231,6 +234,27 @@ private fun captureScreenshot(options: Any, tolerance: Float) = Unit
                         baseline.write_text("configuration=default\n", encoding="utf-8")
                     result = make_result(workspace, paths=(str(subject.relative_to(workspace)),))
                     self.assertTrue(grade_subject(case, result).objective_pass)
+
+                    if case_id == "compose-ui-testing-patterns-direct":
+                        subject.write_text(
+                            """package example
+import kotlin.test.Test
+class SubjectTest {
+  @Test fun test() {
+    // captureScreenshot(options = CaptureOptions.Default, tolerance = 0.02f)
+    captureScreenshot(options = CaptureOptions.Other, tolerance = 0.02f)
+  }
+}
+private object CaptureOptions { object Default; object Other }
+private fun captureScreenshot(options: Any, tolerance: Float) = Unit
+""",
+                            encoding="utf-8",
+                        )
+                        result = make_result(
+                            workspace,
+                            paths=(str(subject.relative_to(workspace)),),
+                        )
+                        self.assertFalse(grade_subject(case, result).objective_pass)
 
     def test_regrades_persisted_subject_evidence_without_model_calls(self):
         report = validate_corpus(REPO_ROOT, suite="compose")

--- a/evals/validators/compose_case.py
+++ b/evals/validators/compose_case.py
@@ -8,12 +8,83 @@ from pathlib import Path
 
 
 _KOTLIN_NON_CODE = re.compile(
-    r'""".*?"""|/\*.*?\*/|//[^\n]*|"(?:\\.|[^"\\])*"', re.DOTALL
+    r'""".*?"""|/\*.*?\*/|//[^\n]*|"(?:\\.|[^"\\])*"|\'(?:\\.|[^\'\\])\'',
+    re.DOTALL,
+)
+_TEST_FUNCTION = re.compile(
+    r"@Test\b.*?\bfun\s+\w+\s*\([^)]*\)\s*(?::\s*[^\n{=]+)?\s*\{",
+    re.DOTALL,
 )
 
 
 def _kotlin_code(source: str) -> str:
     return _KOTLIN_NON_CODE.sub(lambda match: "\n" * match.group().count("\n"), source)
+
+
+def _matching_brace(code: str, opening_index: int) -> int | None:
+    depth = 0
+    for index, character in enumerate(code[opening_index:], start=opening_index):
+        if character == "{":
+            depth += 1
+        elif character == "}":
+            depth -= 1
+            if depth == 0:
+                return index
+    return None
+
+
+def _test_bodies(code: str) -> list[str]:
+    bodies: list[str] = []
+    for match in _TEST_FUNCTION.finditer(code):
+        opening_index = match.end() - 1
+        closing_index = _matching_brace(code, opening_index)
+        if closing_index is not None:
+            bodies.append(code[opening_index + 1 : closing_index])
+    return bodies
+
+
+def _call_arguments(body: str, name: str) -> list[str]:
+    arguments: list[str] = []
+    call_pattern = re.compile(rf"\b{re.escape(name)}\s*\(")
+    for match in call_pattern.finditer(body):
+        opening_index = body.find("(", match.start())
+        closing_index = _matching_parenthesis(body, opening_index)
+        if closing_index is not None:
+            arguments.append(body[opening_index + 1 : closing_index])
+    return arguments
+
+
+def _matching_parenthesis(code: str, opening_index: int) -> int | None:
+    depth = 0
+    for index, character in enumerate(code[opening_index:], start=opening_index):
+        if character == "(":
+            depth += 1
+        elif character == ")":
+            depth -= 1
+            if depth == 0:
+                return index
+    return None
+
+
+def _has_named_arguments(arguments: str, expected: dict[str, str]) -> bool:
+    return all(
+        re.search(rf"\b{re.escape(name)}\s*=\s*{re.escape(value)}\b", arguments)
+        for name, value in expected.items()
+    )
+
+
+def _has_test_call(code: str, expected: dict[str, object]) -> bool:
+    name = expected["name"]
+    arguments = expected["arguments"]
+    if not isinstance(name, str) or not isinstance(arguments, dict):
+        return False
+    if not all(isinstance(key, str) and isinstance(value, str) for key, value in arguments.items()):
+        return False
+    return any(
+        _has_named_arguments(call, arguments)
+        for body in _test_bodies(code)
+        for call in _call_arguments(body, name)
+    )
 
 
 def main(argv: list[str]) -> int:
@@ -54,6 +125,12 @@ def main(argv: list[str]) -> int:
                 failures.append(
                     f"missing required evidence in {relative}: {required!r}"
                 )
+    for relative, expected_content in expectations.get("exact_content_by_file", {}).items():
+        path = workspace / relative
+        if not path.is_file():
+            failures.append(f"missing subject file: {relative}")
+        elif path.read_text(encoding="utf-8").strip() != expected_content.strip():
+            failures.append(f"unexpected content in {relative}")
     for alternatives in expectations.get("must_contain_any", []):
         if not any(alternative in subject for alternative in alternatives):
             failures.append(f"missing one of: {alternatives!r}")
@@ -63,12 +140,12 @@ def main(argv: list[str]) -> int:
             failures.append(
                 f"expected at least {count} occurrences of {required!r}, found {actual}"
             )
-    for pattern in expectations.get("must_match_code", []):
-        if not re.search(pattern, kotlin_code, re.DOTALL):
-            failures.append(f"missing required code evidence: {pattern!r}")
-    for pattern in expectations.get("must_not_match_code", []):
-        if re.search(pattern, kotlin_code, re.DOTALL):
-            failures.append(f"forbidden code evidence remains: {pattern!r}")
+    required_test_call = expectations.get("required_test_call")
+    if required_test_call is not None and not _has_test_call(kotlin_code, required_test_call):
+        failures.append("missing required test call")
+    forbidden_test_call = expectations.get("forbidden_test_call")
+    if forbidden_test_call is not None and _has_test_call(kotlin_code, forbidden_test_call):
+        failures.append("forbidden test call remains")
     for forbidden in expectations.get("must_not_contain", []):
         if forbidden in subject:
             failures.append(f"forbidden evidence remains: {forbidden!r}")

--- a/evals/validators/compose_case.py
+++ b/evals/validators/compose_case.py
@@ -32,6 +32,17 @@ def main(argv: list[str]) -> int:
     for required in expectations.get("must_contain", []):
         if required not in subject:
             failures.append(f"missing required evidence: {required!r}")
+    for relative, required_values in expectations.get("must_contain_by_file", {}).items():
+        path = workspace / relative
+        if not path.is_file():
+            failures.append(f"missing subject file: {relative}")
+            continue
+        contents = path.read_text(encoding="utf-8")
+        for required in required_values:
+            if required not in contents:
+                failures.append(
+                    f"missing required evidence in {relative}: {required!r}"
+                )
     for alternatives in expectations.get("must_contain_any", []):
         if not any(alternative in subject for alternative in alternatives):
             failures.append(f"missing one of: {alternatives!r}")

--- a/evals/validators/compose_case.py
+++ b/evals/validators/compose_case.py
@@ -2,8 +2,18 @@
 from __future__ import annotations
 
 import json
+import re
 import sys
 from pathlib import Path
+
+
+_KOTLIN_NON_CODE = re.compile(
+    r'""".*?"""|/\*.*?\*/|//[^\n]*|"(?:\\.|[^"\\])*"', re.DOTALL
+)
+
+
+def _kotlin_code(source: str) -> str:
+    return _KOTLIN_NON_CODE.sub(lambda match: "\n" * match.group().count("\n"), source)
 
 
 def main(argv: list[str]) -> int:
@@ -28,6 +38,7 @@ def main(argv: list[str]) -> int:
             return 1
         contents.append(path.read_text(encoding="utf-8"))
     subject = "\n".join(contents)
+    kotlin_code = _kotlin_code(subject)
     failures: list[str] = []
     for required in expectations.get("must_contain", []):
         if required not in subject:
@@ -52,6 +63,12 @@ def main(argv: list[str]) -> int:
             failures.append(
                 f"expected at least {count} occurrences of {required!r}, found {actual}"
             )
+    for pattern in expectations.get("must_match_code", []):
+        if not re.search(pattern, kotlin_code, re.DOTALL):
+            failures.append(f"missing required code evidence: {pattern!r}")
+    for pattern in expectations.get("must_not_match_code", []):
+        if re.search(pattern, kotlin_code, re.DOTALL):
+            failures.append(f"forbidden code evidence remains: {pattern!r}")
     for forbidden in expectations.get("must_not_contain", []):
         if forbidden in subject:
             failures.append(f"forbidden evidence remains: {forbidden!r}")

--- a/evals/validators/compose_case.py
+++ b/evals/validators/compose_case.py
@@ -12,7 +12,8 @@ _KOTLIN_NON_CODE = re.compile(
     re.DOTALL,
 )
 _TEST_FUNCTION = re.compile(
-    r"@Test\b.*?\bfun\s+\w+\s*\([^)]*\)\s*(?::\s*[^\n{=]+)?\s*\{",
+    r"@Test\b.*?\bfun\s+(?:\w+|`[^`]+`)\s*\([^)]*\)\s*"
+    r"(?::\s*[^\n{=]+)?\s*(?P<body_start>[{=])",
     re.DOTALL,
 )
 
@@ -36,10 +37,14 @@ def _matching_brace(code: str, opening_index: int) -> int | None:
 def _test_bodies(code: str) -> list[str]:
     bodies: list[str] = []
     for match in _TEST_FUNCTION.finditer(code):
-        opening_index = match.end() - 1
-        closing_index = _matching_brace(code, opening_index)
-        if closing_index is not None:
-            bodies.append(code[opening_index + 1 : closing_index])
+        body_start = match.end() - 1
+        if match.group("body_start") == "=":
+            next_test = code.find("@Test", match.end())
+            bodies.append(code[match.end() : next_test if next_test != -1 else None])
+        else:
+            closing_index = _matching_brace(code, body_start)
+            if closing_index is not None:
+                bodies.append(code[body_start + 1 : closing_index])
     return bodies
 
 
@@ -66,9 +71,32 @@ def _matching_parenthesis(code: str, opening_index: int) -> int | None:
     return None
 
 
+def _top_level_arguments(arguments: str) -> list[str]:
+    result: list[str] = []
+    start = 0
+    depth = 0
+    for index, character in enumerate(arguments):
+        if character in "([{":
+            depth += 1
+        elif character in ")]}":
+            depth -= 1
+        elif character == "," and depth == 0:
+            result.append(arguments[start:index])
+            start = index + 1
+    result.append(arguments[start:])
+    return result
+
+
 def _has_named_arguments(arguments: str, expected: dict[str, str]) -> bool:
+    top_level_arguments = _top_level_arguments(arguments)
     return all(
-        re.search(rf"\b{re.escape(name)}\s*=\s*{re.escape(value)}\b", arguments)
+        any(
+            re.match(
+                rf"\s*{re.escape(name)}\s*=\s*{re.escape(value)}(?=\s*(?:$|\())",
+                argument,
+            )
+            for argument in top_level_arguments
+        )
         for name, value in expected.items()
     )
 

--- a/skills/compose-ui-testing-patterns/SKILL.md
+++ b/skills/compose-ui-testing-patterns/SKILL.md
@@ -156,6 +156,17 @@ Keep screenshot state deterministic:
 - Replace network/image loading with fake or preview handlers.
 - Avoid asserting dynamic text such as current time unless controlled.
 
+### When screenshot defaults change
+
+- Keep an intentionally changed named preset or default in the test and update
+  its baseline. Do not substitute a raw value to retain the old image; preserve
+  assertions and tolerances unless independently justified.
+- Keep an explicit fixed value when that fixed resolution or geometry is the
+  contract.
+- Verify recording separately from comparison: inspect the expected artifact
+  paths and intentional baseline diff. A passing comparison does not prove that
+  recording occurred. Keep tool-specific commands in the repository runbook.
+
 ## Fake images and platform services
 
 When image content is irrelevant, fake the loader and assert the requested model if that is the behavior. The exact hook depends on your image library; a project helper might look like this:


### PR DESCRIPTION
## Summary

- clarify how screenshot tests should handle intentional default changes
- add direct, review, and no-change evaluation coverage
- require baseline-artifact evidence separately from comparison results

## Validation

- `python3 -m unittest evals.tests.test_compose_matrix`
- `python3 evals/run.py validate`
- `python3 /Users/chris/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/compose-ui-testing-patterns`
- `npm run lint`

`npm test` did not complete within the local command time limit, so it is not listed as passing.